### PR TITLE
Module 'purchase_requisition_line_analytic' should not really depend on 'account_analytic_plans'

### DIFF
--- a/purchase_requisition_for_everybody/security/requisition_security.xml
+++ b/purchase_requisition_for_everybody/security/requisition_security.xml
@@ -12,14 +12,25 @@
         <field name="implied_ids"
         eval="[(6,0, [ref('purchase_requisition.group_purchase_requisition_user')])]"/>
     </record> 
+    <record id="requisition_modify_ev_followers_rule" model="ir.rule">
+        <field name="name">Follow Purchase Requisition</field>
+        <field name="model_id" ref="purchase_requisition.model_purchase_requisition"/>
+        <field name="groups" eval="[(6,0, [ref('purchase_requisition_user_ev_groups')])]"/>
+        <field name="perm_read" eval="True"/>                               
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+        <field name="domain_force">['|',('user_id','=',user.id),
+                                        ('message_follower_ids', 'in', [user.partner_id.id])]</field>
+    </record>
     <record id="requisition_modify_ev_rule" model="ir.rule">
         <field name="name">Modify Purchase Requisition</field>
         <field name="model_id" ref="purchase_requisition.model_purchase_requisition"/>
         <field name="groups" eval="[(6,0, [ref('purchase_requisition_user_ev_groups')])]"/>
-        <field name="perm_read" eval="True"/>                               
-        <field name="perm_write" eval="True"/>                             
-        <field name="perm_create" eval="True"/>                            
-        <field name="perm_unlink" eval="True"/>    
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
         <field name="domain_force">[('user_id','=',user.id)]</field>
     </record>
 </data>

--- a/purchase_requisition_line_analytic/__openerp__.py
+++ b/purchase_requisition_line_analytic/__openerp__.py
@@ -36,7 +36,7 @@ the account analytic value from the purchase requisition.
     "website": "http://www.vauxoo.com/", 
     "license": "", 
     "depends": [
-        "account_analytic_plans", 
+        "analytic",
         "purchase_requisition", 
         "purchase_requisition_line_view", 
         "pr_line_related_po_line"


### PR DESCRIPTION
Should only depend on 'account_analytic'. The dependence on 'account_analytic_plans' installs this module, which can be a problem for companies that really don't use it.

If purchase requisitions should really make use of analytic plans, then I suggest a new module on top of the existing called 'purchase_requisition_line_analytic_plan'.

Regards,
Jordi.
