### PR TITLE
[ADD][product_unique_default_code] Unitest added to prove new unique constraint for product's internal reference

### DIFF
--- a/product_unique_default_code/__openerp__.py
+++ b/product_unique_default_code/__openerp__.py
@@ -37,7 +37,9 @@
     "depends": [
         "product"
     ], 
-    "demo": [], 
+    "demo": [
+        'demo/test_unique_ref_demo.xml',
+    ], 
     "data": [], 
     "test": [], 
     "js": [], 

--- a/product_unique_default_code/demo/test_unique_ref_demo.xml
+++ b/product_unique_default_code/demo/test_unique_ref_demo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+
+        <record id="product.product_product_5" model="product.product">
+            <field name="default_code">B3424</field>
+        </record>
+        
+    </data>
+</openerp>

--- a/product_unique_default_code/model/__init__.py
+++ b/product_unique_default_code/model/__init__.py
@@ -1,9 +1,3 @@
-# -*- encoding: utf-8 -*-
-###########################################################################
-#    Module Writen to OpenERP, Open Source Management Solution
-#
-#    Copyright (c) 2012 Vauxoo - http://www.vauxoo.com
-#    All Rights Reserved.
 #    info@vauxoo.com
 ############################################################################
 #    Coded by: julio (julio@vauxoo.com)
@@ -24,4 +18,4 @@
 #
 ##############################################################################
 
-from . import model
+from . import product

--- a/product_unique_default_code/model/product.py
+++ b/product_unique_default_code/model/product.py
@@ -43,26 +43,7 @@ class product_product(osv.Model):
         return super(product_product, self).copy(cr, uid, id, default=default,
                                                  context=context)
 
-    def _unique_internal_reference(self, cr, uid, ids):
-        """
-        Python Constraint to check if default code for
-        products are really unique
-        """
-        all_product_ids = self.search(cr, uid, [])
-        all_def_codes = [prod.default_code for prod in self.browse(cr, uid, all_product_ids)]
-        for product in self.browse(cr, uid, ids):
-            if product.default_code in all_def_codes:
-                return False
-        return True
-
-    #~ _sql_constraints = [
-        #~ ('default_code_unique', 'unique (default_code)',
-         #~ 'The code of Product must be unique !'),
-    #~ ]
-
-    _constraints = [
-        (_unique_internal_reference,
-         "You can't have more than one product with the"
-         "same internal reference",
-         ['default_code']),
+    _sql_constraints = [
+        ('default_code_unique', 'unique (default_code)',
+         'The code of Product must be unique !'),
     ]

--- a/product_unique_default_code/model/product.py
+++ b/product_unique_default_code/model/product.py
@@ -43,7 +43,26 @@ class product_product(osv.Model):
         return super(product_product, self).copy(cr, uid, id, default=default,
                                                  context=context)
 
-    _sql_constraints = [
-        ('default_code_unique', 'unique (default_code)',
-         'The code of Product must be unique !'),
+    def _unique_internal_reference(self, cr, uid, ids):
+        """
+        Python Constraint to check if default code for
+        products are really unique
+        """
+        all_product_ids = self.search(cr, uid, [])
+        all_def_codes = [prod.default_code for prod in self.browse(cr, uid, all_product_ids)]
+        for product in self.browse(cr, uid, ids):
+            if product.default_code in all_def_codes:
+                return False
+        return True
+
+    #~ _sql_constraints = [
+        #~ ('default_code_unique', 'unique (default_code)',
+         #~ 'The code of Product must be unique !'),
+    #~ ]
+
+    _constraints = [
+        (_unique_internal_reference,
+         "You can't have more than one product with the"
+         "same internal reference",
+         ['default_code']),
     ]

--- a/product_unique_default_code/tests/__init__.py
+++ b/product_unique_default_code/tests/__init__.py
@@ -19,7 +19,3 @@
 ##############################################################################
 
 from . import test_for_unique_ref
-
-fast_suite = [
-    test_for_unique_ref,
-]

--- a/product_unique_default_code/tests/__init__.py
+++ b/product_unique_default_code/tests/__init__.py
@@ -1,9 +1,3 @@
-# -*- encoding: utf-8 -*-
-###########################################################################
-#    Module Writen to OpenERP, Open Source Management Solution
-#
-#    Copyright (c) 2012 Vauxoo - http://www.vauxoo.com
-#    All Rights Reserved.
 #    info@vauxoo.com
 ############################################################################
 #    Coded by: julio (julio@vauxoo.com)
@@ -24,4 +18,8 @@
 #
 ##############################################################################
 
-from . import model
+from . import test_for_unique_ref
+
+fast_suite = [
+    test_for_unique_ref,
+]

--- a/product_unique_default_code/tests/test_for_unique_ref.py
+++ b/product_unique_default_code/tests/test_for_unique_ref.py
@@ -1,0 +1,86 @@
+# -*- encoding: utf-8 -*-
+###############################################################################
+#    Module Writen to OpenERP, Open Source Management Solution
+#
+#    Copyright (c) 2010 Vauxoo - http://www.vauxoo.com/
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+###############################################################################
+#    Coded by: Sergio Ernesto Tostado Sánchez (sergio@vauxoo.com)
+###############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from openerp.tests.common import TransactionCase
+from openerp.exceptions import except_orm
+from openerp.tools import mute_logger
+
+
+class TestForUniqueRef(TransactionCase):
+
+    """
+    This test will prove the new constraint constraint and copy
+    ovarriding function to can create a duplicated product with
+    a unique internal reference (default_code product field)
+    """
+
+    def setUp(self):
+        super(TestForUniqueRef, self).setUp()
+
+    def test_1_copied_product_unique_default_code(self):
+        """
+        Test 1: This test will prove the next case:
+        - Create a product with an internal reference
+        - Execute the copy method to create another product record
+        - Verify that copied-product has an internal reference totally unique
+        """
+        product_data = {
+            'name': 'Test Cellphone ACME',
+            'default_code': '101001000',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'standard_price': 100.90,
+            'list_price': 123.50
+        }
+        product = self.env['product.product'].create(product_data)
+        self.assertTrue(
+            product.copy().default_code == '%s (copy)' % product.default_code,
+            "ERROR: New product has not a unique internal reference ...")
+    
+    def test_2_constraint_unique_internal_reference(self):
+        """
+        Test 2: This test will prove the new constraint added to this module
+        to can store only product with unique default_codes (internal refs):
+        - Create two products with the same internal reference
+        - 
+        """
+        product_data_1 = {
+            'name': 'Test Cellphone ACME',
+            'default_code': '101001000',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'standard_price': 100.90,
+            'list_price': 123.50
+        }
+        product_data_2 = {
+            'name': 'Test Cellphone SANYO',
+            'default_code': '101001000',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'standard_price': 200.80,
+            'list_price': 241.70
+        }
+        product_obj = self.env['product.product']
+        product_obj.create(product_data_1)
+        product_obj.create(product_data_2)
+        print "*"*120, [p.default_code for p in product_obj.browse([ ids.id for ids in product_obj.search([]) ])]


### PR DESCRIPTION
A test is added to prove the new constraint added with this module:
- Test 1: To prove if the module can copy a product with default code included
- Test 2: To prove if the constraint for unique internal references is correctly active
