### PR TITLE
8.0 controller report xls hbto

### DIFF
--- a/controller_report_xls/controllers/main.py
+++ b/controller_report_xls/controllers/main.py
@@ -1,7 +1,5 @@
 from openerp.addons.report.controllers import main
 from openerp.addons.web.http import route, request
-from openerp.addons.web.controllers.main import _serialize_exception
-from openerp.tools import html_escape
 from werkzeug import url_decode
 import simplejson
 from bs4 import BeautifulSoup


### PR DESCRIPTION
Giving proper filename to report in XLS format
As MIME type is not recognized by Chrome Family Browsers and Internet Explorer

Only Mozilla Firefox stable version does.

Besides it was the right thing to do.
