### PR TITLE
Add # -*- coding: utf-8 -*- may be it is necesary for pylint

### DIFF
--- a/controller_report_xls/controllers/main.py
+++ b/controller_report_xls/controllers/main.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from openerp.addons.report.controllers import main
 from openerp.addons.web.http import route, request
 from werkzeug import url_decode


### PR DESCRIPTION
Trying to fix this pylint errors.

cmd: [u'/home/runbot/instance/extra_addons/odoo-extra/runbot/static/build/35660-8-0-8-0-lo/pylint_run.sh']
[7;33m************\* Module openerp.addons.controller_report_xls.controllers.main[0m
openerp.addons.controller_report_xls.controllers.main:2: [F0401([1;4;31mimport-error[0m), ] [1;4;31mUnable to import 'openerp.addons.web.http'[0m
openerp.addons.controller_report_xls.controllers.main:3: [E0611([1;31mno-name-in-module[0m), ] [1;31mNo name 'url_decode' in module 'werkzeug'[0m
