### PR TITLE
8.0 commission payment issues hbto

### DIFF
--- a/commission_payment/model/commission.py
+++ b/commission_payment/model/commission.py
@@ -487,7 +487,6 @@ class commission_payment(osv.Model):
         aml_obj = self.pool.get('account.move.line')
         comm_brw = self.browse(cr, uid, ids[0], context=context)
         aml_brw = aml_obj.browse(cr, uid, pay_id, context=context)
-        print ">>>>>>>>>>>>>>>>> %s" % aml_brw.id
         date = False
         if comm_brw.commission_policy_date_end == 'last_payment_date':
             date = aml_brw.rec_aml.date_last_payment

--- a/commission_payment/model/commission.py
+++ b/commission_payment/model/commission.py
@@ -487,6 +487,7 @@ class commission_payment(osv.Model):
         aml_obj = self.pool.get('account.move.line')
         comm_brw = self.browse(cr, uid, ids[0], context=context)
         aml_brw = aml_obj.browse(cr, uid, pay_id, context=context)
+        print ">>>>>>>>>>>>>>>>> %s" % aml_brw.id
         date = False
         if comm_brw.commission_policy_date_end == 'last_payment_date':
             if aml_brw.rec_invoice:

--- a/commission_payment/model/commission.py
+++ b/commission_payment/model/commission.py
@@ -490,10 +490,7 @@ class commission_payment(osv.Model):
         print ">>>>>>>>>>>>>>>>> %s" % aml_brw.id
         date = False
         if comm_brw.commission_policy_date_end == 'last_payment_date':
-            if aml_brw.rec_invoice:
-                date = aml_brw.rec_invoice.date_last_payment
-            else:
-                date = aml_brw.rec_aml.date_last_payment
+            date = aml_brw.rec_aml.date_last_payment
         elif comm_brw.commission_policy_date_end == 'date_on_payment':
             date = aml_brw.date
         return date


### PR DESCRIPTION
[FIX] Only take into account last_payment_date on Journal Entry as is
more reliable than the one on invoice, because if some checks fail
 payments in functional field payment_ids will not be reflected properly
