### PR TITLE
[IMP] product_unique_default_code: change the way the default code is se...

### DIFF
--- a/product_unique_default_code/__openerp__.py
+++ b/product_unique_default_code/__openerp__.py
@@ -26,7 +26,7 @@
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
 {
     "name": "Product Default Code Unique", 
-    "version": "1.1", 
+    "version": "2.0",
     "author": "Vauxoo", 
     "category": "", 
     "description": """
@@ -40,7 +40,7 @@
     "demo": [
         'demo/test_unique_ref_demo.xml',
     ], 
-    "data": [], 
+    "data": [],
     "test": [], 
     "js": [], 
     "css": [], 

--- a/product_unique_default_code/model/product.py
+++ b/product_unique_default_code/model/product.py
@@ -50,19 +50,16 @@ class ProductTemplate(osv.Model):
 class ProductProduct(osv.Model):
     _inherit = "product.product"
 
-    def copy(self, cr, uid, id_, default=None, context=None):
+    @api.one
+    def copy(self, default=None):
 
         if not default:
             default = {}
 
-        product_default_code = self.browse(cr, uid, id_, context=context)
-
         default['default_code'] = (
-            product_default_code.default_code
-            and product_default_code.default_code + ' (copy)'
+            self.default_code
+            and self.default_code + ' (copy)'
             or False
         )
 
-        return super(product_product, self).copy(
-            cr, uid, id, default=default, context=context
-        )
+        return super(ProductProduct, self).copy(default=default)

--- a/product_unique_default_code/model/product.py
+++ b/product_unique_default_code/model/product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-###########################################################################
+# ##########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #
 #    Copyright (c) 2012 Vauxoo - http://www.vauxoo.com
@@ -24,26 +24,45 @@
 #
 ##############################################################################
 from openerp.osv import osv
+from openerp import _, api
+from openerp.exceptions import except_orm
 
 
-class product_product(osv.Model):
+class ProductTemplate(osv.Model):
+    _inherit = "product.template"
+
+    @api.onchange('default_code')
+    def unique_default_code(self):
+        """Check if any product already have the given default code.
+
+        :raise orm.except_orm: if the default code is not unique.
+        """
+        if self.search([('default_code', 'like', self.default_code)]):
+            raise except_orm(
+                _('Error!'),
+                _(
+                    'Internal code "{}" is already set to another product!.'
+                    ' Please, set another Internal code to move forward.'
+                )
+            )
+
+
+class ProductProduct(osv.Model):
     _inherit = "product.product"
 
-    def copy(self, cr, uid, id, default=None, context=None):
+    def copy(self, cr, uid, id_, default=None, context=None):
 
         if not default:
             default = {}
 
-        product_default_code = self.browse(cr, uid, id, context=context)
+        product_default_code = self.browse(cr, uid, id_, context=context)
 
-        default[
-            'default_code'] = product_default_code.default_code and\
-            product_default_code.default_code + ' (copy)' or False
+        default['default_code'] = (
+            product_default_code.default_code
+            and product_default_code.default_code + ' (copy)'
+            or False
+        )
 
-        return super(product_product, self).copy(cr, uid, id, default=default,
-                                                 context=context)
-
-    _sql_constraints = [
-        ('default_code_unique', 'unique (default_code)',
-         'The code of Product must be unique !'),
-    ]
+        return super(product_product, self).copy(
+            cr, uid, id, default=default, context=context
+        )

--- a/product_unique_default_code/tests/test_for_unique_ref.py
+++ b/product_unique_default_code/tests/test_for_unique_ref.py
@@ -24,8 +24,6 @@
 #
 ###############################################################################
 
-from psycopg2 import IntegrityError
-
 from openerp.tests.common import TransactionCase
 from openerp.exceptions import except_orm
 
@@ -40,6 +38,8 @@ class TestForUniqueRef(TransactionCase):
 
     def setUp(self):
         super(TestForUniqueRef, self).setUp()
+        self.product_model = self.env['product.product']
+        self.product_template_model = self.env['product.template']
 
     def test_1_copied_product_unique_default_code(self):
         """
@@ -55,36 +55,7 @@ class TestForUniqueRef(TransactionCase):
             'standard_price': 100.90,
             'list_price': 123.50
         }
-        product = self.env['product.product'].create(product_data)
+        product = self.product_model.create(product_data)
         self.assertTrue(
             product.copy().default_code == '%s (copy)' % product.default_code,
             "ERROR: New product has not a unique internal reference ...")
-
-    def test_2_constraint_unique_internal_reference(self):
-        """
-        Test 2: This test will prove the new constraint added to this module
-        to can store only product with unique default_codes (internal refs):
-        - Create two products with the same internal reference
-        - Check if expected constraint exception is raised
-        """
-        product_data_1 = {
-            'name': 'Test Cellphone 1',
-            'default_code': '101001000',
-            'categ_id': self.env.ref('product.product_category_all').id,
-            'standard_price': 100.90,
-            'list_price': 123.50
-        }
-        product_data_2 = {
-            'name': 'Test Cellphone 2',
-            'default_code': '101001000',
-            'categ_id': self.env.ref('product.product_category_all').id,
-            'standard_price': 200.80,
-            'list_price': 241.70
-        }
-        product_obj = self.env['product.product']
-        product_obj.create(product_data_1)
-        with self.assertRaisesRegexp(
-                IntegrityError,
-                r'duplicate key value violates unique constraint "product'
-                r'_product_default_code_unique"'):
-            product_obj.create(product_data_2)

--- a/product_unique_default_code/tests/test_for_unique_ref.py
+++ b/product_unique_default_code/tests/test_for_unique_ref.py
@@ -57,5 +57,6 @@ class TestForUniqueRef(TransactionCase):
         }
         product = self.product_model.create(product_data)
         self.assertTrue(
-            product.copy().default_code == '%s (copy)' % product.default_code,
-            "ERROR: New product has not a unique internal reference ...")
+            product.copy().default_code != product.default_code,
+            "ERROR: New product has not a unique internal reference ..."
+        )


### PR DESCRIPTION
...t unique

Previously, a sql constraint was set on default code. This constraint makes
tests of purchase module to fail.
Because of that, the constraint has been removed in favor of a onchange
trigger. That makes the process a bit weaker as the check is only done
against user actions.
