### PR TITLE
Update res_partner.py

### DIFF
--- a/account_advance_payment/model/account_voucher.py
+++ b/account_advance_payment/model/account_voucher.py
@@ -61,6 +61,8 @@ class account_voucher(osv.Model):
             advance_account_id = partner.property_account_customer_advance.id
         else:
             advance_account_id = partner.property_account_supplier_advance.id
+        if len(res)==0:
+            return res
         res['value']['advance_account_id'] = advance_account_id
 
         return res

--- a/account_advance_payment/model/res_partner.py
+++ b/account_advance_payment/model/res_partner.py
@@ -40,14 +40,12 @@ class res_partner(osv.Model):
             type='many2one',
             relation='account.account',
             string="Account Supplier Advance",
-            view_load=True,
             domain="[('type','=','payable')]",
             help="This account will be used for advance payment of suppliers"),
         'property_account_customer_advance': fields.property(
             type='many2one',
             relation='account.account',
             string="Account Customer Advance",
-            view_load=True,
             domain="[('type','=','receivable')]",
             help="This account will be used for advance payment of custom"),
         #        'customer_advance': fields.function(

--- a/account_advance_payment/model/res_partner.py
+++ b/account_advance_payment/model/res_partner.py
@@ -37,7 +37,6 @@ class res_partner(osv.Model):
 
     _columns = {
         'property_account_supplier_advance': fields.property(
-            'account.account',
             type='many2one',
             relation='account.account',
             string="Account Supplier Advance",
@@ -45,7 +44,6 @@ class res_partner(osv.Model):
             domain="[('type','=','payable')]",
             help="This account will be used for advance payment of suppliers"),
         'property_account_customer_advance': fields.property(
-            'account.account',
             type='many2one',
             relation='account.account',
             string="Account Customer Advance",


### PR DESCRIPTION
fix  "**init**() takes exactly 1 argument (8 given )"  for odoo 8.0
