### PR TITLE
[ADD] only "Techincal Features" users can see the "Purchases/Purchases/Calls for  Bids" menu. For all the users like the Requisition Manager, Requisition User, Purchase User can only access to the purchase requisition using the "Requisitions/Requisition/Calls for Bids" menu.

### DIFF
--- a/purchase_requisition_for_everybody/view/purchase_requisition_view.xml
+++ b/purchase_requisition_for_everybody/view/purchase_requisition_view.xml
@@ -59,5 +59,9 @@
         action="purchase_requisition.action_purchase_requisition"
         />
 
+    <record id="purchase_requisition.menu_purchase_requisition_pro_mgt" model="ir.ui.menu">
+        <field name="groups_id" eval="[(4,ref('base.group_no_one'))]"/>
+    </record>
+
     </data>
 </openerp>


### PR DESCRIPTION
Task [vx#3350](https://www.vauxoo.com/#id=3350&view_type=form&model=project.task) HU [319](https://www.vauxoo.com/?debug=#id=319&view_type=form&model=user.story&action=726) Sprint 10
Here a demostration [video](http://youtu.be/_5GhvAa5uAE)
