### PR TITLE
[ADD] hide the purchase requisition generic groups configuration at the res.user form view to only use this module requisition security groups

### DIFF
--- a/purchase_requisition_for_everybody/view/purchase_requisition_view.xml
+++ b/purchase_requisition_for_everybody/view/purchase_requisition_view.xml
@@ -59,5 +59,16 @@
         action="purchase_requisition.action_purchase_requisition"
         />
 
+    <record model="ir.ui.view" id="res_users_hide_requistion_group">
+        <field name="name">res.users.hide.requistion.group</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.user_groups_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='sel_groups_54_55']" position="attributes">
+                <attribute name="invisible">True</attribute>
+            </xpath>
+        </field>
+    </record>
+
     </data>
 </openerp>


### PR DESCRIPTION
Task [vx#3351](https://www.vauxoo.com/#id=3351&view_type=form&model=project.task) HU [319](https://www.vauxoo.com/?debug=#id=319&view_type=form&model=user.story&action=726) Sprint 10
Result at this [image](https://docs.google.com/a/vauxoo.com/file/d/0B1UUUA6bRx8-VFRoblkwVXVubG8/edit?usp=drivesdk)
