### PR TITLE
[REF][account_group_auditory] change pass and adding attr noupdate=1 in data

### DIFF
--- a/account_group_auditory/security/account_user_group.xml
+++ b/account_group_auditory/security/account_user_group.xml
@@ -11,9 +11,7 @@
         <record id="group_account_user_audit" model="res.groups">
             <field name="menu_access" eval="[(4, ref('account.menu_finance'))]"/>
         </record>
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_finance_receivables'))]"/>
-        </record>
+
         <record id="group_account_user_audit" model="res.groups">
             <field name="menu_access" eval="[(4, ref('account.menu_action_account_moves_all'))]"/>
         </record>

--- a/account_group_auditory/security/account_user_group.xml
+++ b/account_group_auditory/security/account_user_group.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <openerp>
-    <data>
+    <data noupdate="0">
         <record id="group_account_user_audit" model="res.groups">
             <field name="name">Auditor (Read-Only)</field>
             <field name="category_id" ref="base.module_category_accounting_and_finance"/>
@@ -53,7 +53,7 @@
             <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         </record>
     </data>
-    <data noupdate=1>
+    <data noupdate="1">
         <record model="res.users" id="res_auditor_user">
             <field name="name">Auditor user</field>
             <field name="login">auditor</field>

--- a/account_group_auditory/security/account_user_group.xml
+++ b/account_group_auditory/security/account_user_group.xml
@@ -52,12 +52,13 @@
         <record id="group_account_user_audit" model="res.groups">
             <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         </record>
-
+    </data>
+    <data noupdate=1>
         <record model="res.users" id="res_auditor_user">
             <field name="name">Auditor user</field>
             <field name="login">auditor</field>
             <field name="tz">America/Mexico_City</field>
-            <field name="password">lodi-@uditor</field>
+            <field name="password">auditor</field>
             <field name="alias_name">auditor</field>
             <field name="company_id" eval="ref('base.main_company')"/> 
             <field name="groups_id"  eval="[(6,0,[ref('account_group_auditory.group_account_user_audit')])]"/>


### PR DESCRIPTION
This pr change the password, modify the data
and delete menu_acces account.menu_finance_receivables from the Auditor group
This change is motivated by a issue that happens when you install just OML or odoo-ifrs, the menu Accounting/Customer become hidden
the solutions is move this "menu_acces" from addons-vauxoo/account_group_auditory  to lodigroup/lodi-security
