### PR TITLE
[7.0][sprint_kanban] Added new ir_rule to portal group

### DIFF
--- a/sprint_kanban/__openerp__.py
+++ b/sprint_kanban/__openerp__.py
@@ -16,6 +16,7 @@
         "base_status", 
         "product", 
         "analytic", 
+        "portal", 
         "board", 
         "mail", 
         "resource"

--- a/sprint_kanban/security/ir.model.access.csv
+++ b/sprint_kanban/security/ir.model.access.csv
@@ -1,5 +1,6 @@
 "id","name","model_id:id","group_id:id",perm_read,perm_write,perm_create,perm_unlink
 "access_sprint_user","sprint_kanban","model_sprint_kanban","sprint_kanban.group_sprint_kanban_user",1,0,0,0
+"access_sprint_user_portal","sprint_kanban","model_sprint_kanban","portal.group_portal",1,0,0,0
 "access_sprint_manager","sprint_kanban","model_sprint_kanban","sprint_kanban.group_sprint_kanban_manager",1,1,1,1
 
 


### PR DESCRIPTION
Now the portal group can read the model sprint.kanban. This allows to the users with portal group can use the search view in the tree view
