### PR TITLE
[ADD] help short added in partner foreign test

### DIFF
--- a/partner_foreign/tests/test_partner_foreign.py
+++ b/partner_foreign/tests/test_partner_foreign.py
@@ -31,6 +31,7 @@ class TestPartnerLocation(TransactionCase):
 
     def get_records(self):
         """
+        get records to test
         """
         self.partner_rec = self.env.ref('base.main_partner')
         self.vauxoo_rec = self.env.ref('base.res_partner_23')


### PR DESCRIPTION
help short added in partner foreign test because warning in runbot openerp.addons.partner_foreign.tests.test_partner_foreign:32: [C0112([1mempty-docstring[0m), TestPartnerLocation.get_records] [1mEmpty method docstring[0m
