### PR TITLE
[8.0][product_historical_price] Modified the module to remove useless fields

### DIFF
--- a/product_historical_price/__openerp__.py
+++ b/product_historical_price/__openerp__.py
@@ -3,14 +3,14 @@
 #    Module Writen to OpenERP, Open Source Management Solution
 #    Copyright (C) Vauxoo (<http://vauxoo.com>).
 #    All Rights Reserved
-###############Credits######################################################
+###########################################################################
 #    Coded by: Vauxoo C.A.
 #    Planified by: Nhomar Hernandez
 #    Audited by: Vauxoo C.A.
 #############################################################################
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
@@ -20,7 +20,7 @@
 #
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-################################################################################
+##############################################################################
 #                    "security/groups.xml",
 {
     "name": "Product Historical Price",
@@ -38,11 +38,13 @@
         "decimal_precision",
         "account",
         "sale",
+        "base_action_rule",
     ],
     "demo": [],
     "data": [
         "view/product_view.xml",
         "data/product_data.xml",
+        "data/action_server_data.xml",
         "security/ir.model.access.csv"
     ],
     "test": [],

--- a/product_historical_price/data/action_server_data.xml
+++ b/product_historical_price/data/action_server_data.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<openerp>
+    <data noupdate="1">
+
+           <record model="ir.actions.server" id="update_prices_action">
+            <field name="name">Changes in list price</field>
+            <field name="model_id" eval="ref('product.model_product_template')"/>
+            <field name="state">code</field>
+            <field name="condition"></field>
+            <field name="sequence">5</field>
+            <field name="code">
+# Available locals:
+#  - time, datetime, dateutil: Python libraries
+#  - env: Odoo Environement
+#  - model: Model of the record on which the action is triggered
+#  - object: Record on which the action is triggered if there is one, otherwise None
+#  - workflow: Workflow engine
+#  - Warning: Warning Exception to use with raise
+# To return an action, assign: action = {...}
+price_obj = self.pool.get('product.historic.price')
+last_price = price_obj.search(cr, uid, [('product_id', '=', object.id)], order='name desc', limit=1)
+if last_price:
+    price_brw = price_obj.browse(cr, uid, last_price[0])
+    if price_brw.price != object.list_price:
+        price_obj.create(cr, uid, {'product_id': object.id, 'name': time.strftime('%Y-%m-%d %H:%M:%S'), 'price': object.list_price, 'product_uom': object.uom_id.id})
+else:
+    price_obj.create(cr, uid, {'product_id': object.id, 'name': time.strftime('%Y-%m-%d %H:%M:%S'), 'price': object.list_price, 'product_uom': object.uom_id.id})
+            </field>
+        </record>
+
+        <record model="base.action.rule" id="action_rule_issue_close">
+            <field name="name">Changes in list price</field>
+            <field name="model_id" eval="ref('product.model_product_template')"/>
+            <field name="sequence">0</field>
+            <field name="active">True</field>
+            <field name="kind">on_create_or_write</field>
+            <field name="server_action_ids" eval="[(6, 0, [ref('product_historical_price.update_prices_action')])]"/>
+        </record>
+
+
+    </data>
+</openerp>

--- a/product_historical_price/security/ir.model.access.csv
+++ b/product_historical_price/security/ir.model.access.csv
@@ -1,7 +1,5 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_product_historical","product_historical_price","model_product_historic_price","base.group_user",1,0,0,0
 "access_product_historical_partner_manager","product_historical_price_partner_manager","model_product_historic_price","base.group_partner_manager",1,1,1,1
-"access_product_historic_cost_user","product.historic.cost.user","model_product_historic_cost","base.group_user",1,0,0,0
-"access_product_historic_cost_manager","product.historic.cost.manager","model_product_historic_cost","base.group_partner_manager",1,1,1,1
 
 

--- a/product_historical_price/tests/__init__.py
+++ b/product_historical_price/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_historical_price

--- a/product_historical_price/tests/test_historical_price.py
+++ b/product_historical_price/tests/test_historical_price.py
@@ -1,0 +1,58 @@
+from openerp.tests.common import TransactionCase
+import time
+
+
+class TestHistoricalPrice(TransactionCase):
+
+    def setUp(self):
+        super(TestHistoricalPrice, self).setUp()
+        self.product = self.registry('product.template')
+        self.h_price = self.registry('product.historic.price')
+        self.h_cost = self.registry('product.price.history')
+        self.product_id = None
+
+    def test_create_product(self):
+        cr, uid = self.cr, self.uid
+        # Creating a product
+        self.product_id = self.product.create(cr, uid,
+                                              {'name': 'Product Test',
+                                               'list_price': 25,
+                                               'standard_price': 15})
+        # Checking if the historical was created correctly
+        h_price = self.h_price.search(cr, uid,
+                                      [('product_id', '=', self.product_id)])
+        h_cost = self.h_cost.search(cr, uid,
+                                    [('product_template_id', '=',
+                                      self.product_id)])
+        self.assertTrue(h_price and h_cost,
+                        "The historical were not created correctly")
+        price = h_price and self.h_price.browse(cr, uid, h_price[0]).price
+        cost = h_cost and self.h_cost.browse(cr, uid, h_cost[0]).cost
+        self.assertTrue(price == 25,
+                        "The sale price was to saved correctly")
+        self.assertTrue(cost == 15,
+                        "The cost was to saved correctly")
+
+    def test_write_product(self):
+        cr, uid = self.cr, self.uid
+        # Updating the product
+        self.test_create_product()
+        time.sleep(2)
+        self.product.write(cr, uid, [self.product_id],
+                           {'list_price': 40, 'standard_price': 18})
+        # Checking if the historical was changed correctly
+        h_price = self.h_price.search(cr, uid,
+                                      [('product_id', '=', self.product_id)],
+                                      order='name desc', limit=1)
+        h_cost = self.h_cost.search(cr, uid,
+                                    [('product_template_id', '=',
+                                      self.product_id)],
+                                    order='datetime desc', limit=1)
+        self.assertTrue(h_price and h_cost,
+                        "The historical does not exist")
+        price = h_price and self.h_price.browse(cr, uid, h_price[0]).price
+        cost = h_cost and self.h_cost.browse(cr, uid, h_cost[0]).cost
+        self.assertTrue(price == 40,
+                        "The sale price was not changed correctly")
+        self.assertTrue(cost == 18,
+                        "The cost was not changed correctly")

--- a/product_historical_price/view/product_view.xml
+++ b/product_historical_price/view/product_view.xml
@@ -25,29 +25,6 @@
                 </form>
             </field>
         </record>
-        <record id="product_historical_cost_tree" model="ir.ui.view">
-            <field name="name">product.historical.cost.tree</field>
-            <field name="model">product.historic.cost</field>
-            <field name="arch" type="xml">
-                <tree string="Historical Cost">
-                    <field name="name"/>
-                    <field name="price"/>
-                    <field name="product_uom"/>
-                </tree>
-            </field>
-        </record>
-
-        <record id="product_historical_cost_form" model="ir.ui.view">
-            <field name="name">product.historical.cost.form</field>
-            <field name="model">product.historic.cost</field>
-            <field name="arch" type="xml">
-                <form string="Historical Cost" version="7.0">
-                    <field name="name"/>
-                    <field name="price"/>
-                    <field name="product_uom"/>
-                </form>
-            </field>
-        </record>
 
         <!--
         <record model="ir.ui.view" id="product_historical_price">


### PR DESCRIPTION
Removed useless fields in product template because these fields shown duplicate info 
Remove the model product historic cost to use a new model of the odoo to save the historical cost of the products
Created action server to avoid overwrite the main methods (create and write)
Created unit test to confirm the functionality of the module
