### PR TITLE
[IMP][account_voucher_tax]Changed name of tax ISR, because this not must be have IVA in your name

### DIFF
--- a/account_voucher_tax/demo/account_voucher_tax_demo.xml
+++ b/account_voucher_tax/demo/account_voucher_tax_demo.xml
@@ -179,12 +179,12 @@
         </record>
         <record id="account_voucher_tax_purchase_iva10_rete_isr" model="account.tax">
             <field name="company_id" ref="base.main_company"/>
-            <field name="name">IVA 10% RETENIDO ISR - Test</field>
+            <field name="name">RETENTION ISR 10% - Test</field>
             <field name="tax_voucher_ok" eval="True"/>
             <field name="type_tax_use">purchase</field>
             <field name="type">percent</field>
             <field name="amount">-0.10000</field>
-            <field name="description">IVA 10% RETENIDO ISR Test</field>
+            <field name="description">RETENTION ISR 10% Test</field>
             <field name="account_collected_id" ref="account.iva"/>
             <field name="account_paid_id" ref="account.iva"/>
             <field name="account_collected_voucher_id" ref="account_iva_voucher10_rete_isr"/>

--- a/account_voucher_tax/demo/account_voucher_tax_demo.xml
+++ b/account_voucher_tax/demo/account_voucher_tax_demo.xml
@@ -179,12 +179,12 @@
         </record>
         <record id="account_voucher_tax_purchase_iva10_rete_isr" model="account.tax">
             <field name="company_id" ref="base.main_company"/>
-            <field name="name">RETENTION ISR 10% - Test</field>
+            <field name="name">WITHHOLDING ISR 10% - Test</field>
             <field name="tax_voucher_ok" eval="True"/>
             <field name="type_tax_use">purchase</field>
             <field name="type">percent</field>
             <field name="amount">-0.10000</field>
-            <field name="description">RETENTION ISR 10% Test</field>
+            <field name="description">WITHHOLDING ISR 10% Test</field>
             <field name="account_collected_id" ref="account.iva"/>
             <field name="account_paid_id" ref="account.iva"/>
             <field name="account_collected_voucher_id" ref="account_iva_voucher10_rete_isr"/>

--- a/account_voucher_tax/i18n/es.po
+++ b/account_voucher_tax/i18n/es.po
@@ -298,6 +298,6 @@ msgstr "Ayuda"
 
 #. module: account_voucher_tax
 #: model:account.tax,name:account_voucher_tax.account_voucher_tax_purchase_iva10_rete_isr
-msgid "RETENTION ISR 10% - Test"
+msgid "WITHHOLDING ISR 10% - Test"
 msgstr "RETENCIÓN ISR 10% - Prueba"
 

--- a/account_voucher_tax/i18n/es.po
+++ b/account_voucher_tax/i18n/es.po
@@ -296,3 +296,8 @@ msgstr "change"
 msgid "help"
 msgstr "Ayuda"
 
+#. module: account_voucher_tax
+#: model:account.tax,name:account_voucher_tax.account_voucher_tax_purchase_iva10_rete_isr
+msgid "RETENTION ISR 10% - Test"
+msgstr "RETENCIÓN ISR 10% - Prueba"
+


### PR DESCRIPTION
Se cambio el nombre del impuesto de ISR, para que este no contenga en su nombre la palabra IVA, ya que realmente éste no es un iva. 
