### PR TITLE
[8.0][hr_timesheet_reports] Changed quote in extra options in form view of the hr tiemsheet report

### DIFF
--- a/hr_timesheet_reports/model/hr_timesheet_reports_view.xml
+++ b/hr_timesheet_reports/model/hr_timesheet_reports_view.xml
@@ -120,7 +120,7 @@
                     </sheet>
                     <div class="oe_chatter">
                         <field name="message_follower_ids" widget="mail_followers"/>
-                        <field name="message_ids" widget="mail_thread" options="{'thread_level': 1}"/>
+                        <field name="message_ids" widget="mail_thread" options='{"thread_level": 1}'/>
                     </div>
                 </form>
             </field>


### PR DESCRIPTION
Changed the quotes in the options values because at the moment to render the form view the quotes must be double
