### PR TITLE
[FIX] the name field at the task form view now it shows in the complete lenght  of the view sheet. Fix Vauxoo/instance-vauxoo-com#62

### DIFF
--- a/user_story/view/project_view.xml
+++ b/user_story/view/project_view.xml
@@ -12,6 +12,10 @@
         <xpath expr="//field[@name='date_deadline']" position="after">
           <field name="userstory_id" on_change="onchange_user_story_task(userstory_id)" domain="[('project_id','=',project_id)]"/>
         </xpath>
+
+        <xpath expr="//field[@name='name']" position="attributes">
+            <attribute name="class"></attribute>
+        </xpath>
         
       </field>
     </record>


### PR DESCRIPTION
Task [vx#3789](https://www.vauxoo.com/web#id=3789&view_type=form&model=project.task&menu_id=136&action=138)

This is re result at the view.

![image](https://cloud.githubusercontent.com/assets/7593953/8535300/267846d8-240a-11e5-94d5-3bca6eed6406.png)
