### PR TITLE
[FIX] addons-vauxoo on some customer validations

### DIFF
--- a/product_category_attributes/data/server_actions.xml
+++ b/product_category_attributes/data/server_actions.xml
@@ -11,10 +11,14 @@
 categ_obj = pool.get('product.category')
 categ_ids = categ_obj.search(cr, uid, [('id','=',object.categ_id.id)])
 datas = []
+line_attrs = []
+for line in object.attribute_line_ids:
+    line_attrs.append(line.attribute_id.id)
 if categ_ids:
     for categ in categ_obj.browse(cr, uid, categ_ids, context):
         for attribute in categ.attribute_ids:
-            datas.append((0, 0, {'attribute_id':attribute.id}))
+            if attribute.id not in line_attrs:
+                datas.append((0, 0, {'attribute_id':attribute.id}))
         object.write({'attribute_line_ids': datas})]]>
             </field>
         </record>

--- a/website_product_availability/models/product.py
+++ b/website_product_availability/models/product.py
@@ -76,7 +76,8 @@ class product_product(osv.Model):
             method=True, selection=SELECTION_LIST,
             string="Website Stock State",
             store={'product.product': (lambda self, cr, uid, ids,
-                                       context={}: ids, ['qty_available', 'low_stock'], 15)}),
+                                       context={}: ids, ['qty_available',
+                                                         'low_stock'], 15)}),
     }
     _default = {
         'low_stock': 0,

--- a/website_product_availability/models/product.py
+++ b/website_product_availability/models/product.py
@@ -71,10 +71,12 @@ class product_product(osv.Model):
         'low_stock': fields.integer('Low Stock', help="This field is used to show\
     on the website when a product has low availability, any number of stock\
     equals the value set or lower will show 'low avilability' on product "),
-        'stock_state': fields.function(_get_availability, type='selection',
-                                       method=True, selection=SELECTION_LIST,
-                                       string="Website Stock State",
-                                       store=True),
+        'stock_state': fields.function(
+            _get_availability, type='selection',
+            method=True, selection=SELECTION_LIST,
+            string="Website Stock State",
+            store={'product.product': (lambda self, cr, uid, ids,
+                                       context={}: ids, ['qty_available', 'low_stock'], 15)}),
     }
     _default = {
         'low_stock': 0,

--- a/website_product_availability/views/templates.xml
+++ b/website_product_availability/views/templates.xml
@@ -7,9 +7,11 @@
 
  				<h5><span class="label label-info stock_delay"></span></h5>
 
- 				<div id="similar_products_vx" class="alert alert-success" style="align: center;">
- 					<a href="#rec_prod" class="alert-link">Similar Products</a>
- 				</div>
+ 				<t t-if="product.alternative_product_ids">
+ 					<div id="similar_products_vx" class="alert alert-success" style="align: center;">
+ 						<a href="#rec_prod" class="alert-link">Similar Products</a>
+ 					</div>
+ 				</t>
  			</xpath>
  		</template>
  		<template id="product_rec_prod_name" inherit_id="website_sale.recommended_products">

--- a/website_product_comment_purchased/views/website_comment_purchased.xml
+++ b/website_product_comment_purchased/views/website_comment_purchased.xml
@@ -4,7 +4,6 @@
         <template id="discussion_purchased" inherit_id="website_sale.product_comment" active="False" customize_show="True" name="Bougth Item On Comments">
             <xpath  expr="//div[@class='media-body oe_msg_content']" position="after">
                     <t t-if="message.comment_bought"><span class="label label-success">Customer bought the item</span></t>
-                    <t t-if="message.comment_bought != True"><span class="label label-danger">Customer didnt't bought the item</span></t>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
- website_product_comment_purchased: [REM] No longer necessary to show if customer didnt bought the item on product.
- website_product_availability: [FIX] similar products link only will be shown if there are alternative products
- product_category_attributes: [ADD] validation on server action if attribute is set it wont add it again
