### PR TITLE
Description field on task form view to html widget

### DIFF
--- a/note_to_task/__openerp__.py
+++ b/note_to_task/__openerp__.py
@@ -3,10 +3,11 @@
 #    Module Writen to OpenERP, Open Source Management Solution
 #    Copyright (C) Vauxoo (<http://vauxoo.com>).
 #    All Rights Reserved
-################# Credits######################################################
+#
+#    CREDITS:
 #    Coded by: Luis Escobar <Luis@vauxoo.com>
 #    Audited by: Nhomar Hernandez <nhomar@vauxoo.com>
-###############################################################################
+#
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published
 #    by the Free Software Foundation, either version 3 of the License, or
@@ -22,7 +23,7 @@
 ###############################################################################
 {
     "name": "Convert Note to Task",
-    "version": "1.6",
+    "version": "1.6.1",
     "author": "Vauxoo",
     "category": "Tools",
     "website": "http://vauxoo.com",

--- a/note_to_task/model/__init__.py
+++ b/note_to_task/model/__init__.py
@@ -3,10 +3,11 @@
 #    Module Writen to OpenERP, Open Source Management Solution
 #    Copyright (C) Vauxoo (<http://vauxoo.com>).
 #    All Rights Reserved
-################# Credits######################################################
+#
+#    CREDITS
 #    Coded by: Luis Escobar <luis@vauxoo.com>
 #    Audited by: Nhomar Hernandez <nhomar@vauxoo.com>
-###############################################################################
+#
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published
 #    by the Free Software Foundation, either version 3 of the License, or

--- a/note_to_task/view/note_view.xml
+++ b/note_to_task/view/note_view.xml
@@ -11,5 +11,16 @@
                 </xpath>
             </field>
         </record>
+        
+        <record model="ir.ui.view" id="view_task_form2">
+            <field name="name">project.task.search.form</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="project.view_task_form2"/>
+            <field name="arch" type="xml">
+                <field name="description" position="replace">
+                    <field name="description" nolabel="1" widget="text_html" placeholder="Add a Description..."/>
+                </field>
+            </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
Since note brings a html description in task form after conversion, it seems only right to use a html widget on task description too.
A fresh PR from a freshly cloned repo.
