### PR TITLE
[ADD] No module named xlrd fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
       - python-lxml  # because pip installation is slow
       - python-simplejson
       - python-serial
+      - python-xlrd
 
 install:
   - git clone --single-branch --depth=1 https://github.com/vauxoo/maintainer-quality-tools.git -b master ${HOME}/maintainer-quality-tools


### PR DESCRIPTION
  File "/home/travis/addons-vauxoo/purchase_rfq_xls/wizard/wizard.py", line 24, in <module>
    import xlrd
ImportError: No module named xlrd
