### PR TITLE
[WIP] manage a source and dest location in the warehouse receipt input wizard.

### DIFF
--- a/warehouse_interim_receipt/__openerp__.py
+++ b/warehouse_interim_receipt/__openerp__.py
@@ -28,6 +28,7 @@
         "views/warehouse_receipt.xml",
         "views/stock_move_views.xml",
         "views/stock_picking_views.xml",
+        "views/res_config_views.xml",
     ],
     "demo": [
         "demo/stock_move.yml",

--- a/warehouse_interim_receipt/models/__init__.py
+++ b/warehouse_interim_receipt/models/__init__.py
@@ -11,3 +11,4 @@
 
 from . import warehouse_receipt
 from . import stock_move
+from . import res_config

--- a/warehouse_interim_receipt/models/res_config.py
+++ b/warehouse_interim_receipt/models/res_config.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Katherine Zaoral <kathy@vauxoo.com>
+#    planned by: Rafael Silva <rsilvam@vauxoo.com>
+############################################################################
+
+from openerp import models, fields
+
+
+class StockConfigSettings(models.TransientModel):
+
+    _inherit = 'stock.config.settings'
+
+    default_location_id = fields.Many2one(
+        'stock.location',
+        string='Default Source Location',
+        default_model='wizard.warehouse.receipt.input')
+
+    default_location_dest_id = fields.Many2one(
+        'stock.location',
+        string='Default Destination Location',
+        default_model='wizard.warehouse.receipt.input')

--- a/warehouse_interim_receipt/views/res_config_views.xml
+++ b/warehouse_interim_receipt/views/res_config_views.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<openerp>
+    <data>
+
+        <record id="stock_settings_warehouse_receipt_form" model="ir.ui.view">
+            <field name="name">stock.settings.warehouse.receipt.form</field>
+            <field name="model">stock.config.settings</field>
+            <field name="inherit_id" ref="stock.view_stock_config_settings"/>
+            <field name="arch" type="xml">
+                <xpath expr="//form" position="inside">
+                    <group>
+                        <label for="id" string="WHR Input Report"/>
+                        <div>
+                            <div>
+                                <field name="default_location_id" class="oe_inline"/>
+                                <label for="default_location_id"/>
+                            </div>
+                            <div>
+                                <field name="default_location_dest_id" class="oe_inline"/>
+                                <label for="default_location_dest_id"/>
+                            </div>
+                        </div>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>
+

--- a/warehouse_interim_receipt/wizards/warehouse_receipt_input.py
+++ b/warehouse_interim_receipt/wizards/warehouse_receipt_input.py
@@ -38,6 +38,12 @@ class WarehouseReceiptInput(models.TransientModel):
     whr_filter = fields.Boolean(
         string='Generate Filter',
         help='Generates the filter to build the report')
+    location_id = fields.Many2one(
+        'stock.location', 'Source Location',
+        help='Source location of the moves to show')
+    location_dest_id = fields.Many2one(
+        'stock.location', 'Destination Location',
+        help='Destination location of the moves to show')
 
     @api.multi
     def view_moves(self):
@@ -72,6 +78,10 @@ class WarehouseReceiptInput(models.TransientModel):
         model = 'stock.move'
         domain = [
             ('purchase_order_id', 'in', self.purchase_order_ids.mapped('id'))]
+        if self.location_id:
+            domain.append(('location_id', '=', self.location_id.id))
+        if self.location_dest_id:
+            domain.append(('location_dest_id', '=', self.location_dest_id.id))
         context = {'group_by': ['purchase_order_id', 'warehouse_receipt_id']}
         return name, domain, model, context
 

--- a/warehouse_interim_receipt/wizards/warehouse_receipt_input_view.xml
+++ b/warehouse_interim_receipt/wizards/warehouse_receipt_input_view.xml
@@ -12,6 +12,8 @@
                         <field name="bol"/>
                         <field name="purchase_order_ids" widget="many2many_tags"/>
                         <field name="whr_filter"/>
+                        <field name="location_id"/>
+                        <field name="location_dest_id"/>
                     </group>
                     <footer>
                         <button name="view_moves" string="Retrieve the Warehouse Receipt Report" type="object" class="oe_highlight"/>


### PR DESCRIPTION
Try to solve the issue #496
- [ ] Fix: try to manage default form stock.config.settings but find and error.
- [ ] Add missing warehouse configuration to enable WH/Input location
- [ ] Check if is required to add new data demo for the Wh/Input location. 
