### PR TITLE
[WIP] find cause of error reported in Vauxoo/addons-vauxoo#535 

### DIFF
--- a/user_story/__openerp__.py
+++ b/user_story/__openerp__.py
@@ -43,8 +43,8 @@
         "demo/demo.xml"
     ],
     "data": [
-        #"data/data_us_report.xml",
-        #"report/user_story_report_view.xml",
+        # "data/data_us_report.xml",
+        # "report/user_story_report_view.xml",
         "security/userstory_security.xml",
         "security/ir.model.access.csv",
         "view/userstory_view.xml",

--- a/user_story/tests/test_user_story.py
+++ b/user_story/tests/test_user_story.py
@@ -265,8 +265,7 @@ class TestUserStory(TransactionCase):
                                 "The criterial was not accepted")
 
             elif i == 1:
-                mes = 'El criterio%{0}%ha sido terminado por%'.\
-                    format(criterial.name)
+                mes = 'Please Review%{0}'.format(criterial.name)
                 self.criterial.ask_review(cr, user_brw.id, [criterial.id])
                 m_id = self.message.search(cr, uid,
                                            [('res_id', '=', story_brw.id),

--- a/user_story/tests/test_user_story.py
+++ b/user_story/tests/test_user_story.py
@@ -241,8 +241,9 @@ class TestUserStory(TransactionCase):
         i = 0
         for criterial in user_brw and story_brw and story_brw.accep_crit_ids:
             if i == 0:
-                mes = 'El criterio%{0}%ha sido aceptado por%'.\
-                    format(criterial.name)
+                mes = ('The acceptability criterion %{criteria}%'
+                       ' has been accepted by %').format(
+                           criteria=criterial.name)
                 self.assertFalse(criterial.accepted)
                 self.criterial.approve(cr, user_brw.id, [criterial.id])
                 self.assertTrue(criterial.accepted)

--- a/user_story/tests/test_user_story.py
+++ b/user_story/tests/test_user_story.py
@@ -245,6 +245,7 @@ class TestUserStory(TransactionCase):
                     format(criterial.name)
                 self.assertFalse(criterial.accepted)
                 self.criterial.approve(cr, user_brw.id, [criterial.id])
+                self.assertTrue(criterial.accepted)
                 m_id = self.message.search(cr, uid,
                                            [('res_id', '=', story_brw.id),
                                             ('body', 'ilike', mes)])


### PR DESCRIPTION
Fix Vauxoo/addons-vauxoo#535

At runbot the message is created after clicking the approve of the AC.
It can be seen because after click the approve button a message is added to the user story message log.
### Finding the error
- [x] make a runbot test tryting to approve a acceptability criteria and check if the message appers in the user story message log.

> The message appears. The message is been created.
- [x] update unit test to check if the criteria is really accepted. Maybe the message has not been created because the criteria really is not been approved.

> The criteria was really approved
- [x] download a local copy and run the instance to check from the interface if the message is created.

> The messege is created and added to the user story message log.
- [x] the unit test use a text in spanish to make the comparation. Maybe this is the problem. use the original text and use the translation _ function to manage the compare (use pdb)

> **The error was found**

NOTE: Another error was throw. is the same error. so will be fixed and push in this same solution.
