### PR TITLE
[FIX] website_product_filters: Breadcrumb and attribute tags of filters now are shown in the same line

### DIFF
--- a/website_product_filters/views/templates.xml
+++ b/website_product_filters/views/templates.xml
@@ -159,12 +159,19 @@
           <xpath expr="//div[@class='products_pager']/div[@class='row']/t[@t-call='website_sale.search']" position="replace">
 
             <div class="container">
-            <div class="col-md-6 panel-no-margins">
+            <div class="col-md-9 panel-no-margins">
                 <ul class="breadcrumb pull-left panel-no-borders">
                     <li><a id="bread_home" href="/">Home</a></li>
                     <li><a id="bread_products" href="/shop">Products</a></li>
                     <li class="active"><a id="bread_category">All Products</a></li>
                 </ul>
+                  <t t-foreach="attributes" t-as="a">
+                    <t t-foreach="a.value_ids" t-as="v">
+                      <t t-if="v.id in attrib_set">
+                        <h4 class="inline-hs panel-no-borders text-left"><span class="label label-info" t-field="v.name"></span></h4>
+                      </t>
+                    </t>
+                  </t>
             </div>
               <div class="col-md-3 pull-right">
                 <select class="form-control yoytec-input mt3" id="product_sorter" name="product_sorter">
@@ -177,28 +184,16 @@
                   <option value="popularity">Popularity</option>
                 </select>
               </div>
-              <form t-att-action="keep('/shop'+ ('/category/'+slug(category)) if category else '', search=0)" method="get" t-att-class="search_class">
 
+              <form t-att-action="keep('/shop'+ ('/category/'+slug(category)) if category else '', search=0)" method="get" t-att-class="search_class">
                 <t t-if="attrib_values">
                   <t t-foreach="attrib_values" t-as="a">
                     <input class="yoytec-input mt3" type="hidden" name="attrib" t-att-value="'%s-%s' % (a[0], a[1])"/>
                   </t>
                 </t>
-            </form>
-
-
+              </form>
             </div>
-              <div class="">
-              <div class="panel-no-borders pull-left">
-                  <t t-foreach="attributes" t-as="a">
-                    <t t-foreach="a.value_ids" t-as="v">
-                      <t t-if="v.id in attrib_set">
-                        <h4 class="inline-hs panel-no-borders"><span class="label label-info" t-field="v.name"></span></h4>
-                      </t>
-                    </t>
-                  </t>
-              </div>
-            </div>
+
 
           </xpath>
           <xpath expr="//div[@class='products_pager']/div[@class='row']/t[@t-call='website.pager']" position="replace">


### PR DESCRIPTION
BULID https://github.com/Vauxoo/yoytec/pull/407
Fixes https://github.com/Vauxoo/yoytec/issues/387

![image](https://www.evernote.com/l/AFzuqaPnUzxOU7kOD89kWdD8mR5QLfXQ_BsB/image.png)
