### PR TITLE
[IMP] changes in the stock_allow_past_date module to only create past picking/quant in a date when is explicitly required by another module.

### DIFF
--- a/stock_allow_past_date/README.rst
+++ b/stock_allow_past_date/README.rst
@@ -3,11 +3,26 @@ Stock Allow Past Date
 
 This module add the functionality to let to validate a picking with a past
 date and generate the move/quant with the past date instead the current date.
+It is considered as an stock module's bugfix. This module by it self do not
+change the way that picking is created, just add a workaround that can be
+manage with a key in context to let to create the picking in a past date.
 
-It is considered as an stock module's bugfix.
+This module is not for final user use, is more like a tool to be use for
+another modules (that take this module as dependency) to let then create
+picking and quants in past date. This is mostly used when creating historical
+data demo. And is not needed for regular creating picking purpose.
 
-The field ``date`` need to be set in the picking and also in the move to
-re-used and set it to the quant.
+What do you need to create picking/quant in a past date:
+
+#. Create the demo data of the picking and move. You need to set the ``date``
+   field in both records. This field is the one re-used to set it in the
+   quant.
+#. You need to call the picking methods with a prefix context activating the
+   "Allow Past Date" mode. For this just add the
+   ``with_context({'allow_past_date_quants': True})``. This is required to be
+   use in the call of the ``action_confirm()``, ``do_transfer()``,
+   ``action_done()`` picking methods and whatever other method that influence
+   in the quant creation and validation.
 
 TODO
 ====
@@ -16,5 +31,3 @@ TODO
   the one that is used when in the move. I check this an this is not happened,
   please review again and then report.
 - Check via unit test that the quant in_date/write date is the same.
-- Want to get better the way that overwrite the methods that write the
-  move/quant date. Maybe using context instead.

--- a/stock_allow_past_date/__openerp__.py
+++ b/stock_allow_past_date/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Stock Allow Past Date",
-    "version": "8.0.1.0",
+    "version": "8.0.2.0.0",
     "license": "LGPL-3",
     "author": "Vauxoo",
     "website": "http://www.vauxoo.com/",

--- a/stock_allow_past_date/model/stock_move.py
+++ b/stock_allow_past_date/model/stock_move.py
@@ -35,7 +35,22 @@ class StockMove(models.Model):
         return bool(quants)
 
     def action_done(self, cr, uid, ids, context=None):
-        """ Overwrite complete the method to introduce exception on the test.
+        context = context or {}
+        if context.get('allow_past_date_quants', False):
+            res = self.action_done_allow_past_date(cr, uid, ids,
+                                                   context=context)
+        else:
+            res = super(StockMove, self).action_done(cr, uid, ids,
+                                                     context=context)
+        return res
+
+    def action_done_allow_past_date(self, cr, uid, ids, context=None):
+        """NOTE: This method is a copy of the original one in odoo named
+        action_done but we add a new sectiond of conde to introduce exception
+        on the test.
+
+        Look for "# NOTE VX: This section was overwritten." to find the added
+        code.
         """
         context = context or {}
         picking_obj = self.pool.get("stock.picking")
@@ -207,9 +222,33 @@ class StockQuant(models.Model):
             src_package_id=False, dest_package_id=False,
             force_location_from=False, force_location_to=False,
             context=None):
-        """NOTE: This method is a copy of the original one in odoo
-        Here we set in_date taking into account the move date
+        context = context or {}
+        if context.get('allow_past_date_quants', False):
+            res = self._quant_create_allow_past_date(
+                cr, uid, qty, move, lot_id=lot_id, owner_id=owner_id,
+                src_package_id=src_package_id, dest_package_id=dest_package_id,
+                force_location_from=force_location_from,
+                force_location_to=force_location_to, context=context)
+        else:
+            res = super(StockQuant, self)._quant_create(
+                cr, uid, qty, move, lot_id=lot_id, owner_id=owner_id,
+                src_package_id=src_package_id, dest_package_id=dest_package_id,
+                force_location_from=force_location_from,
+                force_location_to=force_location_to, context=context)
+        return res
+
+    def _quant_create_allow_past_date(
+            self, cr, uid, qty, move, lot_id=False, owner_id=False,
+            src_package_id=False, dest_package_id=False,
+            force_location_from=False, force_location_to=False,
+            context=None):
+        """ NOTE: This method is a copy of the original one in odoo named
+        _quant_create Here we set in_date taking into account the move date
+
         This method is call from the quant_move after action_done.
+
+        Look for "# NOTE VX: This section was overwritten." to find the added
+        code.
         """
         if context is None:
             context = {}

--- a/stock_allow_past_date/static/description/index.html
+++ b/stock_allow_past_date/static/description/index.html
@@ -13,18 +13,54 @@
     <p class="oe_mt32">
      This module add the functionality to let to validate a picking with a past
 date and generate the move/quant with the past date instead the current date.
+It is considered as an stock module's bugfix. This module by it self do not
+change the way that picking is created, just add a workaround that can be
+manage with a key in context to let to create the picking in a past date.
     </p>
     <p class="oe_mt32">
-     It is considered as an stock module's bugfix.
+     This module is not for final user use, is more like a tool to be use for
+another modules (that take this module as dependency) to let then create
+picking and quants in past date. This is mostly used when creating historical
+data demo. And is not needed for regular creating picking purpose.
     </p>
     <p class="oe_mt32">
-     The field
-     <code class="docutils literal">
-      date
-     </code>
-     need to be set in the picking and also in the move to
-re-used and set it to the quant.
+     What do you need to create picking/quant in a past date:
     </p>
+    <ol class="arabic simple">
+     <li>
+      Create the demo data of the picking and move. You need to set the
+      <code class="docutils literal">
+       date
+      </code>
+      field in both records. This field is the one re-used to set it in the
+quant.
+     </li>
+     <li>
+      You need to call the picking methods with a prefix context activating the
+"Allow Past Date" mode. For this just add the
+      <code class="docutils literal">
+       <span class="pre">
+        with_context({'allow_past_date_quants':
+       </span>
+       True})
+      </code>
+      . This is required to be
+use in the call of the
+      <code class="docutils literal">
+       action_confirm()
+      </code>
+      ,
+      <code class="docutils literal">
+       do_transfer()
+      </code>
+      ,
+      <code class="docutils literal">
+       action_done()
+      </code>
+      picking methods and whatever other method that influence
+in the quant creation and validation.
+     </li>
+    </ol>
    </div>
    <div class="section oe_span12" id="todo">
     <h1>
@@ -42,10 +78,6 @@ please review again and then report.
      </li>
      <li>
       Check via unit test that the quant in_date/write date is the same.
-     </li>
-     <li>
-      Want to get better the way that overwrite the methods that write the
-move/quant date. Maybe using context instead.
      </li>
     </ul>
    </div>

--- a/stock_allow_past_date/tests/test_past_date.py
+++ b/stock_allow_past_date/tests/test_past_date.py
@@ -103,10 +103,10 @@ class TestPickingDate(common.TransactionCase):
         self.assertEqual(picking.move_lines, move)
 
         # Confirm Picking
-        picking.action_confirm()
+        picking.with_context({'allow_past_date_quants': True}).action_confirm()
 
         # Validate Picking
-        picking.do_transfer()
+        picking.with_context({'allow_past_date_quants': True}).do_transfer()
         self.assertEqual(picking.state, 'done')
 
         # Check move dates


### PR DESCRIPTION
This changes were make in pro to solve the error log messages founds in the PR https://github.com/Vauxoo/yoytec/pull/473
This is a POC and first need to be tested by a dummy PR.
If works then need to to make a squash to finally merge.

Best Regards.
