### PR TITLE
[FIX] Remove text in claim diagnosis

### DIFF
--- a/crm_claim_summary_report/reports/claim_summary_report.xml
+++ b/crm_claim_summary_report/reports/claim_summary_report.xml
@@ -212,7 +212,7 @@
                     <div class="row">
                         <div class="col-xs-12">
                             <p class="list-group-item-text"><strong>Customer description<span>: </span></strong>
-                                <span t-field="line.claim_diagnosis"/>This is a very long long description for what customer was doing at this time, I don't know what else to say for this, please help me to say something useful and funny, this is not anymore
+                                <span t-field="line.claim_diagnosis"/>
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
## Changes:
- It removes hardcoded text left in report for product labels as it shows below

![image](https://cloud.githubusercontent.com/assets/2961943/11752065/9d76652c-a00f-11e5-9854-055a27a19582.png)
