### PR TITLE
[ADD] website_product_filters: breadcrumb on product detail shows product name, [x] set as a sup with extra space on filter tags HU#1006 CA#9 CA#10

### DIFF
--- a/website_product_filters/views/templates.xml
+++ b/website_product_filters/views/templates.xml
@@ -211,7 +211,8 @@
                             <span class="label label-warning">
                               <t t-esc="v.name"></t>
                                 <a t-att-data-attrvalue="v.id" class="removable-badge">
-                                  <i class="fa fa-times"></i>
+                                  <i class="fa"></i>
+                                  <sup><i class="fa fa-times"></i></sup>
                                 </a>
                             </span>
                           </h4>
@@ -308,6 +309,9 @@
                 <ul class="breadcrumb pull-left panel-no-borders">
                     <t t-set="current_category" t-value="category"/>
                     <t t-call="website_product_filters.breadcrumbs"/>
+                    <t t-if="product.id">
+                      <li class="active"><span t-field="product.name"/></li>
+                    </t>
                 </ul>
               </t>
             </div>


### PR DESCRIPTION
Fixes https://github.com/Vauxoo/yoytec/issues/543
Build https://github.com/Vauxoo/yoytec/pull/561
![bread](https://www.evernote.com/l/AFwxRzUa5ehFVaIKxS-SKNIgQXBZLsFL-zYB/image.png)
![tags](https://www.evernote.com/l/AFyLSFDc_jxK0o-Gq9xYOwWgrqOLtdYtVXYB/image.png)
