### PR TITLE
[BUG] warning missing ACL for `website.config.settings` model

### DIFF
--- a/website_product_filters/models/res_config.py
+++ b/website_product_filters/models/res_config.py
@@ -25,7 +25,7 @@
 from openerp import models, fields
 
 
-class Website(models.Model):
+class Website(models.TransientModel):
     _inherit = 'website.config.settings'
 
     default_sort = fields.Selection(string='Default Sort',


### PR DESCRIPTION
module: website_product_filters
version: 1.0

NOTE: This PR Fixes Vauxoo/yoytec#562
One of our clients odoo server log register this warning

``` bash
WARNING openerp_test openerp.modules.loading: The model website.config.settings has no access rules, consider adding one. E.g. access_website_config_settings,access_website_config_settings,model_website_config_settings,,1,0,0,0
```

The module `website.config.settings` is a wizard so should not require a ACL. 
Making a grep I found that the `website_product_filters` module overwrite this model using:

``` python
class Website(models.Model):
    _inherit = 'website.config.settings'
```

[original code](https://github.com/Vauxoo/addons-vauxoo/blob/8.0/website_product_filters/models/res_config.py#L28-L29)

To fix this warning only need to change the `models.Model` for a `models.TransientModel`
