### PR TITLE
[FIX] avoid copy account_move_id when mrp.production is duplicated

### DIFF
--- a/mrp_workcenter_account_move/model/mrp.py
+++ b/mrp_workcenter_account_move/model/mrp.py
@@ -5,6 +5,7 @@ from openerp.exceptions import except_orm, Warning as UserError
 
 
 class MrpProduction(models.Model):
+
     """
     Production Orders / Manufacturing Orders
     """
@@ -14,7 +15,8 @@ class MrpProduction(models.Model):
         'account.move',
         string='Cost Journal Entry',
         readonly=True,
-        )
+        copy=False,
+    )
 
     @api.multi
     def test_accounting_setting(self):
@@ -195,7 +197,7 @@ class MrpProduction(models.Model):
                     credit=cycle_cost,
                     account_id=wc.costs_general_account_id.id,
                     analytic_account_id=wc.costs_cycle_account_id.id,
-                    )
+                )
                 aml_obj.create(debit_cycle)
                 aml_obj.create(credit_cycle)
 
@@ -208,13 +210,13 @@ class MrpProduction(models.Model):
                     base_hour,
                     debit=hour_cost,
                     account_id=production_account_id,
-                    )
+                )
                 credit_hour = dict(
                     base_hour,
                     credit=hour_cost,
                     account_id=wc.costs_general_account_id.id,
                     analytic_account_id=wc.costs_hour_account_id.id,
-                    )
+                )
                 aml_obj.create(debit_hour)
                 aml_obj.create(credit_hour)
         return True

--- a/mrp_workcenter_account_move/tests/test_mrp_production.py
+++ b/mrp_workcenter_account_move/tests/test_mrp_production.py
@@ -9,6 +9,7 @@ from openerp.tests.common import TransactionCase
 
 
 class TestMrpProduction(TransactionCase):
+
     '''
         This test do the following:
             1.- Create a mrp.production.
@@ -68,6 +69,8 @@ class TestMrpProduction(TransactionCase):
                          'done',
                          "The mrp production doesn't done.")
 
+        self.production_copy_test(self.mrp_production)
+
         aml_ids = self.mrp_production.aml_production_ids
 
         aml_raw_and_fg = [
@@ -107,6 +110,12 @@ class TestMrpProduction(TransactionCase):
         wip_credit = sum([q.credit for q in wip_ids])
         self.assertEqual((wip_debit, wip_credit),
                          (100, 100), "Work in Process is wrong")
+
+    def production_copy_test(self, production_id=False):
+        self.assertTrue(production_id.account_move_id)
+        new_production_id = production_id.copy()
+        self.assertTrue(new_production_id != production_id)
+        self.assertEqual(new_production_id.account_move_id.id, False)
 
     def create_wizard(self, values=None):
         self.wzd_id = self.wzd_obj.with_context(


### PR DESCRIPTION
## Changes made:
- [X] Disable copy for `account_move_id` field
- [X] Add unit test to validate it
