### PR TITLE
[REF] .travis.yml: Disable tests for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,10 @@ script:
   - PYTHONPATH=${PATH} python -c "import getaddons;print 'export INCLUDE_LINT=\"' + ' '.join(getaddons.get_modules_changed('${TRAVIS_BUILD_DIR}', 'origin/${TRAVIS_BRANCH}')) + '\"'" >${TRAVIS_BUILD_DIR}/modules_changed.profile
   - PYTHONPATH=${PATH} python -c "import os, getaddons;print 'export INCLUDE=\"' + ','.join(map(os.path.basename, getaddons.get_modules_changed('${TRAVIS_BUILD_DIR}', 'origin/${TRAVIS_BRANCH}'))) + '\"'" >>${TRAVIS_BUILD_DIR}/modules_changed.profile
   - source ${TRAVIS_BUILD_DIR}/modules_changed.profile
+  # If there isn't modules changed for lint checks then exit
   - if [[ "x${INCLUDE_LINT}" == "x" && "${TESTS}" == "0" ]]; then exit 0; fi
+  # Travis tests disabled. Travis can't download private repositories.
+  - if [[ "${TESTS}" == "1" && "${RUNBOT}" != "1" ]]; then exit 0; fi
   - travis_wait travis_run_tests
 
 after_success:


### PR DESCRIPTION
Because, runbot can't download private repositories in public build
