### PR TITLE
[WIP][8.0] Add onchange method to wizard to show current recursive cost valuation for a BoM Product

### DIFF
--- a/product_extended_segmentation/tests/__init__.py
+++ b/product_extended_segmentation/tests/__init__.py
@@ -21,3 +21,4 @@
 ##############################################################################
 
 from . import test_extend_segmentation
+from . import test_wizard

--- a/product_extended_segmentation/tests/test_wizard.py
+++ b/product_extended_segmentation/tests/test_wizard.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2015 Vauxoo
+#    Author : Humberto Arocha <hbto@vauxoo.com>
+#             Osval Reyes <osval@vauxoo.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.tests.common import TransactionCase
+
+
+class TestWizard(TransactionCase):
+
+    def setUp(self):
+        super(TestWizard, self).setUp()
+        self.prod_template = self.env['product.template']
+        self.wizard = self.env['wizard.price']
+        self.producto_d_id = self.env.ref(
+            'product_extended_segmentation.producto_d').product_tmpl_id
+        self.producto_e_id = self.env.ref(
+            'product_extended_segmentation.producto_e').product_tmpl_id
+
+    def create_wizard(self, product_tmpl_id):
+        return self.wizard.with_context({
+            'active_model': product_tmpl_id._name,
+            'active_id': product_tmpl_id.id,
+            'active_ids': product_tmpl_id.ids,
+        }).create({})
+
+    def get_product_cost(self, info_field, product_tmpl_id):
+        return eval(info_field)[product_tmpl_id]
+
+    def test_01_test_wizard_onchange_recursive(self):
+        wizard_id = self.create_wizard(self.producto_d_id)[0]
+        self.assertEqual(wizard_id.recursive, False,
+                         'WizardPrice recursive check should be unchecked'
+                         'by default')
+        cost = self.get_product_cost(
+            wizard_id.info_field, self.producto_d_id.id)
+        self.assertEqual(cost, 35, 'Non-recursive cost valuation should be 35')
+
+        wizard_id.recursive = True
+
+        cost = self.get_product_cost(
+            wizard_id.info_field, self.producto_d_id.id)
+        self.assertEqual(cost, 35, 'Recursive cost for D should be keep at 35')
+
+        wizard_id = self.create_wizard(self.producto_e_id)[0]
+        self.assertEqual(wizard_id.recursive, False,
+                         'WizardPrice recursive check should be unchecked'
+                         'by default')
+        cost = self.get_product_cost(
+            wizard_id.info_field, self.producto_e_id.id)
+        self.assertEqual(cost, 40, 'Non-recursive cost for E should be 40')
+
+        res = wizard_id.onchange_recursive(True)['value']
+
+        cost = self.get_product_cost(res['info_field'], self.producto_e_id.id)
+        self.assertEqual(cost, 75, 'Recursive cost for E should be up to 75')

--- a/product_extended_segmentation/view/view.xml
+++ b/product_extended_segmentation/view/view.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
 <openerp>
     <data>
+        <record id="view_compute_price_wizard" model="ir.ui.view">
+            <field name="name">Compute Price as Sum of BoM Components and Routing</field>
+            <field name="model">wizard.price</field>
+            <field name="inherit_id" ref="product_extended.view_compute_price_wizard"/>
+            <field name="arch" type="xml">
+              <xpath expr="//field[@name='recursive']" position="attributes">
+                <attribute name="on_change">onchange_recursive(recursive)</attribute>
+              </xpath>
+            </field>
+        </record>
     </data>
 </openerp>

--- a/product_extended_segmentation/wizard/__init__.py
+++ b/product_extended_segmentation/wizard/__init__.py
@@ -19,3 +19,4 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
+from . import wizard_price

--- a/product_extended_segmentation/wizard/wizard_price.py
+++ b/product_extended_segmentation/wizard/wizard_price.py
@@ -2,7 +2,7 @@
 from openerp import models
 
 
-class WizardPrice(models.TransientModel):
+class WizardPrice(models.Model):
     _inherit = "wizard.price"
 
     def onchange_recursive(self, cr, uid, ids, recursive, context=None):

--- a/product_extended_segmentation/wizard/wizard_price.py
+++ b/product_extended_segmentation/wizard/wizard_price.py
@@ -1,4 +1,5 @@
-from openerp import fields, models
+# -*- coding: utf-8 -*-
+from openerp import models
 
 
 class WizardPrice(models.TransientModel):

--- a/product_extended_segmentation/wizard/wizard_price.py
+++ b/product_extended_segmentation/wizard/wizard_price.py
@@ -12,5 +12,5 @@ class WizardPrice(models.TransientModel):
                           recursive=recursive, real_time_accounting=False,
                           context=context)
 
-        res = str((template_id, sum([res[x] for x in res.keys()])))
+        res = str({template_id: sum([res[x] for x in res.keys()])})
         return {'value': {'info_field': res}}

--- a/product_extended_segmentation/wizard/wizard_price.py
+++ b/product_extended_segmentation/wizard/wizard_price.py
@@ -1,0 +1,16 @@
+from openerp import fields, models
+
+
+class WizardPrice(models.TransientModel):
+    _inherit = "wizard.price"
+
+    def onchange_recursive(self, cr, uid, ids, recursive, context=None):
+        template_id = context.get('active_id')
+        res = self.pool.get('product.template').\
+            compute_price(cr,  uid, product_ids=[],
+                          template_ids=[template_id], test=True,
+                          recursive=recursive, real_time_accounting=False,
+                          context=context)
+
+        res = str((template_id, sum([res[x] for x in res.keys()])))
+        return {'value': {'info_field': res}}


### PR DESCRIPTION
## Change log :
- When using wizard to recompute price for BoM, cost will be fully instantly computed and show right there.

[![X5266FcYvqg](http://img.youtube.com/vi/X5266FcYvqg/0.jpg)](https://www.youtube.com/watch?v=X5266FcYvqg)
## NOTE:
- It should be merge after #646 gets done
## Pending stuff
- [ ] Rebase
