### PR TITLE
[FIX] account_move_line_extended: Replace old reconcile field by the new one reconcile_ref in 8.0

### DIFF
--- a/account_move_line_extended/view/account_move_line_view.xml
+++ b/account_move_line_extended/view/account_move_line_view.xml
@@ -34,7 +34,7 @@
                     <field name="amount_currency"/>
                     <field name="currency_id"/>
                     <field name="date_maturity"/>
-                    <field name="reconcile"/>
+                    <field name="reconcile_ref"/>
                     <field name="state"/>
                     <field name="company_id" invisible="1"/>
                 </tree>
@@ -49,7 +49,7 @@
             <field name="view_id" ref="aml_extended_tree"/>
         </record>
 
-        <menuitem 
+        <menuitem
             id="journal_aml_menu"
             name="Journal Items Extended"
             parent="account.menu_finance_entries"


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after replace the old field `reconcile` by the new one `reconcile_ref` in branch 8.0:

![account_move_line_extended](https://cloud.githubusercontent.com/assets/11741384/12405689/edb999b8-be0b-11e5-9373-e49667bd0e03.png)
