### PR TITLE
[FIX] account_move_line_group_analytic: To fix element cannot be located in parent view.

### DIFF
--- a/account_move_line_group_analytic/account_move_line.xml
+++ b/account_move_line_group_analytic/account_move_line.xml
@@ -6,7 +6,7 @@
             <field name="model">account.move.line</field>
             <field name="inherit_id" ref="account.view_account_move_line_filter"/>
             <field name="arch" type="xml">
-                <xpath expr="//group[@string='Group By...']/filter[@string='Period']" position="after">
+                <xpath expr="//group[@string='Group By']/filter[@string='Period']" position="after">
                     <filter string="Analytic" icon="terp-folder-green" domain="[]" context="{'group_by':'analytic_account_id'}"/>
                     <filter string="Product" icon="terp-accessories-archiver" domain="[]" context="{'group_by':'product_id'}"/>
                     <filter string="Poliza" icon="terp-folder-blue" domain="[]" context="{'group_by':'move_id'}"/>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after replacing `<xpath expr="//group[@string='Group By...']` by the new one `<xpath expr="//group[@string='Group By']` in branch 8.0:

![account_move_line_group_analytic](https://cloud.githubusercontent.com/assets/11741384/12407612/55d60880-be1e-11e5-8152-be3a1578bd62.png)

For references of this change visit: [view_account_move_line_filter v7.0](https://github.com/odoo/odoo/blob/7.0/addons/account/account_view.xml#L1169) and [view_account_move_line_filter v8.0](https://github.com/odoo/odoo/blob/8.0/addons/account/account_view.xml#L1258)
