### PR TITLE
[FIX] account_entries_report_group_by_ref: Change xpath expr to allow locate element in parent view.

### DIFF
--- a/account_entries_report_group_by_ref/account_entries_report_view.xml
+++ b/account_entries_report_group_by_ref/account_entries_report_view.xml
@@ -1,17 +1,17 @@
 <?xml version='1.0' encoding='utf-8'?>
 <openerp>
     <data>
-        
+
         <record id="view_account_entries_report_search_origin_inh" model="ir.ui.view">
             <field name="name">view.account.entries.report.search.origin.inh</field>
             <field name="model">account.entries.report</field>
             <field name="inherit_id" ref="account.view_account_entries_report_search"/>
             <field name="arch" type="xml">
-                <xpath expr="//group[@string='Group By...']/filter[@string='Fiscal Year']" position="after">
+                <xpath expr="//group[@string='Group By']/filter[@string='Company']" position="after">
                    <filter string="Origin" icon="terp-stock_symbol-selection" context="{'group_by':'ref'}"/>
                 </xpath>
             </field>
         </record>
-        
+
     </data>
 </openerp>

--- a/account_entries_report_group_by_ref/account_entries_report_view.xml
+++ b/account_entries_report_group_by_ref/account_entries_report_view.xml
@@ -7,8 +7,8 @@
             <field name="model">account.entries.report</field>
             <field name="inherit_id" ref="account.view_account_entries_report_search"/>
             <field name="arch" type="xml">
-                <xpath expr="//group[@string='Group By']/filter[@string='Company']" position="after">
-                   <filter string="Origin" icon="terp-stock_symbol-selection" context="{'group_by':'ref'}"/>
+                <xpath expr="//group[@string='Group By']/filter[@string='Entries Month']" position="after">
+                   <filter string="Origin" context="{'group_by':'ref'}"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after replacing: 
  - `<xpath expr="//group[@string='Group By...']` by the new one `<xpath expr="//group[@string='Group By']` in branch 8.0.
  - `/filter[@string='Fiscal Year']` by the last filter `/filter[@string='Entries Month']` Because `'Fiscal Year'` no longer exists in that view in branch 8.0.

![account_entries_r_g_b_r](https://cloud.githubusercontent.com/assets/11741384/12413909/c64dc8bc-be57-11e5-91fe-9872ed8a5e70.png)

For references of this change visit: [view_account_entries_report_search v7.0](https://github.com/odoo/odoo/blob/7.0/addons/account/report/account_entries_report_view.xml#L86) [view_account_entries_report_search v8.0](https://github.com/odoo/odoo/blob/8.0/addons/account/report/account_entries_report_view.xml#L91) 
