### PR TITLE
[FIX] account_move_line_group_by_extend: To allow locate element in parent view.

### DIFF
--- a/account_move_line_group_by_extend/account_move_line.xml
+++ b/account_move_line_group_by_extend/account_move_line.xml
@@ -6,7 +6,7 @@
             <field name="model">account.move.line</field>
             <field name="inherit_id" ref="account.view_account_move_line_filter"/>
             <field name="arch" type="xml">
-                <xpath expr="//group[@string='Group By...']/filter[@string='Period']" position="after">
+                <xpath expr="//group[@string='Group By']/filter[@string='Period']" position="after">
                     <filter string="Stock Move" icon="terp-stock" domain="[]" context="{'group_by':'stock_move_id'}"/>
                     <filter string="Production" icon="terp-mrp" domain="[]" context="{'group_by':'production_id'}"/>
                 </xpath>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after replacing `<xpath expr="//group[@string='Group By...']` by the new one `<xpath expr="//group[@string='Group By']` in branch 8.0:

![account_move_line_group_by_extend](https://cloud.githubusercontent.com/assets/11741384/12409926/fd626786-be34-11e5-807c-bed8aeb3b804.png)

For references of this change visit: [view_account_move_line_filter v7.0](https://github.com/odoo/odoo/blob/7.0/addons/account/account_view.xml#L1169) and [view_account_move_line_filter v8.0](https://github.com/odoo/odoo/blob/8.0/addons/account/account_view.xml#L1258)
