### PR TITLE
[FIX] account_reconcile_search: To allow locate element in parent view.

### DIFF
--- a/account_reconcile_search/view/account_reconcile_search.xml
+++ b/account_reconcile_search/view/account_reconcile_search.xml
@@ -7,6 +7,9 @@
             <field name="model">account.move.line</field>
             <field name="inherit_id" ref="account.view_account_move_line_filter"/>
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='partner_id']" position="after">
+                    <field name="reconcile_ref"/>
+                </xpath>
                 <xpath expr="//group[@string='Group By']/filter[@string='Period']" position="after">
                     <filter string="Reconcile" icon="terp-folder-blue" domain="[]" context="{'group_by':'reconcile'}"/>
                 </xpath>

--- a/account_reconcile_search/view/account_reconcile_search.xml
+++ b/account_reconcile_search/view/account_reconcile_search.xml
@@ -7,7 +7,7 @@
             <field name="model">account.move.line</field>
             <field name="inherit_id" ref="account.view_account_move_line_filter"/>
             <field name="arch" type="xml">
-                <xpath expr="//group[@string='Group By...']/filter[@string='Period']" position="after">
+                <xpath expr="//group[@string='Group By']/filter[@string='Period']" position="after">
                     <filter string="Reconcile" icon="terp-folder-blue" domain="[]" context="{'group_by':'reconcile'}"/>
                 </xpath>
             </field>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after replacing `<xpath expr="//group[@string='Group By...']` by the new one `<xpath expr="//group[@string='Group By']` in branch 8.0

![account_reconcile_search](https://cloud.githubusercontent.com/assets/11741384/12410443/e4f13884-be3a-11e5-819e-05d772ebd01a.png)
- [x] Add the field `reconcile_ref` in search options.

For references of this change visit: [view_account_move_line_filter v7.0](https://github.com/odoo/odoo/blob/7.0/addons/account/account_view.xml#L1169) and [view_account_move_line_filter v8.0](https://github.com/odoo/odoo/blob/8.0/addons/account/account_view.xml#L1258)
