### PR TITLE
[FIX] incoterm_delivery_type: To allow locate element in parent view.

### DIFF
--- a/incoterm_delivery_type/view/incoterm_delivery_type_view.xml
+++ b/incoterm_delivery_type/view/incoterm_delivery_type_view.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="stock.stock_incoterms_form"/>
             <field name="arch" type="xml">
 
-                <xpath expr="//form//group" position="inside">
+                <xpath expr="//form//sheet" position="inside">
                     <field name="is_delivery"/>
                 </xpath>
 


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after replacing `<xpath expr="//form//group" position="inside">` by the new one `<xpath expr="//form//sheet" position="inside">` in branch 8.0

![incoterm_delivery_type](https://cloud.githubusercontent.com/assets/11741384/12424135/6145d738-be94-11e5-9259-aa60c063122f.png)

For references of this change visit: [stock_incoterms_form v.8.0](https://github.com/odoo/odoo/blob/8.0/addons/stock/stock_view.xml#L1265) [stock_incoterms_form v.7.0](https://github.com/odoo/odoo/blob/7.0/addons/stock/stock_view.xml#L1540)
