### PR TITLE
[FIX] project_image: To allow locate element in parent view.

### DIFF
--- a/project_image/view/project_image_view.xml
+++ b/project_image/view/project_image_view.xml
@@ -9,31 +9,31 @@
 			<xpath expr='//field[@name="name"]' position="before">
 				<field name="logo" widget="image" class="oe_left oe_avatar"/>
             </xpath>
-            	
+
 		</field>
 	  </record>
-	  
+
 	  <record model="ir.ui.view" id="inherit_project_image_kanban2_view">
 		<field name="inherit_id" ref="project.view_project_kanban"/>
 		<field name="model">project.project</field>
 		<field name="name">project.project.image.kanban</field>
 		<field name="arch" type="xml">
-			<xpath expr='//div[@class="oe_kanban_content"]/h4/field[@name="name"]' position="before">
-				<img t-att-src="kanban_image('project.project', 'logo', record.id.value)" width="24" height="24" class="oe_kanban_avatar"/>				
+            <xpath expr='//div[@class="oe_kanban_content"]/h4/strong/field[@name="name"]' position="before">
+				<img t-att-src="kanban_image('project.project', 'logo', record.id.value)" width="24" height="24" class="oe_kanban_avatar"/>
 			</xpath>
-            	
+
 		</field>
 	  </record>
-	  
+
 	  <record model="ir.ui.view" id="inherit_project_image_kanban_view">
 		<field name="inherit_id" ref="project.view_task_kanban"/>
 		<field name="model">project.task</field>
 		<field name="name">project.task.image.kanban</field>
 		<field name="arch" type="xml">
 			<xpath expr='//div[@class="oe_kanban_content"]/div/b/field[@name="name"]' position="before">
-				<img t-att-src="kanban_image('project.task', 'logo', record.id.value)" width="24" height="24" class="oe_kanban_avatar"/>				
+				<img t-att-src="kanban_image('project.task', 'logo', record.id.value)" width="24" height="24" class="oe_kanban_avatar"/>
 			</xpath>
-            	
+
 		</field>
 	  </record>
 


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after adding the missing label `<strong>`to the xpath expr  `<xpath expr='//div[@class="oe_kanban_content"]/h4/strong/field[@name` in branch 8.0

![project_image](https://cloud.githubusercontent.com/assets/11741384/12431814/2dd9dc04-bebd-11e5-8ee7-c99bd0e9cec1.png)

For references of this change visit: [`project_view.xml` v. 7.0](https://github.com/odoo/odoo/blob/7.0/addons/project/project_view.xml#L247) and [`project_view.xml`  v. 8.0](https://github.com/odoo/odoo/blob/8.0/addons/project/project_view.xml#L270)
