### PR TITLE
[FIX] stock_picking_security_force: Change view to make it compatible for v. 8.0

### DIFF
--- a/stock_picking_security_force/stock_picking_security_force_view.xml
+++ b/stock_picking_security_force/stock_picking_security_force_view.xml
@@ -1,42 +1,20 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <openerp>
     <data>
-        
-        <record model="ir.ui.view" id="view_stock_picking_inherit_button_force_inc_form">
-            <field name="name">view.stock.picking.inherit.button.force.inc.form</field>
-            <field name="model">stock.picking</field>
-            <field name="inherit_id" ref="stock.view_picking_in_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//button[@name='force_assign']" position="replace">
-                    <button name="force_assign" states="confirmed" string="Force Availability" type="object" icon="gtk-jump-to" groups="stock.force_availability"/>
-                </xpath>
-            </field>
-        </record>
-        
-        <record model="ir.ui.view" id="view_stock_picking_inherit_button_force_out_form">
-            <field name="name">view.stock.picking.inherit.button.force.out.form</field>
-            <field name="model">stock.picking</field>
-            <field name="inherit_id" ref="stock.view_picking_out_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//button[@name='force_assign']" position="replace">
-                    <button name="force_assign" states="confirmed" string="Force Availability" type="object" icon="gtk-jump-to" groups="stock.force_availability"/>
-                </xpath>
-            </field>
-        </record>
-        
+
         <record model="ir.ui.view" id="view_stock_picking_inherit_button_force_int_form">
             <field name="name">view.stock.picking.inherit.button.force.int.form</field>
             <field name="model">stock.picking</field>
             <field name="inherit_id" ref="stock.view_picking_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//button[@name='draft_validate']" position="replace">
-                    <button name="draft_validate" states="draft" string="Process Now" type="object" icon="gtk-jump-to" groups="stock.force_availability"/>
+                <xpath expr="//button[@name='action_confirm']" position="replace">
+                    <button name="action_confirm" states="draft" string="Process Now" type="object" groups="stock.force_availability"/>
                 </xpath>
                 <xpath expr="//button[@name='force_assign']" position="replace">
-                    <button name="force_assign" states="confirmed" string="Force Availability" type="object" icon="gtk-jump-to" groups="stock.force_availability"/>
+                    <button name="force_assign" states="confirmed,waiting,partially_available" string="Force Availability" type="object" groups="stock.force_availability"/>
                 </xpath>
             </field>
         </record>
-        
-    </data>    
+
+    </data>
 </openerp>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after changing view to make it compatible for v. 8.0 in `stock_view.xml`:
  - [x] Remove records relating to xml ids that no longer exist in v. 8.0: `view_picking_in_form` and `view_picking_out_form`.
  - [x] Use the buttons in v. 8.0. instead of those used in v. 7.0

![stock_picking_security_force](https://cloud.githubusercontent.com/assets/11741384/12456160/2cb78482-bf64-11e5-8505-1f5a14af6ac3.png)
