### PR TITLE
[FIX] stock_view_product: To find the external id in the system.

### DIFF
--- a/stock_view_product/stock_product.xml
+++ b/stock_view_product/stock_product.xml
@@ -5,7 +5,7 @@
         <record id="view_stock_move_tree_inherit" model="ir.ui.view">
             <field name="name">view.stock.move.tree.inherit</field>
             <field name="model">stock.move</field>
-            <field name="inherit_id" ref="stock.view_move_tree_reception_picking_board"/>
+            <field name="inherit_id" ref="stock.view_move_tree_receipt_picking_board"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='date']" position="after">
                     <field name="date_expected"/>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after changing the view's xml id by the new one in v. 8.0:

![stock_view_product](https://cloud.githubusercontent.com/assets/11741384/12457796/3e917df4-bf6c-11e5-8c08-ab2b956ceab5.png)

For references to his change visit: [`stock_view.xml v. 7.0`](https://github.com/odoo/odoo/blob/7.0/addons/stock/stock_view.xml#L1478) and [`stock_view.xml v. 8.0`](https://github.com/odoo/odoo/blob/8.0/addons/stock/stock_view.xml#L1216)
