### PR TITLE
[FIX] purchase_requisition_type: Change xpath expr to allow locating filters.

### DIFF
--- a/purchase_requisition_type/view/purchase_requisition_view.xml
+++ b/purchase_requisition_type/view/purchase_requisition_view.xml
@@ -38,7 +38,7 @@
                     <field name="type"/>
                 </xpath>
 
-                <xpath expr="//filter[@string='Purchase Done']" position="after">
+                <xpath expr="//filter[@string='Closed Bids']" position="after">
                     <separator/>
                     <filter icon="terp-dialog-close" string="Materials Requisition" domain="[('type','=','materials')]"/>
                     <filter icon="terp-dialog-close" string="Service Requisition" domain="[('type','=','service')]"/>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after replacing `<xpath expr="//filter[@string='Purchase Done']" position="after">` by  `<xpath expr="//filter[@string='Closed Bids']" position="after">` because that filter in v. 7.0 no longer exist in v. 8.0:

![purchase_requisition_type](https://cloud.githubusercontent.com/assets/11741384/12472133/957cda60-bfca-11e5-9711-250d804ade06.png)

References of this change: [view_purchase_requisition_filter v.8.0](https://github.com/odoo/odoo/blob/8.0/addons/purchase_requisition/purchase_requisition_view.xml#L150) and [view_purchase_requisition_filter v.8.0](https://github.com/odoo/odoo/blob/7.0/addons/purchase_requisition/purchase_requisition_view.xml#L128)
