### PR TITLE
[WIP][FIX] purchase_test_data_imp: Fix import error and avoid warnings like LocalService() deprecated.

### DIFF
--- a/purchase_test_data_imp/test/purchase_order_product_can_be_purchased.yml
+++ b/purchase_test_data_imp/test/purchase_order_product_can_be_purchased.yml
@@ -4,8 +4,8 @@
     Create purchase order, picking in and invoice by product
 -
   !python {model: purchase.order}: |
-    import tools
-    import netsvc
+    from openerp import tools
+    from openerp import netsvc
     import os
     import tempfile
     import csv
@@ -82,7 +82,7 @@
             #~ Click button Confirm
             if purchase_order_id:
                 try:
-                    wf_service = netsvc.LocalService("workflow")
+                    wf_service = netsvc.openerp.workflow
                     wf_service.trg_validate(uid, 'purchase.order', purchase_order_id , 'purchase_confirm', cr)
                 except Exception, e:
                     fcsv_csv_Log.writerow({'error' : tools.ustr(e).replace('\n', ''), 'localization': 'Confirm purchase', 'product_id' : repr(product_id)})
@@ -114,7 +114,7 @@
                     cost_invoice = account_invoice_obj.browse(cr, uid, invoice_id.get('res_id'), context=context).amount_total or 0
                     account_invoice_obj.write(cr, uid, [invoice_id.get('res_id')], {'check_total' : cost_invoice}, context=context)
                 try:
-                    wf_service = netsvc.LocalService("workflow")
+                    wf_service = netsvc.openerp.workflow
                     wf_service.trg_validate(uid, 'account.invoice', invoice_id.get('res_id') , 'invoice_open', cr)
                 except Exception, e:
                     fcsv_csv_Log.writerow({'error' : tools.ustr(e).replace('\n', ''), 'localization': 'Validate Invoice',  'product_id' : repr(product_id)})

--- a/purchase_test_data_imp/test/purchase_order_test_data.xml
+++ b/purchase_test_data_imp/test/purchase_order_test_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data noupdate="0">
-        
+
         <record id="res_partner_purchase_test" model="res.partner">
             <field name="name">PURCHASE TEST</field>
             <field name="supplier">1</field>
@@ -9,22 +9,22 @@
             <field name="is_company">1</field>
             <field name="type">default</field>
         </record>
-        
+
         <record id="account_payment_term_purchase_test_data_imp" model="account.payment.term">
             <field name="name">30 Days End of Month</field>
             <field name="note">30 Days End of Month</field>
         </record>
-        
+
         <record id="price_list_type_test_purchase_order_imp" model="product.pricelist.type">
             <field name="name">Purchase Pricelist (Test)</field>
             <field name="key">purchase</field>
         </record>
-        
+
         <record id="list_price0_test_purchase_order_imp" model="product.price.type">
             <field name="name">Public Price (test)</field>
             <field name="field">list_price</field>
         </record>
-        
+
         <record id="list_test_purchase_order_imp" model="product.pricelist">
             <field name="name">Public Pricelist (Test)</field>
             <field name="type">purchase</field>
@@ -46,27 +46,26 @@
             <field name="fields_id" search="[('model','=','res.partner'),('name','=','property_product_pricelist')]"/>
             <field eval="'product.pricelist,'+str(ref('list_test_purchase_order_imp'))" name="value"/>
         </record>
-        
+
 <!--
     Stock location
 -->
         <record id="stock_location_locations_purchase_test_data" model="stock.location">
             <field name="name">Physical Locations (PURCHASE TEST DATA)</field>
             <field name="usage">view</field>
-            <field name="icon">terp-stock</field>
             <field name="company_id"></field>
         </record>
-        
+
         <record id="stock_location_company_purchase_test_data" model="stock.location">
             <field name="name" model="res.company" search="[]" use="name"/>
             <field name="usage">view</field>
             <field name="location_id" ref="stock_location_locations_purchase_test_data"/>
         </record>
-        
+
         <record id="stock_location_stock_purchase_test_data" model="stock.location">
             <field name="name">Stock (PURCHASE TEST DATA)</field>
             <field name="location_id" ref="stock_location_company_purchase_test_data"/>
         </record>
-        
+
     </data>
 </openerp>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after replacing `import tools` by `from openerp import tools` for example.

![purchase_test_data_imp](https://cloud.githubusercontent.com/assets/11741384/12497374/083e9322-c061-11e5-9c72-fd094b5022e9.png)
- [x] Follow the next recomendation `For workflows, instead of using
  LocalService('workflow'), openerp.workflow should be used` to avoid warning `LocalService() is deprecated since march 2013`.
- [x] Remove unknown field icon to avoid warning.
- [ ] After testing with a copy of `openerp_template` db has an error when start the tests, however with -i and --test-enable in a new db this module is successfully installed. 
