### PR TITLE
[FIX] sale_double_validation: Fixes to make it installable for 8.0 v.

### DIFF
--- a/sale_double_validation/view/sale_double_validation_installer.xml
+++ b/sale_double_validation/view/sale_double_validation_installer.xml
@@ -36,7 +36,6 @@
         <record id="sale_approval_group_installer" model="ir.actions.todo">
             <field name="action_id" ref="action_config_sale_approval_group"/>
             <field name="sequence">9</field>
-            <field name="restart">always</field>
             <field eval="[(6,0,[ref('base.group_no_one')])]" name="groups_id"/>
         </record>
 

--- a/sale_double_validation/view/sale_double_validation_installer.xml
+++ b/sale_double_validation/view/sale_double_validation_installer.xml
@@ -9,7 +9,7 @@
             <field name="inherit_id" ref="base.res_config_installer"/>
             <field name="arch" type="xml">
               <data>
-                <form position="attributes" version="7.0">
+                <form position="attributes">
                   <attribute name="string">Sale Application Configuration</attribute>
                 </form>
                 <separator string="title" position="attributes">
@@ -39,6 +39,6 @@
             <field name="restart">always</field>
             <field eval="[(6,0,[ref('base.group_no_one')])]" name="groups_id"/>
         </record>
-        
+
     </data>
 </openerp>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after doing the following fixes:
  - [x] Remove  `version` in `<form>` because it is not used in version 8.0.
  - [x] Remove field `restart` to avoid warning `Unknown fields restart`

![sale_double_validation](https://cloud.githubusercontent.com/assets/11741384/12500144/0d4253e4-c076-11e5-86b9-7202583b80ad.png)
##### This PR is rebased, but If another change was previously merged in addons-vauxoo, ask for a rebase to avoid conflicts please :')
