### PR TITLE
[FIX] sale_uncommitted_product: Fixes to make it installable for 8.0 v.

### DIFF
--- a/sale_uncommitted_product/view/sale_double_validation_installer.xml
+++ b/sale_uncommitted_product/view/sale_double_validation_installer.xml
@@ -9,7 +9,7 @@
             <field name="inherit_id" ref="base.res_config_installer"/>
             <field name="arch" type="xml">
               <data>
-                <form position="attributes" version="7.0">
+                <form position="attributes">
                   <attribute name="string">Sale Application Configuration</attribute>
                 </form>
                 <xpath expr='//button[@name="action_next"]' position="before">
@@ -40,6 +40,6 @@
             <field name="restart">always</field>
             <field eval="[(6,0,[ref('base.group_no_one')])]" name="groups_id"/>
         </record>
-        
+
     </data>
 </openerp>

--- a/sale_uncommitted_product/view/sale_double_validation_installer.xml
+++ b/sale_uncommitted_product/view/sale_double_validation_installer.xml
@@ -37,7 +37,6 @@
         <record id="sale_approval_group_installer" model="ir.actions.todo">
             <field name="action_id" ref="action_config_sale_approval_group"/>
             <field name="sequence">1</field>
-            <field name="restart">always</field>
             <field eval="[(6,0,[ref('base.group_no_one')])]" name="groups_id"/>
         </record>
 


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after doing the following fixes:
  - [x] Remove  `version` in `<form>` because it is not used in version 8.0.
  - [x] Remove field `restart` to avoid warning `Unknown fields restart`
  - [x] Rebased.

![sale_uncommitted_product](https://cloud.githubusercontent.com/assets/11741384/12500804/1b852a20-c07c-11e5-92eb-175bc4478f06.png)
##### This PR is rebased, but If another change was previously merged in addons-vauxoo, ask for a rebase to avoid conflicts please :')
