### PR TITLE
[8.0] Add demo and unit test for stock_card_segmentation

### DIFF
--- a/product_extended_segmentation/view/view.xml
+++ b/product_extended_segmentation/view/view.xml
@@ -9,10 +9,6 @@
                 <xpath expr="//field[@name='recursive']" position="attributes">
                     <attribute name="on_change">onchange_recursive(recursive)</attribute>
                 </xpath>
-                <xpath expr="//field[@name='recursive']" position="after">
-                    <field name="update_avg_costs"
-                        attrs="{'invisible':[('recursive','=',False)]}"/>
-                </xpath>
             </field>
         </record>
     </data>

--- a/product_extended_variants/model/template.py
+++ b/product_extended_variants/model/template.py
@@ -32,10 +32,13 @@ class ProductTemplate(models.Model):
             .get_product_accounts(cr, uid, product_id,
                                   context=context)
         product_brw = self.browse(cr, uid, product_id)
-        diff_acc_id = product_brw.property_account_creditor_price_difference and \
+        diff_acc_id = product_brw.\
+            property_account_creditor_price_difference and \
             product_brw.property_account_creditor_price_difference.id or \
-            product_brw.categ_id.property_account_creditor_price_difference_categ and \
-            product_brw.categ_id.property_account_creditor_price_difference_categ.id or \
+            product_brw.categ_id.\
+            property_account_creditor_price_difference_categ and \
+            product_brw.categ_id.\
+            property_account_creditor_price_difference_categ.id or \
             False
 
         res.update({'property_difference_price_account_id': diff_acc_id})

--- a/product_extended_variants/wizard/wizard_price.py
+++ b/product_extended_variants/wizard/wizard_price.py
@@ -76,7 +76,7 @@ class WizardPrice(models.Model):
             try:
                 self.compute_from_bom(cr, uid, [price_id], context=context)
                 new = product_obj.browse(cr, uid, product).standard_price,
-            except Exception as msg:
+            except Exception as msg:  # pylint: disable=W0703
                 new = msg
 
             context['message'] = message.format(old=old, new=new)

--- a/product_extended_variants/wizard/wizard_price.py
+++ b/product_extended_variants/wizard/wizard_price.py
@@ -69,7 +69,7 @@ class WizardPrice(models.Model):
         message = 'Old price {old}, New price {new}'
         context['message'] = ''
         for product in product_ids:
-            _logger.debug('Computing cost for product.....  %s', str(product))
+            _logger.info('Computing cost for product.....  %s', str(product))
             context.update({'active_model': 'product.product',
                             'active_id': product})
             price_id = self.create(cr, uid,

--- a/product_extended_variants/wizard/wizard_price.py
+++ b/product_extended_variants/wizard/wizard_price.py
@@ -36,13 +36,13 @@ class WizardPrice(models.Model):
     def _get_products(self, cr, uid, ids=None, context=None):
         '''
         Return all products which represent top parent in bom
-        [x]       [y]
-         | \       |
-         |  \      |
-        [a] [b]   [c]
-         | \
-         |  \
-        [t] [u]
+        [x]---+   [y]
+         |    |    |
+         |    |    |
+        [a]  [b]  [c]
+         |    |
+         |    |
+        [t]  [u]
         That is x and y
         '''
         cr.execute('''

--- a/product_extended_variants/wizard/wizard_price.py
+++ b/product_extended_variants/wizard/wizard_price.py
@@ -38,7 +38,7 @@ class WizardPrice(models.Model):
         context = context or {}
         product_obj = self.pool.get('product.product')
         product_ids = product_obj.search(cr, uid, [('bom_ids', '!=', False)])
-        message = _('Old price {old}, New price {new}')
+        message = 'Old price {old}, New price {new}'
         context['message'] = ''
         for product in product_ids:
             context.update({'active_model': 'product.product',

--- a/product_extended_variants/wizard/wizard_price.py
+++ b/product_extended_variants/wizard/wizard_price.py
@@ -68,18 +68,25 @@ class WizardPrice(models.Model):
         product_ids = self._get_products(cr, uid, ids, context=context)
         message = 'Old price {old}, New price {new}'
         context['message'] = ''
+        count = 0
+        total = len(product_ids)
+        _logger.info(
+            'Cron Job will compute {length} products'.format(length=total))
+        msglog = 'Computing cost for product: [{prod_id}]. {count}/{total}'
         for product in product_ids:
-            _logger.info('Computing cost for product.....  %s', str(product))
+            count += 1
+            _logger.info(
+                msglog.format(prod_id=product, total=total, count=count))
             context.update({'active_model': 'product.product',
                             'active_id': product})
             price_id = self.create(cr, uid,
                                    {'real_time_accounting': True,
                                     'recursive': True},
                                    context=context)
-            old = product_obj.browse(cr, uid, product).standard_price,
+            old = product_obj.browse(cr, uid, product).standard_price
             try:
                 self.compute_from_bom(cr, uid, [price_id], context=context)
-                new = product_obj.browse(cr, uid, product).standard_price,
+                new = product_obj.browse(cr, uid, product).standard_price
             except Exception as msg:  # pylint: disable=W0703
                 new = msg
 

--- a/product_extended_variants/wizard/wizard_price.py
+++ b/product_extended_variants/wizard/wizard_price.py
@@ -22,6 +22,9 @@
 ##############################################################################
 
 from openerp import models,  _
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 class WizardPrice(models.Model):
@@ -66,6 +69,7 @@ class WizardPrice(models.Model):
         message = 'Old price {old}, New price {new}'
         context['message'] = ''
         for product in product_ids:
+            _logger.debug('Computing cost for product.....  %s', str(product))
             context.update({'active_model': 'product.product',
                             'active_id': product})
             price_id = self.create(cr, uid,

--- a/stock_card/model/__init__.py
+++ b/stock_card/model/__init__.py
@@ -1,2 +1,3 @@
 # coding: utf-8
+from . import product
 from . import stock_card

--- a/stock_card/model/product.py
+++ b/stock_card/model/product.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from openerp import models, api, _
+from openerp import models, api
 
 
 class ProductProduct(models.Model):

--- a/stock_card/model/product.py
+++ b/stock_card/model/product.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, api, _
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.multi
+    def stock_card_move_get(self):
+        self.ensure_one()
+        scp_obj = self.env['stock.card.product']
+        scp_brw = scp_obj.create({'product_id': self._ids})
+        return scp_brw.stock_card_move_get()

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 
-from openerp import models, fields, api
+from openerp import models, fields, api, _
 import openerp.addons.decimal_precision as dp
+from openerp.exceptions import Warning as UserError
 
 
 class StockCard(models.TransientModel):
@@ -45,8 +46,7 @@ class StockCardProduct(models.TransientModel):
             return True
         self.stock_card_move_ids.unlink()
         self._stock_card_move_get(self.product_id.id)
-
-        return True
+        return self.action_view_moves()
 
     def _get_quant_values(self, move_id, col='', inner='', where=''):
         self._cr.execute(
@@ -355,7 +355,8 @@ class StockCardProduct(models.TransientModel):
                 [str(scm_id) for scm_id in scm_ids]
             ) + "])]"
         else:
-            action['domain'] = "[('id','in',[])]"
+            raise UserError(
+                _('Asked Product has not Moves to show'))
         return action
 
     def _stock_card_move_history_get(self, product_id):

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -306,6 +306,7 @@ class StockCardProduct(models.TransientModel):
         for row in vals['move_ids']:
             res.append(vals['lines'][row['move_id']])
         vals['res'] = res
+        import pdb; pdb.set_trace()
 
         if return_values:
             return vals

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from openerp import models, fields, api, _
+from openerp import models, fields, api
 import openerp.addons.decimal_precision as dp
 from openerp.exceptions import Warning as UserError
 

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from openerp import models, fields, api
+from openerp import models, fields, api, _
 import openerp.addons.decimal_precision as dp
 from openerp.exceptions import Warning as UserError
 

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -145,8 +145,8 @@ class StockCardProduct(models.TransientModel):
         # NOTE: Falling back to average in case customer return is
         # orphan, i.e., return was created from scratch
         old_average = (
-            vals['move_dict'].get(origin_id, 0.0) and
-            vals['move_dict'][move_id]['average'] or vals['average'])
+            vals['move_dict'].get(origin_id) and
+            vals['move_dict'][origin_id]['average'] or vals['average'])
         vals['move_valuation'] = sum(
             [old_average * qnt['qty'] for qnt in qntval])
         return True

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -306,7 +306,6 @@ class StockCardProduct(models.TransientModel):
         for row in vals['move_ids']:
             res.append(vals['lines'][row['move_id']])
         vals['res'] = res
-        import pdb; pdb.set_trace()
 
         if return_values:
             return vals

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -11,6 +11,7 @@ class StockCard(models.TransientModel):
 
 class StockCardProduct(models.TransientModel):
     _name = 'stock.card.product'
+    _rec_name = 'product_id'
     product_id = fields.Many2one('product.product', string='Product')
     stock_card_move_ids = fields.One2many(
         'stock.card.move', 'stock_card_product_id', 'Product Moves')

--- a/stock_card/view/view.xml
+++ b/stock_card/view/view.xml
@@ -8,8 +8,10 @@
                 <form string="Stock Card Product">
                     <sheet string="Stock Card Product">
                         <h1>
-                            <label string="Product"/>
-                            <field name="product_id" required="1" class="oe_inline"/>
+                            <label for="product_id"/>
+                        </h1>
+                        <h1>
+                            <field name="product_id" required="1"/>
                         </h1>
                         <footer>
                             <button

--- a/stock_card/view/view.xml
+++ b/stock_card/view/view.xml
@@ -71,5 +71,24 @@
             action="stock_card_product_action"
             name="Generate Stock Card"
             parent="menu_stock_card_main"/>
+
+        <record id="product_stock_card_form_view" model="ir.ui.view">
+            <field name="name">product.product.stock.card.form</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_normal_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@name='buttons']" position="inside">
+                    <button
+                        class="oe_inline oe_stat_button"
+                        name="stock_card_move_get"
+                        type="object"
+                        attrs="{'invisible':[('type', '=', 'service')]}"
+                        groups="stock.group_locations"
+                        icon="fa-history">
+                        <div>Stock Card</div>
+                    </button>
+                </xpath>
+            </field>
+        </record>
     </data>
 </openerp>

--- a/stock_card/view/view.xml
+++ b/stock_card/view/view.xml
@@ -6,34 +6,30 @@
             <field name="model">stock.card.product</field>
             <field name="arch" type="xml">
                 <form string="Stock Card Product">
-                    <header>
-                        <button
-                            name="stock_card_move_get"
-                            type="object"
-                            string="Get Moves"/>
-                        <button
-                            name="action_view_moves"
-                            type="object"
-                            string="Show Moves"/>
-                    </header>
                     <sheet string="Stock Card Product">
                         <h1>
                             <label string="Product"/>
-                            <field name="product_id" readonly="0" class="oe_inline"/>
+                            <field name="product_id" required="1" class="oe_inline"/>
                         </h1>
+                        <footer>
+                            <button
+                                name="stock_card_move_get"
+                                type="object"
+                                class="oe_highlight"
+                                string="Show Moves"/>
+                        </footer>
                     </sheet>
                 </form>
             </field>
         </record>
 
         <record id="stock_card_product_action" model="ir.actions.act_window">
-            <field name="name">Stock Card Wizard</field>
+            <field name="name">Stock Card Generate</field>
             <field name="res_model">stock.card.product</field>
             <field name="view_type">form</field>
             <field name="view_mode">form</field>
-            <field eval="False" name="view_id"/>
-            <field name="domain"></field>
-            <field name="context">[]</field>
+            <field name="domain">[]</field>
+            <field name="context">{}</field>
             <field name="target">inline</field>
         </record>
 
@@ -59,9 +55,8 @@
             <field name="res_model">stock.card.move</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree</field>
-            <field eval="False" name="view_id"/>
-            <field name="domain"></field>
-            <field name="context">[]</field>
+            <field name="domain">[]</field>
+            <field name="context">{}</field>
         </record>
 
         <menuitem

--- a/stock_card/view/view.xml
+++ b/stock_card/view/view.xml
@@ -72,7 +72,7 @@
         <menuitem
             id="menu_stock_card_wizard"
             action="stock_card_product_action"
-            name="Stock Card Wizard"
+            name="Generate Stock Card"
             parent="menu_stock_card_main"/>
     </data>
 </openerp>

--- a/stock_card/view/view.xml
+++ b/stock_card/view/view.xml
@@ -56,7 +56,7 @@
             <field name="name">Stock Card Move</field>
             <field name="res_model">stock.card.move</field>
             <field name="view_type">form</field>
-            <field name="view_mode">tree</field>
+            <field name="view_mode">tree,form</field>
             <field name="domain">[]</field>
             <field name="context">{}</field>
         </record>

--- a/stock_card_segmentation/demo/demo.xml
+++ b/stock_card_segmentation/demo/demo.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data noupdate="0">
-        <record id="product_01" model="product.product">
-            <field name="name">AVG Software Package</field>
-            <field name="cost_method">average</field>
-            <field name="valuation">real_time</field>
-            <field name="type">product</field>
-            <field name="weight">1</field>
-            <field name="volume">1</field>
-            <field name="property_stock_account_input" ref="account.o_expense"/>
-            <field name="property_stock_account_output" ref="account.o_income"/>
-        </record>
         <record id="po_01" model="purchase.order">
             <field name="name">po_01</field>
             <field name="partner_id" ref="base.res_partner_23"/>
@@ -20,7 +10,7 @@
         <record id="po_01_line_01" model="purchase.order.line">
             <field name="name">po_01_line_01</field>
             <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_qty">2</field>
             <field name="price_unit">20</field>
             <field name="order_id" ref="po_01"/>
@@ -47,7 +37,7 @@
         <record id="po_02_line_01" model="purchase.order.line">
             <field name="name">po_02_line_01</field>
             <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_qty">3</field>
             <field name="price_unit">40</field>
             <field name="order_id" ref="po_02"/>
@@ -77,7 +67,7 @@
         <record id="so_01_line_01" model="sale.order.line">
             <field name="name">so_01_line_01</field>
             <field name="order_id" ref="so_01"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_uom_qty">1</field>
             <field name="price_unit">32.0</field>
         </record>
@@ -103,7 +93,7 @@
         <record id="po_03_line_01" model="purchase.order.line">
             <field name="name">po_03_line_01</field>
             <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_qty">4</field>
             <field name="price_unit">88</field>
             <field name="order_id" ref="po_03"/>
@@ -131,15 +121,12 @@
         <record id="so_02_line_01" model="sale.order.line">
             <field name="name">so_02_line_01</field>
             <field name="order_id" ref="so_02"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_uom_qty">7</field>
             <field name="price_unit">60.0</field>
         </record>
         <workflow action="order_confirm" model="sale.order" ref="so_02"/>
         <workflow action="manual_invoice" model="sale.order" ref="so_02" uid="base.user_root"/>
-        <workflow action="invoice_open" model="account.invoice">
-            <value eval="obj(ref('so_02')).invoice_ids[0].id" model="sale.order"/>
-        </workflow>
         <function model="stock.picking" name="action_assign">
             <value eval="[obj(ref('so_02')).picking_ids[0].id]" model="sale.order"/>
         </function>
@@ -161,15 +148,12 @@
         <record id="so_03_line_01" model="sale.order.line">
             <field name="name">so_03_line_01</field>
             <field name="order_id" ref="so_03"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_uom_qty">2</field>
             <field name="price_unit">62.0</field>
         </record>
         <workflow action="order_confirm" model="sale.order" ref="so_03"/>
         <workflow action="manual_invoice" model="sale.order" ref="so_03" uid="base.user_root"/>
-        <workflow action="invoice_open" model="account.invoice">
-            <value eval="obj(ref('so_03')).invoice_ids[0].id" model="sale.order"/>
-        </workflow>
         <function model="stock.picking" name="action_assign">
             <value eval="[obj(ref('so_03')).picking_ids[0].id]" model="sale.order"/>
         </function>
@@ -190,7 +174,7 @@
         <record id="po_04_line_01" model="purchase.order.line">
             <field name="name">po_04_line_01</field>
             <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_qty">4</field>
             <field name="price_unit">64</field>
             <field name="order_id" ref="po_04"/>
@@ -206,7 +190,7 @@
         <record model="stock.transfer_details" id="td_07">
             <field name="picking_id" model="purchase.order" eval="obj(ref('po_04')).picking_ids[0].id"/>
         </record>
-        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_07')]]"/>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_07')]]" context="{'force_unlink': True}"/>
 
         <record id="so_04" model="sale.order">
             <field name="name">so_04</field>
@@ -218,15 +202,12 @@
         <record id="so_04_line_01" model="sale.order.line">
             <field name="name">so_04_line_01</field>
             <field name="order_id" ref="so_04"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_uom_qty">6</field>
             <field name="price_unit">51.0</field>
         </record>
         <workflow action="order_confirm" model="sale.order" ref="so_04"/>
         <workflow action="manual_invoice" model="sale.order" ref="so_04" uid="base.user_root"/>
-        <workflow action="invoice_open" model="account.invoice">
-            <value eval="obj(ref('so_04')).invoice_ids[0].id" model="sale.order"/>
-        </workflow>
         <function model="stock.picking" name="action_assign">
             <value eval="[obj(ref('so_04')).picking_ids[0].id]" model="sale.order"/>
         </function>
@@ -248,15 +229,12 @@
         <record id="so_05_line_01" model="sale.order.line">
             <field name="name">so_05_line_01</field>
             <field name="order_id" ref="so_05"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_uom_qty">2</field>
             <field name="price_unit">38.0</field>
         </record>
         <workflow action="order_confirm" model="sale.order" ref="so_05"/>
         <workflow action="manual_invoice" model="sale.order" ref="so_05" uid="base.user_root"/>
-        <workflow action="invoice_open" model="account.invoice">
-            <value eval="obj(ref('so_05')).invoice_ids[0].id" model="sale.order"/>
-        </workflow>
         <function model="stock.picking" name="action_assign">
             <value eval="[obj(ref('so_05')).picking_ids[0].id]" model="sale.order"/>
         </function>
@@ -277,7 +255,7 @@
         <record id="po_05_line_01" model="purchase.order.line">
             <field name="name">po_05_line_01</field>
             <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_qty">2</field>
             <field name="price_unit">48</field>
             <field name="order_id" ref="po_05"/>
@@ -304,7 +282,7 @@
         <record id="po_06_line_01" model="purchase.order.line">
             <field name="name">po_06_line_01</field>
             <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_qty">2</field>
             <field name="price_unit">56</field>
             <field name="order_id" ref="po_06"/>
@@ -331,7 +309,7 @@
         <record id="po_07_line_01" model="purchase.order.line">
             <field name="name">po_07_line_01</field>
             <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
-            <field name="product_id" ref="product_01"/>
+            <field name="product_id" ref="stock_card.product01"/>
             <field name="product_qty">4</field>
             <field name="price_unit">24</field>
             <field name="order_id" ref="po_07"/>
@@ -347,6 +325,6 @@
         <record model="stock.transfer_details" id="td_12">
             <field name="picking_id" model="purchase.order" eval="obj(ref('po_07')).picking_ids[0].id"/>
         </record>
-        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_12')]]"/>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_12')]]" context="{'force_unlink': True}"/>
     </data>
 </openerp>

--- a/stock_card_segmentation/demo/demo.xml
+++ b/stock_card_segmentation/demo/demo.xml
@@ -1,5 +1,352 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data noupdate="0">
+        <record id="product_01" model="product.product">
+            <field name="name">AVG Software Package</field>
+            <field name="cost_method">average</field>
+            <field name="valuation">real_time</field>
+            <field name="type">product</field>
+            <field name="weight">1</field>
+            <field name="volume">1</field>
+            <field name="property_stock_account_input" ref="account.o_expense"/>
+            <field name="property_stock_account_output" ref="account.o_income"/>
+        </record>
+        <record id="po_01" model="purchase.order">
+            <field name="name">po_01</field>
+            <field name="partner_id" ref="base.res_partner_23"/>
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="pricelist_id" ref="purchase.list0"/>
+        </record>
+        <record id="po_01_line_01" model="purchase.order.line">
+            <field name="name">po_01_line_01</field>
+            <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_qty">2</field>
+            <field name="price_unit">20</field>
+            <field name="order_id" ref="po_01"/>
+        </record>
+        <workflow action="purchase_confirm" model="purchase.order" ref="po_01"/>
+        <workflow action="purchase_approve" model="purchase.order" ref="po_01"/>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('po_01')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('po_01')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_01">
+            <field name="picking_id" model="purchase.order" eval="obj(ref('po_01')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_01')]]"/>
+
+        <record id="po_02" model="purchase.order">
+            <field name="name">po_02</field>
+            <field name="partner_id" ref="base.res_partner_23"/>
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="pricelist_id" ref="purchase.list0"/>
+        </record>
+        <record id="po_02_line_01" model="purchase.order.line">
+            <field name="name">po_02_line_01</field>
+            <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_qty">3</field>
+            <field name="price_unit">40</field>
+            <field name="order_id" ref="po_02"/>
+        </record>
+        <workflow action="purchase_confirm" model="purchase.order" ref="po_02"/>
+        <workflow action="purchase_approve" model="purchase.order" ref="po_02"/>
+
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('po_02')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('po_02')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_02">
+            <field name="picking_id" model="purchase.order" eval="obj(ref('po_02')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_02')]]"/>
+
+        <record id="so_01" model="sale.order">
+            <field name="name">so_01</field>
+            <field name="date_order" eval="datetime.now().strftime('%Y-%m-%d')" />
+            <field name="partner_id" ref="base.res_partner_12"/>
+            <field name="currency_id" ref="base.EUR"/>
+            <field name="pricelist_id" ref="product.list0"/>
+            <field name="order_policy">picking</field>
+        </record>
+        <record id="so_01_line_01" model="sale.order.line">
+            <field name="name">so_01_line_01</field>
+            <field name="order_id" ref="so_01"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_uom_qty">1</field>
+            <field name="price_unit">32.0</field>
+        </record>
+        <workflow action="order_confirm" model="sale.order" ref="so_01"/>
+        <workflow action="manual_invoice" model="sale.order" ref="so_01" uid="base.user_root"/>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('so_01')).picking_ids[0].id]" model="sale.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('so_01')).picking_ids[0].id]" model="sale.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_03">
+            <field name="picking_id" model="sale.order" eval="obj(ref('so_01')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_03')]]"/>
+
+        <record id="po_03" model="purchase.order">
+            <field name="name">po_03</field>
+            <field name="partner_id" ref="base.res_partner_23"/>
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="pricelist_id" ref="purchase.list0"/>
+        </record>
+        <record id="po_03_line_01" model="purchase.order.line">
+            <field name="name">po_03_line_01</field>
+            <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_qty">4</field>
+            <field name="price_unit">88</field>
+            <field name="order_id" ref="po_03"/>
+        </record>
+        <workflow action="purchase_confirm" model="purchase.order" ref="po_03"/>
+        <workflow action="purchase_approve" model="purchase.order" ref="po_03"/>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('po_03')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('po_03')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_04">
+            <field name="picking_id" model="purchase.order" eval="obj(ref('po_03')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_04')]]"/>
+
+        <record id="so_02" model="sale.order">
+            <field name="name">so_02</field>
+            <field name="date_order" eval="datetime.now().strftime('%Y-%m-%d')" />
+            <field name="partner_id" ref="base.res_partner_12"/>
+            <field name="currency_id" ref="base.EUR"/>
+            <field name="pricelist_id" ref="product.list0"/>
+        </record>
+        <record id="so_02_line_01" model="sale.order.line">
+            <field name="name">so_02_line_01</field>
+            <field name="order_id" ref="so_02"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_uom_qty">7</field>
+            <field name="price_unit">60.0</field>
+        </record>
+        <workflow action="order_confirm" model="sale.order" ref="so_02"/>
+        <workflow action="manual_invoice" model="sale.order" ref="so_02" uid="base.user_root"/>
+        <workflow action="invoice_open" model="account.invoice">
+            <value eval="obj(ref('so_02')).invoice_ids[0].id" model="sale.order"/>
+        </workflow>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('so_02')).picking_ids[0].id]" model="sale.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('so_02')).picking_ids[0].id]" model="sale.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_05">
+            <field name="picking_id" model="sale.order" eval="obj(ref('so_02')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_05')]]"/>
+
+        <record id="so_03" model="sale.order">
+            <field name="name">so_03</field>
+            <field name="date_order" eval="datetime.now().strftime('%Y-%m-%d')" />
+            <field name="partner_id" ref="base.res_partner_12"/>
+            <field name="currency_id" ref="base.EUR"/>
+            <field name="pricelist_id" ref="product.list0"/>
+        </record>
+        <record id="so_03_line_01" model="sale.order.line">
+            <field name="name">so_03_line_01</field>
+            <field name="order_id" ref="so_03"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_uom_qty">2</field>
+            <field name="price_unit">62.0</field>
+        </record>
+        <workflow action="order_confirm" model="sale.order" ref="so_03"/>
+        <workflow action="manual_invoice" model="sale.order" ref="so_03" uid="base.user_root"/>
+        <workflow action="invoice_open" model="account.invoice">
+            <value eval="obj(ref('so_03')).invoice_ids[0].id" model="sale.order"/>
+        </workflow>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('so_03')).picking_ids[0].id]" model="sale.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('so_03')).picking_ids[0].id]" model="sale.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_06">
+            <field name="picking_id" model="sale.order" eval="obj(ref('so_03')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_06')]]"/>
+
+        <record id="po_04" model="purchase.order">
+            <field name="name">po_04</field>
+            <field name="partner_id" ref="base.res_partner_23"/>
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="pricelist_id" ref="purchase.list0"/>
+        </record>
+        <record id="po_04_line_01" model="purchase.order.line">
+            <field name="name">po_04_line_01</field>
+            <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_qty">4</field>
+            <field name="price_unit">64</field>
+            <field name="order_id" ref="po_04"/>
+        </record>
+        <workflow action="purchase_confirm" model="purchase.order" ref="po_04"/>
+        <workflow action="purchase_approve" model="purchase.order" ref="po_04"/>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('po_04')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('po_04')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_07">
+            <field name="picking_id" model="purchase.order" eval="obj(ref('po_04')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_07')]]"/>
+
+        <record id="so_04" model="sale.order">
+            <field name="name">so_04</field>
+            <field name="date_order" eval="datetime.now().strftime('%Y-%m-%d')" />
+            <field name="partner_id" ref="base.res_partner_12"/>
+            <field name="currency_id" ref="base.EUR"/>
+            <field name="pricelist_id" ref="product.list0"/>
+        </record>
+        <record id="so_04_line_01" model="sale.order.line">
+            <field name="name">so_04_line_01</field>
+            <field name="order_id" ref="so_04"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_uom_qty">6</field>
+            <field name="price_unit">51.0</field>
+        </record>
+        <workflow action="order_confirm" model="sale.order" ref="so_04"/>
+        <workflow action="manual_invoice" model="sale.order" ref="so_04" uid="base.user_root"/>
+        <workflow action="invoice_open" model="account.invoice">
+            <value eval="obj(ref('so_04')).invoice_ids[0].id" model="sale.order"/>
+        </workflow>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('so_04')).picking_ids[0].id]" model="sale.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('so_04')).picking_ids[0].id]" model="sale.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_08">
+            <field name="picking_id" model="sale.order" eval="obj(ref('so_04')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_08')]]"/>
+
+        <record id="so_05" model="sale.order">
+            <field name="name">so_05</field>
+            <field name="date_order" eval="datetime.now().strftime('%Y-%m-%d')" />
+            <field name="partner_id" ref="base.res_partner_12"/>
+            <field name="currency_id" ref="base.EUR"/>
+            <field name="pricelist_id" ref="product.list0"/>
+        </record>
+        <record id="so_05_line_01" model="sale.order.line">
+            <field name="name">so_05_line_01</field>
+            <field name="order_id" ref="so_05"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_uom_qty">2</field>
+            <field name="price_unit">38.0</field>
+        </record>
+        <workflow action="order_confirm" model="sale.order" ref="so_05"/>
+        <workflow action="manual_invoice" model="sale.order" ref="so_05" uid="base.user_root"/>
+        <workflow action="invoice_open" model="account.invoice">
+            <value eval="obj(ref('so_05')).invoice_ids[0].id" model="sale.order"/>
+        </workflow>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('so_05')).picking_ids[0].id]" model="sale.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('so_05')).picking_ids[0].id]" model="sale.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_09">
+            <field name="picking_id" model="sale.order" eval="obj(ref('so_05')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_09')]]"/>
+
+        <record id="po_05" model="purchase.order">
+            <field name="name">po_05</field>
+            <field name="partner_id" ref="base.res_partner_23"/>
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="pricelist_id" ref="purchase.list0"/>
+        </record>
+        <record id="po_05_line_01" model="purchase.order.line">
+            <field name="name">po_05_line_01</field>
+            <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_qty">2</field>
+            <field name="price_unit">48</field>
+            <field name="order_id" ref="po_05"/>
+        </record>
+        <workflow action="purchase_confirm" model="purchase.order" ref="po_05"/>
+        <workflow action="purchase_approve" model="purchase.order" ref="po_05"/>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('po_05')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('po_05')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_10">
+            <field name="picking_id" model="purchase.order" eval="obj(ref('po_05')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_10')]]"/>
+
+        <record id="po_06" model="purchase.order">
+            <field name="name">po_06</field>
+            <field name="partner_id" ref="base.res_partner_23"/>
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="pricelist_id" ref="purchase.list0"/>
+        </record>
+        <record id="po_06_line_01" model="purchase.order.line">
+            <field name="name">po_06_line_01</field>
+            <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_qty">2</field>
+            <field name="price_unit">56</field>
+            <field name="order_id" ref="po_06"/>
+        </record>
+        <workflow action="purchase_confirm" model="purchase.order" ref="po_06"/>
+        <workflow action="purchase_approve" model="purchase.order" ref="po_06"/>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('po_06')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('po_06')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_11">
+            <field name="picking_id" model="purchase.order" eval="obj(ref('po_06')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_11')]]"/>
+
+        <record id="po_07" model="purchase.order">
+            <field name="name">po_07</field>
+            <field name="partner_id" ref="base.res_partner_23"/>
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="pricelist_id" ref="purchase.list0"/>
+        </record>
+        <record id="po_07_line_01" model="purchase.order.line">
+            <field name="name">po_07_line_01</field>
+            <field name="date_planned" eval="datetime.now().strftime('%Y-%m-%d')"/>
+            <field name="product_id" ref="product_01"/>
+            <field name="product_qty">4</field>
+            <field name="price_unit">24</field>
+            <field name="order_id" ref="po_07"/>
+        </record>
+        <workflow action="purchase_confirm" model="purchase.order" ref="po_07"/>
+        <workflow action="purchase_approve" model="purchase.order" ref="po_07"/>
+        <function model="stock.picking" name="action_assign">
+            <value eval="[obj(ref('po_07')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <function model="stock.picking" name="do_enter_transfer_details">
+            <value eval="[obj(ref('po_07')).picking_ids[0].id]" model="purchase.order"/>
+        </function>
+        <record model="stock.transfer_details" id="td_12">
+            <field name="picking_id" model="purchase.order" eval="obj(ref('po_07')).picking_ids[0].id"/>
+        </record>
+        <function model="stock.transfer_details" name="do_detailed_transfer" eval="[[ref('td_12')]]"/>
     </data>
 </openerp>

--- a/stock_card_segmentation/model/stock_card.py
+++ b/stock_card_segmentation/model/stock_card.py
@@ -179,15 +179,15 @@ class StockCardProduct(models.TransientModel):
         move_brw = sm_obj.browse(move_id)
         origin_id = move_brw.origin_returned_move_id.id
         old_average = (
-            vals['move_dict'].get(origin_id, 0.0) and
-            vals['move_dict'][move_id]['average'] or vals['average'])
+            vals['move_dict'].get(origin_id) and
+            vals['move_dict'][origin_id]['average'] or vals['average'])
         vals['move_valuation'] = sum(
             [old_average * qnt['qty'] for qnt in qntval])
 
         for sgmnt in SEGMENTATION:
             old_average = (
-                vals['move_dict'].get(origin_id, 0.0) and
-                vals['move_dict'][move_id][sgmnt] or
+                vals['move_dict'].get(origin_id) and
+                vals['move_dict'][origin_id][sgmnt] or
                 vals[sgmnt])
 
             vals['%s_valuation' % sgmnt] = sum(

--- a/stock_card_segmentation/tests/test_stock_card_negative_stock.py
+++ b/stock_card_segmentation/tests/test_stock_card_negative_stock.py
@@ -19,7 +19,6 @@
 #
 ##############################################################################
 from openerp.tests.common import TransactionCase
-from datetime import datetime
 
 
 class TestStockCardNegativeStock(TransactionCase):

--- a/stock_card_segmentation/tests/test_stock_card_negative_stock.py
+++ b/stock_card_segmentation/tests/test_stock_card_negative_stock.py
@@ -26,169 +26,62 @@ class TestStockCardNegativeStock(TransactionCase):
 
     def setUp(self):
         super(TestStockCardNegativeStock, self).setUp()
-        self.stock_card = self.env['stock.card']
         self.sc_product = self.env['stock.card.product']
-        self.sc_move = self.env['stock.card.move']
         self.move = self.env['stock.move']
+        self.quant = self.env['stock.quant']
+
         self.product_id = self.env.ref('stock_card.product01')
-        self.location_id = self.env.ref('stock.stock_location_stock')
-        self.partner_id = self.env.ref('base.res_partner_23')
-        self.purchase_order = self.env['purchase.order']
-        self.wizard = self.env['stock.transfer_details']
-        self.wizard_item = self.env['stock.transfer_details_items']
-        self.transfer_details = self.env['stock.transfer_details']
-        self.sale_order = self.env['sale.order']
-        self.inv_ids = [
-            {  # 1
-                'do_purchase': True, 'cost': 20, 'qty': 2,
-                'avg': 20, 'move_value': 40, 'inv_value': 40,
-            },
-            {  # 2
-                'do_purchase': True, 'cost': 40, 'qty': 3,
-                'avg': 32, 'move_value': 120, 'inv_value': 160,
-            },
-            {  # 3
-                'do_purchase': False, 'cost': 32, 'qty': 1,
-                'avg': 32, 'move_value': -32, 'inv_value': 128,
-            },
-            {  # 4
-                'do_purchase': True, 'cost': 88, 'qty': 4,
-                'avg': 60, 'move_value': 352, 'inv_value': 480,
-            },
-            {  # 5
-                'do_purchase': False, 'cost': 60, 'qty': 7,
-                'avg': 60, 'move_value': -420, 'inv_value': 60,
-            },
-            {  # 6
-                'do_purchase': False, 'cost': 62, 'qty': 2,
-                'avg': 64, 'move_value': -124, 'inv_value': -64,
-            },
-            {  # 7
-                'do_purchase': True, 'cost': 64, 'qty': 4,
-                'avg': 64, 'move_value': 256, 'inv_value': 192,
-            },
-            {  # 8
-                'do_purchase': False, 'cost': 51, 'qty': 6,
-                'avg': 38, 'move_value': -306, 'inv_value': -114,
-            },
-            {  # 9
-                'do_purchase': False, 'cost': 38, 'qty': 2,
-                'avg': 38, 'move_value': -76, 'inv_value': -190,
-            },
-            {  # 10
-                'do_purchase': True, 'cost': 48, 'qty': 2,
-                'avg': 48, 'move_value': 96, 'inv_value': -94,
-            },
-            {  # 11
-                'do_purchase': True, 'cost': 56, 'qty': 2,
-                'avg': 52, 'move_value': 112, 'inv_value': 18,
-            },
-            {  # 12
-                'do_purchase': True, 'cost': 24, 'qty': 4,
-                'avg': 38, 'move_value': 96, 'inv_value': 114,
-            },
-        ]
-
-    def do_picking(self, picking_id=False):
-        picking_id.action_confirm()
-        wizard_id = self.wizard.create({
-            'picking_id': picking_id.id,
-        })
-
-        for move_id in picking_id.move_lines:
-            self.wizard_item.create({
-                'transfer_id': wizard_id.id,
-                'product_id': move_id.product_id.id,
-                'quantity': move_id.product_qty,
-                'sourceloc_id': move_id.location_id.id,
-                'destinationloc_id': move_id.location_dest_id.id,
-                'product_uom_id': move_id.product_uom.id,
-            })
-
-        wizard_id.do_detailed_transfer()
-        self.assertEqual(picking_id.state, 'done')
-
-    def create_purchase_order(self, qty=False, cost=False):
-        purchase_order_id = self.purchase_order.create({
-            'partner_id': self.partner_id.id,
-            'location_id': self.ref('stock.stock_location_stock'),
-            'pricelist_id': self.ref('purchase.list0'),
-            'order_line': [(0, 0, {
-                'name': "{0} (qty={1}, cost={2})".format(self.product_id.name,
-                                                         qty, cost),
-                'product_id': self.product_id.id,
-                'price_unit': cost,
-                'product_qty': qty,
-                'date_planned': datetime.now().strftime('%Y-%m-%d'),
-            })]
-        })
-
-        purchase_order_id.wkf_confirm_order()
-        purchase_order_id.action_invoice_create()
-        purchase_order_id.action_picking_create()
-        self.do_picking(purchase_order_id.picking_ids[0])
-
-    def create_sale_order(self, qty=False, price=False):
-        sale_order_id = self.sale_order.create({
-            'partner_id': self.partner_id.id,
-            'client_order_ref': "Sale Order (qty={0}, price={1})".format(
-                str(qty), str(price)),
-            'order_policy': 'manual',
-            'order_line': [(0, 0, {
-                'product_id': self.product_id.id,
-                'product_uom_qty': qty,
-                'price_unit': price,
-            })]
-        })
-
-        sale_order_id.action_button_confirm()
-        self.do_picking(sale_order_id.picking_ids[0])
-        return sale_order_id
 
     def get_stock_valuations(self):
         sc_moves = self.sc_product._stock_card_move_get(
             self.product_id.id, return_values=True)
         return sc_moves['res']
 
-    # TODO: This tests need to be adjusted for segmentation
-    # /!\ NOTE: Was added to improve coverage in code because this actually
-    # test the code in this module but not at all.
-    def test_01_do_inouts(self):
-
-        for expected in self.inv_ids:
-            qty = expected['qty']
-            costprice = expected['cost']
-
-            if expected['do_purchase']:
-                self.product_id.write({
-                    'standard_price': expected['cost']
-                })
-                self.create_purchase_order(qty=qty, cost=costprice)
-            else:
-                self.create_sale_order(qty=qty, price=costprice)
-
+    def test_01_stock_card(self):
         card_lines = self.get_stock_valuations()
+        self.assertEqual(len(card_lines), 12,
+                         "Expected Stock Card lines is 12")
 
-        self.assertEqual(len(self.inv_ids), len(card_lines),
-                         "Both lists should have the same length(=12)")
-        for expected, succeded in zip(self.inv_ids, card_lines):
+        self.assertEqual(card_lines[11]['average'], 38)
+        self.assertEqual(card_lines[11]['material'], 38)
+        self.assertEqual(card_lines[11]['landed'], 0.0)
+        self.assertEqual(card_lines[11]['subcontracting'], 0.0)
 
-            self.assertEqual(expected['avg'],
-                             succeded['average'],
-                             "Average Cost {0} is not the expected".
-                             format(expected))
+    def modify_sgmnts(self):
+        transactions = ['po_03_line_01', 'so_02_line_01']
+        for trxname in transactions:
+            quant_ids = self.move.search([('name', '=', trxname)]).\
+                mapped('quant_ids.id')
+            quant_id = self.quant.browse(max(quant_ids))
+            quant_id.write({
+                'material_cost': 64,
+                'landed_cost': 16,
+                'subcontracting_cost': 8,
+            })
 
-            self.assertEqual(expected['cost'],
-                             succeded['cost_unit'],
-                             "Unit Cost {0} is not the expected".
-                             format(expected))
+    def test_02_test_sgmnts(self):
+        self.modify_sgmnts()
+        card_lines = self.get_stock_valuations()
+        self.assertEqual(len(card_lines), 12,
+                         "Expected Stock Card lines is 12")
 
-            self.assertEqual(expected['inv_value'],
-                             succeded['inventory_valuation'],
-                             "Inventory Value {0} does not match".
-                             format(expected))
+        self.assertEqual(card_lines[3]['average'], 60)
+        self.assertEqual(card_lines[4]['average'], 60)
+        self.assertEqual(card_lines[6]['average'], 64)
+        self.assertEqual(card_lines[11]['average'], 38)
 
-            self.assertEqual(expected['move_value'],
-                             succeded['move_valuation'],
-                             "Movement Value {0} does not match".
-                             format(expected))
+        # / ! \ check what's happening with material for this demo
+        self.assertEqual(card_lines[3]['material'], 48)
+        self.assertEqual(card_lines[4]['material'], 48)
+        self.assertEqual(card_lines[6]['material'], 64)
+        self.assertEqual(card_lines[11]['material'], 38)
+
+        self.assertEqual(card_lines[3]['landed'], 8)
+        self.assertEqual(card_lines[4]['landed'], 8)
+        self.assertEqual(card_lines[6]['landed'], 0.0)
+        self.assertEqual(card_lines[11]['landed'], 0.0)
+
+        self.assertEqual(card_lines[3]['subcontracting'], 4)
+        self.assertEqual(card_lines[4]['subcontracting'], 4)
+        self.assertEqual(card_lines[6]['subcontracting'], 0.0)
+        self.assertEqual(card_lines[11]['subcontracting'], 0.0)

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -142,12 +142,12 @@ class StockLandedCost(models.Model):
             debit_line = dict(
                 base_line,
                 name=name,
-                account_id=valuation_account_id,
+                account_id=loss_account_id,
                 debit=-diff,)
             credit_line = dict(
                 base_line,
                 name=name,
-                account_id=gain_account_id,
+                account_id=valuation_account_id,
                 credit=-diff,)
         else:
             name = name.format(
@@ -155,12 +155,12 @@ class StockLandedCost(models.Model):
             debit_line = dict(
                 base_line,
                 name=name,
-                account_id=loss_account_id,
+                account_id=valuation_account_id,
                 credit=diff,)
             credit_line = dict(
                 base_line,
                 name=name,
-                account_id=valuation_account_id,
+                account_id=gain_account_id,
                 debit=diff,)
         aml_obj.create(
             self._cr, self._uid, debit_line, context=ctx, check=False)

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -652,5 +652,5 @@ class StockLandedCost(models.Model):
                 (cost_product.name))
 
         return self._create_landed_account_move_line(
-               line, move_id, credit_account_id, debit_account_id, qty_out,
-               already_out_account_id)
+            line, move_id, credit_account_id, debit_account_id, qty_out,
+            already_out_account_id)

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -134,8 +134,11 @@ class StockLandedCost(models.Model):
             'product_id': product_brw.id,
         }
 
+        name = '{name}: {memo} - AVG'
+
         if diff < 0:
-            name = product_brw.name + ": " + _('Gains on Inventory Deviation')
+            name = name.format(
+                name=name, memo=_('Gains on Inventory Deviation'))
             debit_line = dict(
                 base_line,
                 name=name,
@@ -147,7 +150,8 @@ class StockLandedCost(models.Model):
                 account_id=gain_account_id,
                 credit=diff,)
         else:
-            name = product_brw.name + ": " + _('Losses on Inventory Deviation')
+            name = name.format(
+                name=name, memo=_('Losses on Inventory Deviation'))
             debit_line = dict(
                 base_line,
                 name=name,
@@ -475,8 +479,7 @@ class StockLandedCost(models.Model):
                 # TODO: Compute deviation
                 if fst_avg != ini_avg and lst_avg != ini_avg:
                     self._create_deviation_accounting_entries(
-                        move_id, prod_id,
-                        ini_avg, lst_avg, qty, acc_prod)
+                        move_id, prod_id, ini_avg, lst_avg, qty, acc_prod)
 
             # TODO: Write latest value for average
             cost.compute_average_cost(prod_dict)

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -484,16 +484,9 @@ class StockLandedCost(models.Model):
                         qty_out += quant.qty
 
                 if product_id.cost_method == 'average':
-                    # NOTE: After adding value to product in its quants average
-                    # needs to be recomputed in order to find out the change in
-                    # COGS in case of sales were performed prior to landing
-                    # costs
-                    new_avg_dict = get_average(product_id.id)
-                    new_avg = new_avg_dict['average']
-                    self._create_cogs_accounting_entries(
-                        line, move_id, prod_dict[product_id.id]['average'],
-                        new_avg, prod_qty[product_id.id], acc_prod)
-                    prod_dict[product_id.id] = new_avg_dict.copy()
+                    # /!\ NOTE: Inventory valuation
+                    # TODO:??? Change to a method that can reduce overhead
+                    self._create_accounting_entries(line, move_id, 0.0)
 
                 if product_id.cost_method == 'real':
                     self._create_accounting_entries(line, move_id, qty_out)

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -386,7 +386,6 @@ class StockLandedCost(models.Model):
 
             move_id = self._model._create_account_move(
                 self._cr, self._uid, cost, context=ctx)
-            quant_dict = {}
             prod_dict = {}
             init_avg = {}
             first_lines = {}
@@ -420,6 +419,7 @@ class StockLandedCost(models.Model):
                 per_unit = line.final_cost / line.quantity
                 diff = per_unit - line.former_cost_per_unit
                 quants = [quant for quant in line.move_id.quant_ids]
+                quant_dict = {}
                 for quant in quants:
                     if quant.id not in quant_dict:
                         quant_dict[quant.id] = quant.cost + diff

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -493,7 +493,6 @@ class StockLandedCost(models.Model):
 
                 if product_id.cost_method == 'real':
                     self._create_accounting_entries(line, move_id, qty_out)
-                    prod_dict[product_id.id] = new_avg_dict.copy()
 
             # /!\ NOTE: COGS computation
             # NOTE: After adding value to product with landing cost products

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -467,7 +467,6 @@ class StockLandedCost(models.Model):
                     last_line = tpl[1]
                     fst_avg = first_line['average']
                     lst_avg = last_line['average']
-                    qty = last_line['product_qty']
                     if first_line['qty'] >= 0:
                         # /!\ TODO: This is not true for devolutions
                         continue
@@ -476,9 +475,11 @@ class StockLandedCost(models.Model):
                         acc_prod)
 
                 # TODO: Compute deviation
-                if fst_avg != ini_avg and lst_avg != ini_avg:
+                if prod_qty[prod_id] and fst_avg != ini_avg and \
+                        lst_avg != ini_avg:
                     self._create_deviation_accounting_entries(
-                        move_id, prod_id, ini_avg, lst_avg, qty, acc_prod)
+                        move_id, prod_id, ini_avg, lst_avg, prod_qty[prod_id],
+                        acc_prod)
 
             # TODO: Write latest value for average
             cost.compute_average_cost(prod_dict)

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -356,8 +356,12 @@ class StockLandedCost(models.Model):
             credit_line['debit'] = 0.0
             credit_line['credit'] = diff
         else:
-            # /!\ NOTE: be carefull when making reversions on landed costs
-            return True
+            # /!\ NOTE: be careful when making reversions on landed costs or
+            # negative landed costs
+            debit_line['credit'] = -diff
+            debit_line['debit'] = 0.0
+            credit_line['credit'] = 0.0
+            credit_line['debit'] = -diff
         aml_obj.create(
             self._cr, self._uid, debit_line, context=ctx, check=False)
         aml_obj.create(

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -485,6 +485,8 @@ class StockLandedCost(models.Model):
                     last_line = tpl[1]
                     new_avg = first_line['average']
                     lst_avg = last_line['average']
+                    if first_line['qty'] >= 0:
+                        continue
                     self._create_cogs_accounting_entries(
                         prod_id, move_id, lst_avg, new_avg, first_line['qty'],
                         acc_prod)

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -491,6 +491,18 @@ class StockLandedCost(models.Model):
                 if product_id.cost_method == 'real':
                     self._create_accounting_entries(line, move_id, qty_out)
 
+            # /!\ NOTE: COGS computation
+            # NOTE: After adding value to product with landing cost products
+            # with costing method `average` need to be check in order to
+            # find out the change in COGS in case of sales were performed prior
+            # to landing costs
+            # new_avg_dict = get_average(product_id.id)
+            # new_avg = new_avg_dict['average']
+            # self._create_cogs_accounting_entries(
+            #     line, move_id, prod_dict[product_id.id]['average'],
+            #     new_avg, prod_qty[product_id.id], acc_prod)
+            # prod_dict[product_id.id] = new_avg_dict.copy()
+
             if any([first_avg, prod_dict]):
                 cost.create_deviation_accounting_entries(
                     move_id, first_avg, acc_prod)

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -489,13 +489,6 @@ class StockLandedCost(models.Model):
                         prod_id, move_id, lst_avg, new_avg, first_line['qty'],
                         acc_prod)
 
-            # new_avg_dict = get_average(product_id.id)
-            # new_avg = new_avg_dict['average']
-            # self._create_cogs_accounting_entries(
-            #     line, move_id, prod_dict[product_id.id]['average'],
-            #     new_avg, prod_qty[product_id.id], acc_prod)
-            # prod_dict[product_id.id] = new_avg_dict.copy()
-
             if any([first_avg, prod_dict]):
                 cost.create_deviation_accounting_entries(
                     move_id, first_avg, acc_prod)

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -483,6 +483,7 @@ class StockLandedCost(models.Model):
                     fst_avg = first_line['average']
                     lst_avg = last_line['average']
                     if first_line['qty'] >= 0:
+                        # /!\ TODO: This is not true for devolutions
                         continue
                     self._create_cogs_accounting_entries(
                         prod_id, move_id, lst_avg, fst_avg, first_line['qty'],

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -143,12 +143,12 @@ class StockLandedCost(models.Model):
                 base_line,
                 name=name,
                 account_id=valuation_account_id,
-                debit=diff,)
+                debit=-diff,)
             credit_line = dict(
                 base_line,
                 name=name,
                 account_id=gain_account_id,
-                credit=diff,)
+                credit=-diff,)
         else:
             name = name.format(
                 name=name, memo=_('Losses on Inventory Deviation'))
@@ -156,13 +156,12 @@ class StockLandedCost(models.Model):
                 base_line,
                 name=name,
                 account_id=loss_account_id,
-                credit=-diff,)
+                credit=diff,)
             credit_line = dict(
                 base_line,
                 name=name,
                 account_id=valuation_account_id,
-                debit=-diff,)
-            # negative cost, reverse the entry
+                debit=diff,)
         aml_obj.create(
             self._cr, self._uid, debit_line, context=ctx, check=False)
         aml_obj.create(

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -134,7 +134,7 @@ class StockLandedCost(models.Model):
             'product_id': product_brw.id,
         }
 
-        if diff > 0:
+        if diff < 0:
             name = product_brw.name + ": " + _('Gains on Inventory Deviation')
             debit_line = dict(
                 base_line,

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -285,7 +285,7 @@ class StockLandedCost(models.Model):
 
     @api.multi
     def _create_cogs_accounting_entries(
-            self, product_id, move_id, old_avg, new_avg, qty, acc_prod=None):
+            self, product_id, move_id, lst_avg, fst_avg, qty, acc_prod=None):
         '''
         This method takes the amount of cost that needs to be booked as
         inventory value and later takes the amount of COGS that is needed to
@@ -310,12 +310,12 @@ class StockLandedCost(models.Model):
 
         return self._create_cogs_account_move_line(
             product_brw, move_id, debit_account_id,
-            cogs_account_id, old_avg, new_avg, qty)
+            cogs_account_id, lst_avg, fst_avg, qty)
 
     @api.multi
     def _create_cogs_account_move_line(
             self, product_brw, move_id, debit_account_id,
-            cogs_account_id, old_avg, new_avg, qty):
+            cogs_account_id, lst_avg, fst_avg, qty):
         """
         Create journal items for COGS for those products sold
         before landed costs were applied
@@ -333,7 +333,7 @@ class StockLandedCost(models.Model):
         # Create COGS account move lines for products that were sold prior to
         # applying landing costs
         # NOTE: Rounding problems could arise here, this needs to be checked
-        diff = (new_avg - old_avg) * qty
+        diff = (lst_avg - fst_avg) * qty
         if float_is_zero(
                 diff,
                 self.pool.get('decimal.precision').precision_get(
@@ -480,12 +480,12 @@ class StockLandedCost(models.Model):
                 for tpl in to_cogs[prod_id]:
                     first_line = tpl[0]
                     last_line = tpl[1]
-                    new_avg = first_line['average']
+                    fst_avg = first_line['average']
                     lst_avg = last_line['average']
                     if first_line['qty'] >= 0:
                         continue
                     self._create_cogs_accounting_entries(
-                        prod_id, move_id, lst_avg, new_avg, first_line['qty'],
+                        prod_id, move_id, lst_avg, fst_avg, first_line['qty'],
                         acc_prod)
 
             if any([first_avg, prod_dict]):

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -209,32 +209,6 @@ class StockLandedCost(models.Model):
             move_id, gain_account_id, loss_account_id,
             valuation_account_id, amount, product_brw)
 
-    def create_deviation_accounting_entries(
-            self, move_id, dct=None, acc_prod=None):
-        '''
-        This method books the losses or gains due to difference between old
-        average in product and the first computed average prior to apply
-        landing costs
-        '''
-        # TODO: Rewrite or get rid of this method
-        dct = dict(dct or {})
-        if not dct:
-            return True
-
-        product_obj = self.env['product.product']
-        get_qty = self.env['stock.card.product'].get_qty
-
-        for product_id, avg in dct.iteritems():
-            product_brw = product_obj.sudo().browse(product_id)
-
-            # NOTE: if there is a variation among avg and standard_price set on
-            # product new Journal Entry Lines shall be created
-            qty = get_qty(product_id)
-            self._create_deviation_accounting_entries(
-                move_id, product_id,
-                product_brw.standard_price, avg, qty, acc_prod)
-        return True
-
     def _create_standard_deviation_entry_lines(
             self, line, move_id, valuation_account_id, gain_account_id,
             loss_account_id):

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -138,7 +138,7 @@ class StockLandedCost(models.Model):
 
         if diff < 0:
             name = name.format(
-                name=product_brw.name, memo=_('Gains on Inventory Deviation'))
+                name=product_brw.name, memo=_('Losses on Inventory Deviation'))
             debit_line = dict(
                 base_line,
                 name=name,
@@ -151,7 +151,7 @@ class StockLandedCost(models.Model):
                 credit=-diff,)
         else:
             name = name.format(
-                name=product_brw.name, memo=_('Losses on Inventory Deviation'))
+                name=product_brw.name, memo=_('Gains on Inventory Deviation'))
             debit_line = dict(
                 base_line,
                 name=name,

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -356,11 +356,8 @@ class StockLandedCost(models.Model):
             credit_line['debit'] = 0.0
             credit_line['credit'] = diff
         else:
-            # negative cost, reverse the entry
-            debit_line['credit'] = -diff
-            credit_line['debit'] = -diff
-            debit_line['debit'] = 0.0
-            credit_line['credit'] = 0.0
+            # /!\ NOTE: be carefull when making reversions on landed costs
+            return True
         aml_obj.create(
             self._cr, self._uid, debit_line, context=ctx, check=False)
         aml_obj.create(

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -485,14 +485,15 @@ class StockLandedCost(models.Model):
 
                 if product_id.cost_method == 'average':
                     # /!\ NOTE: Inventory valuation
-                    # TODO:??? Change to a method that can reduce overhead
-                    # /!\ This new update can be taken out of for loop
-                    new_avg_dict = get_average(product_id.id)
                     self._create_accounting_entries(line, move_id, 0.0)
-                    prod_dict[product_id.id] = new_avg_dict.copy()
 
                 if product_id.cost_method == 'real':
                     self._create_accounting_entries(line, move_id, qty_out)
+
+            # /!\ NOTE: This new update is taken out of for loop to improve
+            # performance
+            for prod_id in prod_dict:
+                prod_dict[prod_id] = get_average(prod_id)
 
             # /!\ NOTE: COGS computation
             # NOTE: After adding value to product with landing cost products

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -489,7 +489,10 @@ class StockLandedCost(models.Model):
                     self._create_accounting_entries(line, move_id, 0.0)
 
                 if product_id.cost_method == 'real':
+                    # /!\ This new update can be taken out of for loop
+                    new_avg_dict = get_average(product_id.id)
                     self._create_accounting_entries(line, move_id, qty_out)
+                    prod_dict[product_id.id] = new_avg_dict.copy()
 
             # /!\ NOTE: COGS computation
             # NOTE: After adding value to product with landing cost products

--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -486,11 +486,12 @@ class StockLandedCost(models.Model):
                 if product_id.cost_method == 'average':
                     # /!\ NOTE: Inventory valuation
                     # TODO:??? Change to a method that can reduce overhead
-                    self._create_accounting_entries(line, move_id, 0.0)
-
-                if product_id.cost_method == 'real':
                     # /!\ This new update can be taken out of for loop
                     new_avg_dict = get_average(product_id.id)
+                    self._create_accounting_entries(line, move_id, 0.0)
+                    prod_dict[product_id.id] = new_avg_dict.copy()
+
+                if product_id.cost_method == 'real':
                     self._create_accounting_entries(line, move_id, qty_out)
                     prod_dict[product_id.id] = new_avg_dict.copy()
 

--- a/stock_quant_cost_segmentation/model/stock.py
+++ b/stock_quant_cost_segmentation/model/stock.py
@@ -174,6 +174,9 @@ class StockQuant(models.Model):
             cr, uid, quant.location_id, quant.product_id, quant.qty, dom,
             context=context)
         product_uom_rounding = quant.product_id.uom_id.rounding
+        if context is None:
+            context = {}
+        context.update({'force_unlink': True})
         for quant_neg, qty in quants:
             if not quant_neg or not solving_quant:
                 continue

--- a/stock_quant_cost_segmentation/model/stock.py
+++ b/stock_quant_cost_segmentation/model/stock.py
@@ -174,8 +174,7 @@ class StockQuant(models.Model):
             cr, uid, quant.location_id, quant.product_id, quant.qty, dom,
             context=context)
         product_uom_rounding = quant.product_id.uom_id.rounding
-        if context is None:
-            context = {}
+        context = dict(context or {})
         context.update({'force_unlink': True})
         for quant_neg, qty in quants:
             if not quant_neg or not solving_quant:


### PR DESCRIPTION
# Changes:
- [X] Include PO and SO flow as demo data
- [x] Include segments costs like subcontracting and landed as the image below
  - [x] modify quants in test-runtime
- [x] Modify current unit tests and challenge results given by Stock Card Wizard

The following image reflects expected demo values
![image](https://cloud.githubusercontent.com/assets/2961943/12624347/c80d5780-c500-11e5-8780-075f209c97c0.png)
