### PR TITLE
[FIX] sale_test_data_imp: Fix import error and avoid warnings like LocalService() deprecated.

### DIFF
--- a/sale_test_data_imp/test/sale_order_product_can_be_sold.yml
+++ b/sale_test_data_imp/test/sale_order_product_can_be_sold.yml
@@ -4,8 +4,8 @@
     Create sale order, picking in and invoice by product
 -
   !python {model: sale.order}: |
-    import tools
-    import netsvc
+    from openerp import tools
+    from openerp import netsvc
     import os
     import tempfile
     import csv
@@ -109,7 +109,7 @@
             #~ Validate invoice for this sale order 
             if invoice_id:
                 try:
-                    wf_service = netsvc.LocalService("workflow")
+                    wf_service = netsvc.openerp.workflow
                     wf_service.trg_validate(uid, 'account.invoice', invoice_id.get('res_id') , 'invoice_open', cr)
                 except Exception, e:
                     fcsv_csv_Log.writerow({'error' : tools.ustr(e).replace('\n', ''), 'localization': 'Validate Invoice',  'product_id' : repr(product_id)})


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after replacing `import tools` by `from openerp import tools` for example.
- [x] Follow the next recomendation `For workflows, instead of using
  LocalService('workflow'), openerp.workflow should be used` to avoid warning `LocalService() is deprecated since march 2013`.

![sale_test_data_imp](https://cloud.githubusercontent.com/assets/11741384/12601313/c849dfb6-c465-11e5-8ff3-5f879b831a12.png)
