### PR TITLE
[FIX] purchase_requisition_remarks: Remove sorting to a field priority not found on model purchase.requisition

### DIFF
--- a/purchase_requisition_remarks/model/purchase_requisition.py
+++ b/purchase_requisition_remarks/model/purchase_requisition.py
@@ -27,7 +27,6 @@ from openerp.osv import osv, fields
 
 class PurchaseRequisition(osv.Model):
     _inherit = 'purchase.requisition'
-    _order = 'priority asc'
     _columns = {
         'remarks': fields.text(
             'Remarks',


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after removing _order to sort `priority` field not found in `purchase.requisition`:
  ![purchase_requisition_remarks](https://cloud.githubusercontent.com/assets/11741384/12604886/339437f2-c485-11e5-837e-e7c7a7bfc291.png)
