### PR TITLE
[FIX] product_price_visible: Change dependency to locate the price fields in the inherited views, also change references to views.

### DIFF
--- a/product_price_visible/__openerp__.py
+++ b/product_price_visible/__openerp__.py
@@ -33,7 +33,7 @@
     "website": "www.vauxoo.com",
     "license": "AGPL-3",
     "depends": [
-        "stock"
+        "stock_account",
     ],
     "demo": [],
     "data": [

--- a/product_price_visible/product_view.xml
+++ b/product_price_visible/product_view.xml
@@ -1,24 +1,32 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <openerp>
     <data>
-        <record model="ir.ui.view" id="product_normal_form_inh_visible_view">
-            <field name="name">product.normal.form.inh.visible.view</field>
+        <record model="ir.ui.view" id="product_templ_form_inh_visible_view">
+            <field name="name">product.templ.form.inh.visible.view</field>
             <field name="model">product.product</field>
-            <field name="inherit_id" ref="product.product_normal_form_view"/>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
-                <field name="list_price" position="replace">
+                <xpath expr="//field[@name='list_price']" position="replace">
                     <field name="list_price" groups="product_price_visible.group_product_visible"/>
-                </field>
+                </xpath>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="product_templ_stock_property_form_inh_visible_view">
+            <field name="name">product.templ.stock.property.form.inh.visible.view</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="stock_account.view_template_property_form"/>
+            <field name="arch" type="xml">
                 <field name="cost_method" position="replace">
                     <field name="cost_method" groups="product_price_visible.group_product_visible"/>
                 </field>
             </field>
         </record>
-        
+
         <record model="ir.ui.view" id="view_product_standard_price_inh_visible_form">
             <field name="name">view.product.standard.price.inh.visible.form</field>
             <field name="model">product.product</field>
-            <field name="inherit_id" ref="stock.view_product_standard_price_form"/>
+            <field name="inherit_id" ref="stock_account.view_template_property_form"/>
             <field name="arch" type="xml">
                 <field name="standard_price" position="replace">
 <!--
@@ -26,12 +34,12 @@
 -->
                     <group col="2" colspan="1" groups="product_price_visible.group_product_visible">
                         <field name="standard_price" attrs="{'readonly':[('cost_method','=','average')]}" nolabel="1" groups="product_price_visible.group_product_visible"/>
-                        <button name="%(stock.action_view_change_standard_price)d" string="Update" type="action" icon="gtk-execute" attrs="{'invisible':[('cost_method','&lt;&gt;','average')]}" groups="product_price_visible.group_product_visible"/>
+                        <button name="%(stock_account.action_view_change_standard_price)d" string="Update" type="action" icon="gtk-execute" attrs="{'invisible':[('cost_method','&lt;&gt;','average')]}" groups="product_price_visible.group_product_visible"/>
                     </group>
                 </field>
             </field>
         </record>
-        
+
         <record model="ir.ui.view" id="product_product_tree_inh_visible_view">
             <field name="name">product.product.tree.inh.visible.view</field>
             <field name="model">product.product</field>
@@ -42,9 +50,6 @@
                 </field>
                 <field name="price" position="replace">
                     <field name="price" invisible="not context.get('pricelist',False)" groups="product_price_visible.group_product_visible"/>
-                </field>
-                <field name="standard_price" position="replace">
-                    <field name="standard_price" groups="product_price_visible.group_product_visible"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after the next additions and fixes:
  - [x] Use `product.product_template_form_view` instead `product.product_normal_form_view` because the `list_price` field is not being located in the parent view.
  - [x] Add new record for the missing field `cost_method` because isn't located in any of the parent views `product.product_template_form_view` or `product.product_normal_form_view` at v. 8.0. In this case to add a group for that field the reference to the inherited view was: `stock_account.view_template_property_form`
  - [x] Change dependency to stock_account because the references to the view `product.product_template_form_view`are in `stock_account`.

![product_price_visible](https://cloud.githubusercontent.com/assets/11741384/12653783/a9565fa6-c5b6-11e5-8576-333e4062a5bb.png)
