### PR TITLE
[FIX] product_rfq: To locate the purchase_requisition field, also change id and name to be consistent with the changed ref id.

### DIFF
--- a/product_rfq/view/product_view.xml
+++ b/product_rfq/view/product_view.xml
@@ -11,10 +11,10 @@
                 </xpath>
             </field>
         </record>
-    <record model="ir.ui.view" id="inherited_product_product_form_rfq">
-            <field name="name">product.product.form.inherit</field>
+    <record model="ir.ui.view" id="inherited_product_template_form_rfq">
+            <field name="name">product.template.form.inherit</field>
             <field name="model">product.product</field>
-            <field name="inherit_id" ref="purchase_requisition.product_normal_form_view_inherit"/>
+            <field name="inherit_id" ref="purchase_requisition.product_template_form_view_inherit"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='purchase_requisition']" position="after">
                         <field name="product_rfq"/>
@@ -27,9 +27,9 @@
             <field name="model">purchase.requisition</field>
             <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_form"/>
             <field name="arch" type="xml">
-                <xpath expr='//field[@name="product_id"]' position='attributes'>                                                                 
-                    <attribute name="context">{'search_default_product_rfq':True,'product_rfq':True}</attribute>         
-                </xpath>   
+                <xpath expr='//field[@name="product_id"]' position='attributes'>
+                    <attribute name="context">{'search_default_product_rfq':True,'product_rfq':True}</attribute>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after doing the following fix:
  - [x] Use the reference id `product_template_form_view_inherit` instead `product_normal_form_view_inherit` to locate the `purchase_requisition` field in parent view.

![product_rfq](https://cloud.githubusercontent.com/assets/11741384/12656427/d7493fa2-c5c3-11e5-8e34-5bb7eb4f3b5d.png)
- [x] Also the id and name of the record was changed to be consistent with the new inherited view id.
