### PR TITLE
[DEL] invoice_cancel_iva: Remove record because the actions are added to Server Actions.

### DIFF
--- a/invoice_cancel_iva/__openerp__.py
+++ b/invoice_cancel_iva/__openerp__.py
@@ -3,14 +3,14 @@
 #    Module Writen to OpenERP, Open Source Management Solution
 #    Copyright (C) Vauxoo (<http://vauxoo.com>).
 #    All Rights Reserved
-###############Credits######################################################
+# ##############Credits######################################################
 #    Coded by: Vauxoo C.A.
 #    Planified by: Nhomar Hernandez
 #    Audited by: Vauxoo C.A.
 #############################################################################
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,

--- a/invoice_cancel_iva/model/invoice.py
+++ b/invoice_cancel_iva/model/invoice.py
@@ -9,8 +9,8 @@
 #    Audited by: Vauxoo C.A.
 #############################################################################
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
@@ -32,14 +32,16 @@ class AccountInvoice(osv.Model):
 
     _inherit = 'account.invoice'
 
-    #~ def action_cancel_draft(self, cr, uid, ids, *args):
-#~
-    #~ wf_service = workflow
-    #~ res = super(account_invoice, self).action_cancel_draft(cr, uid, ids, ())
-    #~ for i in self.browse(cr,uid,ids,context={}):
-    #~ if i.wh_iva_id:
-    #~ wf_service.trg_validate(uid, 'account.wh.iva',i.wh_iva_id.id, 'set_to_draft', cr)
-    #~ return res
+# ~ def action_cancel_draft(self, cr, uid, ids, *args):
+# ~
+    # ~ wf_service = workflow
+    # ~ res = super(account_invoice, self).action_cancel_draft(
+    # ~     cr, uid, ids, ())
+    # ~ for i in self.browse(cr,uid,ids,context={}):
+    # ~ if i.wh_iva_id:
+    # ~ wf_service.trg_validate(uid, 'account.wh.iva',i.wh_iva_id.id,
+    # ~                         'set_to_draft', cr)
+    # ~ return res
     def action_number(self, cr, uid, ids, context=None):
         '''
         Modified to witholding vat validate

--- a/invoice_cancel_iva/model/wh_iva_doc.py
+++ b/invoice_cancel_iva/model/wh_iva_doc.py
@@ -9,8 +9,8 @@
 #    Audited by: Vauxoo C.A.
 #############################################################################
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
@@ -40,10 +40,10 @@ class WhIvaDoc(osv.Model):
         '''
         Check invoice state to not move in state
         '''
-        iva_brw = self.browse(cr, uid, ids, context=context)[0]
+        # iva_brw = self.browse(cr, uid, ids, context=context)[0]
 
         for i in self.browse(cr, uid, ids, context=context)[0].wh_lines:
-            print "i.invoice_id.state", i.invoice_id.state
+            # print "i.invoice_id.state", i.invoice_id.state
             if i.invoice_id.state == 'cancel':
                 return False
 

--- a/invoice_cancel_iva/workflow/account_workflow.xml
+++ b/invoice_cancel_iva/workflow/account_workflow.xml
@@ -3,21 +3,15 @@
 <data>
 
 
-      
-<!--        From WH_ROUTER to Withholdings-->
-        <record id="l10n_ve_withholding_iva.trans_wh_router_wh_vat" model="workflow.transition">
-            <field name="act_from" ref="l10n_ve_withholding.act_wh_router"/>
-            <field name="act_to" ref="l10n_ve_withholding_iva.act_withold_vat"/>
-            <field name="condition">check_wh_apply() and check_withholdable() and check_iva()</field>
-            <field name="signal"/>
-        </record>
-        
-        
-        
+
+<!--        From WH_ROUTER to Withholdings was deprecated and added to the Server Actions
+            at l10n_ve_withholding_iva
+-->
+
         <record id="l10n_ve_withholding_iva.trans_cancel_draft" model="workflow.transition">
             <field name="act_from" ref="l10n_ve_withholding_iva.act_cancel"/>
             <field name="act_to" ref="l10n_ve_withholding_iva.act_draft"/>
-            <field name="condition">check_state_cancel()</field> 
+            <field name="condition">check_state_cancel()</field>
             <field name="signal">set_to_draft</field>
         </record>
 


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after doing the following:
  - [x] Remove [record](https://github.com/Vauxoo/addons-vauxoo/blob/8.0/invoice_cancel_iva/workflow/account_workflow.xml#L8-L13) because the actions they were added to [Server Actions](https://github.com/Vauxoo/odoo-venezuela/blob/8.0/l10n_ve_withholding_iva/workflow/wh_action_server.xml#L13-L17) in the `l10n_ve_withholding_iva` dependency.

![invoice_cancel_iva](https://cloud.githubusercontent.com/assets/11741384/12690223/9e8e26fc-c6a7-11e5-9483-e7ba44b47a7f.png)
- [x] Fix flake8 and pylint.
