### PR TITLE
[FIX] set store=True in total_tree_products and has_products_ok fields to avoid bad performance in website search

### DIFF
--- a/website_product_filters/models/product.py
+++ b/website_product_filters/models/product.py
@@ -80,9 +80,9 @@ class ProductCategory(models.Model):
         "product_template_id", readonly=True)
     total_tree_products = fields.Integer("Total Subcategory Prods",
                                          compute="_get_product_count",
-                                         store=False,)
+                                         store=True,)
     has_products_ok = fields.Boolean(compute="_get_has_products_ok",
-                                     store=False, readonly=True)
+                                     store=True, readonly=True)
 
     @api.depends("product_ids")
     @api.multi
@@ -145,6 +145,7 @@ class ProductCategory(models.Model):
             to_jsonfy = [{'id': k, 'qty': count_dict[k]} for k in count_dict]
             return to_jsonfy
 
+    @api.depends("product_ids")
     @api.multi
     def _get_product_count(self):
         prod_obj = self.env["product.template"]

--- a/website_product_filters/views/templates.xml
+++ b/website_product_filters/views/templates.xml
@@ -358,7 +358,7 @@
         </template>
 
         <template id="option_collapse_products_categories"
-          name="Collapsible Category List" inherit_id="website_sale.products_categories" active="True">
+          name="Collapsible Category List" inherit_id="website_sale.products_categories" customize_show="True" active="True">
           <xpath expr="//div[@id='products_grid_before']/ul" position="replace">
             <ul class="nav nav-pills nav-stacked mt16" id="o_shop_collapse_category">
               <t t-foreach="categories" t-as="categ">


### PR DESCRIPTION
Solve search issue performance:

Video:
https://drive.google.com/file/d/0B_jQX2tloXM7UXNXUG1LcWQ1NG8/view

PR Dummy https://github.com/Vauxoo/yoytec/pull/668
