### PR TITLE
[product_extended_segmentation] Consider bottom threshold for product cost update

### DIFF
--- a/product_extended_segmentation/model/company.py
+++ b/product_extended_segmentation/model/company.py
@@ -9,8 +9,8 @@ class ResCompany(models.Model):
 
     std_price_neg_threshold = fields.Float(
         string="Standard Price Bottom Threshold (%)",
-        help=_('Maximum percentage threshold that Standard Price is allowed to '
-               'be lower in order to be changed with the update cost wizard'),
+        help='Maximum percentage threshold that Standard Price is allowed to'
+        ' be lower in order to be changed with the update cost wizard',
         default=0.0)
 
     @api.constrains('std_price_neg_threshold')

--- a/product_extended_segmentation/model/company.py
+++ b/product_extended_segmentation/model/company.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
-from openerp import models, fields
+from openerp import _, api, models, fields
+from openerp.exceptions import ValidationError
 
 
 class ResCompany(models.Model):
@@ -8,5 +9,11 @@ class ResCompany(models.Model):
 
     std_price_neg_threshold = fields.Float(
         string="Standard Price Bottom Threshold (%)",
-        help=('Maximum percentage threshold that Standard Price is '
-              'allowed to lower'), default=1.0)
+        help=_('Maximum percentage threshold that Standard Price is allowed to '
+               'be lower in order to be changed with the update cost wizard'),
+        default=0.0)
+
+    @api.constrains('std_price_neg_threshold')
+    def _check_bottom_cost_threshold(self):
+        if self.std_price_neg_threshold < 0:
+            raise ValidationError(_('Bottom cost threshold must be positive'))

--- a/product_extended_segmentation/model/company.py
+++ b/product_extended_segmentation/model/company.py
@@ -7,6 +7,6 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     std_price_neg_threshold = fields.Float(
-        string="Standard Price Negative Threshold (%)",
+        string="Standard Price Bottom Threshold (%)",
         help=('Maximum percentage threshold that Standard Price is '
               'allowed to lower'))

--- a/product_extended_segmentation/model/company.py
+++ b/product_extended_segmentation/model/company.py
@@ -9,4 +9,4 @@ class ResCompany(models.Model):
     std_price_neg_threshold = fields.Float(
         string="Standard Price Bottom Threshold (%)",
         help=('Maximum percentage threshold that Standard Price is '
-              'allowed to lower'))
+              'allowed to lower'), default=1.0)

--- a/product_extended_segmentation/model/company.py
+++ b/product_extended_segmentation/model/company.py
@@ -7,6 +7,6 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     std_price_neg_threshold = fields.Float(
-            string="Standard Price Negative Threshold (%)",
-            help=('Maximum percentage threshold that Standard Price is '
-                  'allowed to lower'))
+        string="Standard Price Negative Threshold (%)",
+        help=('Maximum percentage threshold that Standard Price is '
+              'allowed to lower'))

--- a/product_extended_segmentation/model/installer.py
+++ b/product_extended_segmentation/model/installer.py
@@ -1,35 +1,28 @@
 # -*- coding: utf-8 -*-
-from openerp.osv import fields, osv
+from openerp.osv import osv
+from openerp import api, fields
 
 
 class ProductExtendedSegmentationSettings(osv.osv_memory):
     _inherit = 'purchase.config.settings'
-    _columns = {
-        'std_price_neg_threshold': fields.float(
-            string="Standard Price Negative Threshold (%)",
-            help=('Maximum percentage threshold that Standard Price is '
-                  'allowed to lower')),
-    }
+    std_price_neg_threshold = fields.Float(
+        string="Standard Price Bottom Threshold (%)",
+        help=('Maximum percentage threshold that Standard Price is '
+              'allowed to lower')
+    )
 
-    def default_get(self, cr, uid, fieldnames, context=None):
-        res = super(
-            ProductExtendedSegmentationSettings, self).default_get(
-                cr, uid, fieldnames, context)
-        user = self.pool.get('res.users').browse(cr, uid, uid, context)
-        res['std_price_neg_threshold'] =\
-            user.company_id.std_price_neg_threshold
+    @api.model
+    def default_get(self, fieldnames):
+        res = super(ProductExtendedSegmentationSettings, self).\
+            default_get(fieldnames)
+        res['std_price_neg_threshold'] = \
+            self.env.user.company_id.std_price_neg_threshold
         return res
 
-    _defaults = {
-        'std_price_neg_threshold': 1.0,
-    }
-
-    def set_purchase_defaults(self, cr, uid, ids, context=None):
-        # super(
-        #     ProductExtendedSegmentationSettings, self).set_purchase_defaults(
-        #         cr, uid, context)
-        wizard = self.browse(cr, uid, ids)[0]
-        user = self.pool.get('res.users').browse(cr, uid, uid, context)
-        user.company_id.write(
-            {'std_price_neg_threshold': wizard.std_price_neg_threshold})
+    @api.multi
+    def set_purchase_defaults(self):
+        self.ensure_one()
+        self.env.user.company_id.write({
+            'std_price_neg_threshold': self.std_price_neg_threshold
+        })
         return {}

--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -207,8 +207,8 @@ class ProductTemplate(models.Model):
         diff = price - current_price
         computed_th = abs(diff * 100 / current_price)
         if float_is_zero(diff, precision_id) or \
-                (current_price and diff < 0
-                    and computed_th > bottom_price_threshold):
+                (current_price and diff < 0 and
+                    computed_th > bottom_price_threshold):
             tmpl_obj.message_post(cr, uid, [product_tmpl_id.id],
                                   'Not Updated Cost, But Segments only.',
                                   'I cowardly did not update Standard new \n'

--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -91,7 +91,6 @@ class ProductTemplate(models.Model):
         bom_obj = self.pool.get('mrp.bom')
         prod_obj = self.pool.get('product.product')
         user = self.pool.get('res.users').browse(cr, uid, uid, context)
-        bottom_price_threshold = user.company_id.std_price_neg_threshold
         precision_id = self.pool.get('decimal.precision').precision_get(
             cr, uid, 'Account')
         model = 'product.product'
@@ -197,6 +196,11 @@ class ProductTemplate(models.Model):
         # NOTE: Instanciating BOM related product
         product_tmpl_id = tmpl_obj.browse(
             cr, uid, bom.product_tmpl_id.id, context=context)
+
+        bottom_price_threshold = product_tmpl_id.company_id.\
+            std_price_neg_threshold
+        if not bottom_price_threshold:
+            bottom_price_threshold = user.company_id.std_price_neg_threshold
 
         current_price = product_tmpl_id.standard_price
         diff = price - current_price

--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -205,7 +205,11 @@ class ProductTemplate(models.Model):
 
         current_price = product_tmpl_id.standard_price
         diff = price - current_price
-        computed_th = abs(diff * 100 / current_price)
+        computed_th = current_price and abs(diff * 100 / current_price) or 0.0
+
+        if diff < 0 and current_price == 0:
+            return price
+
         if float_is_zero(diff, precision_id) or \
                 (current_price and diff < 0 and
                     computed_th > bottom_price_threshold):

--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -205,10 +205,10 @@ class ProductTemplate(models.Model):
 
         current_price = product_tmpl_id.standard_price
         diff = price - current_price
-        computed_th = diff * 100 / current_price
-
+        computed_th = abs(diff * 100 / current_price)
         if float_is_zero(diff, precision_id) or \
-                (current_price and computed_th < bottom_price_threshold):
+                (current_price and diff < 0
+                    and computed_th > bottom_price_threshold):
             tmpl_obj.message_post(cr, uid, [product_tmpl_id.id],
                                   'Not Updated Cost, But Segments only.',
                                   'I cowardly did not update Standard new \n'

--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -23,6 +23,7 @@ from openerp import models
 from openerp.addons.product import _common
 from openerp.tools import float_is_zero
 import logging
+
 _logger = logging.getLogger(__name__)
 SEGMENTATION_COST = [
     'landed_cost',

--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -204,13 +204,15 @@ class ProductTemplate(models.Model):
 
         if float_is_zero(diff, precision_id) or \
                 (current_price and computed_th < bottom_price_threshold):
-            tmpl_obj.message_post(
-                cr, uid, [product_tmpl_id.id],
-                'Cost not updated but segments. Bottom threshold reached:\n',
-                '- Current price {new}\n- Old price {old}\n'
-                '- Threshold {th}\n{segments}'.
-                format(old=current_price, new=price, segments=str(sgmnt_dict),
-                       th=computed_th))
+            tmpl_obj.message_post(cr, uid, [product_tmpl_id.id],
+                                  'Not Updated Cost, But Segments only.',
+                                  'I cowardly did not update Standard new \n'
+                                  'price less than old price \n'
+                                  'new {new} old {old} \n'
+                                  'Segments where written CHECK AFTERWARDS.'
+                                  '{segments}'.
+                                  format(old=current_price, new=price,
+                                         segments=str(sgmnt_dict)))
             # Just writting segments to be consistent with segmentation
             # feature. TODO: A report should show differences.
             tmpl_obj.write(cr, uid, [product_tmpl_id.id], sgmnt_dict,

--- a/product_extended_segmentation/tests/test_wizard.py
+++ b/product_extended_segmentation/tests/test_wizard.py
@@ -51,10 +51,18 @@ class TestWizard(TransactionCase):
     def get_product_cost(self, info_field, product_tmpl_id):
         return safe_eval(info_field)[product_tmpl_id]
 
+    def check_default_cost(self, product_id, value):
+        wizard_id = self.create_wizard(product_id)[0]
+        cost = self.get_product_cost(wizard_id.info_field, product_id.id)
+        self.assertEqual(cost, value, 'Default wizard value for {0} '
+                         'should be {1}'.format(product_id.name, value))
+
     def test_00_test_wizard_defaults(self):
         wizard_id = self.create_wizard(self.producto_d_id)[0]
         self.assertEqual(wizard_id.recursive, False,
                          'Recursive check should be unchecked by default')
+        self.check_default_cost(self.producto_d_id, 35)
+        self.check_default_cost(self.producto_e_id, 90)
 
     def test_01_test_threshold_no_update(self):
         self.company_id.write({'std_price_neg_threshold': 0})

--- a/product_extended_segmentation/tests/test_wizard.py
+++ b/product_extended_segmentation/tests/test_wizard.py
@@ -101,7 +101,7 @@ class TestWizard(TransactionCase):
                          'Production Cost for E should be 15')
 
     def test_01_test_threshold_th_30_update(self):
-        self.company_id.write({'std_price_neg_threshold': -30})
+        self.company_id.write({'std_price_neg_threshold': 30})
         # ============================
         # ==== PRODUCT D
         # ============================

--- a/product_extended_segmentation/tests/test_wizard.py
+++ b/product_extended_segmentation/tests/test_wizard.py
@@ -29,6 +29,7 @@ class TestWizard(TransactionCase):
         super(TestWizard, self).setUp()
         self.prod_template = self.env['product.template']
         self.wizard = self.env['wizard.price']
+        self.company_id = self.env.user.company_id
         self.producto_d_id = self.env.ref(
             'product_extended_segmentation.producto_d').product_tmpl_id
         self.producto_e_id = self.env.ref(
@@ -50,48 +51,77 @@ class TestWizard(TransactionCase):
     def get_product_cost(self, info_field, product_tmpl_id):
         return safe_eval(info_field)[product_tmpl_id]
 
-    def check_wizard_values(self, product_id, vals):
-        # check before wizard
-        self.assertEqual(product_id.standard_price, vals['before'],
-                         'Standard Price for {0} should be {1}'.
-                         format(product_id.name, vals['before']))
-        wizard_id = self.create_wizard(product_id)[0]
+    def test_00_test_wizard_defaults(self):
+        wizard_id = self.create_wizard(self.producto_d_id)[0]
         self.assertEqual(wizard_id.recursive, False,
-                         'WizardPrice recursive check should be unchecked'
-                         'by default')
-        cost = self.get_product_cost(wizard_id.info_field, product_id.id)
-        # check what a wizard returns as default value
-        self.assertEqual(cost, vals['default'],
-                         'Non-recursive cost valuation for {0} should be {1}'.
-                         format(product_id.name, vals['default']))
-        wizard_id = self.create_wizard(
-            product_id, recursive=True, update_avg_costs=True)
-        wizard_id.compute_from_bom()
-        cost = product_id.standard_price
-        # check what recursive returns
-        self.assertEqual(cost, vals['after'],
-                         'Recursive cost for {0} should be keep at {1}'.
-                         format(product_id.name, vals['after']))
+                         'Recursive check should be unchecked by default')
 
-    def test_01_test_wizard_onchange_recursive(self):
-        vals = {
-            'before': 50,
-            'default': 35,
-            'after': 35
-        }
-        self.check_wizard_values(self.producto_d_id, vals)
+    def test_01_test_threshold_no_update(self):
+        self.company_id.write({'std_price_neg_threshold': 0})
+        # ============================
+        # ==== PRODUCT D
+        # ============================
+        self.assertEqual(self.producto_d_id.standard_price, 50,
+                         'Standard Price for D should be 50')
+        wizard_id = self.create_wizard(
+            self.producto_d_id, recursive=True, update_avg_costs=True)
+        wizard_id.compute_from_bom()
+
+        # check what recursive returns
+        self.assertEqual(self.producto_d_id.standard_price, 50,
+                         'Recursive cost for D should be keep at 50')
         # check production_cost
         self.assertEqual(self.producto_d_id.production_cost, 5,
                          'Production Cost for D should be 5')
 
-    def test_02_test_wizard_onchange_recursive(self):
-        vals = {
-            'before': 80,
-            'default': 90,
-            'after': 75
-        }
-        self.check_wizard_values(self.producto_e_id, vals)
+        # ============================
+        # ==== PRODUCT E
+        # ============================
+        self.assertEqual(self.producto_e_id.standard_price, 80,
+                         'Standard Price for {0} should be {1}'.
+                         format(self.producto_e_id.name, 80))
+        wizard_id = self.create_wizard(
+            self.producto_e_id, recursive=True, update_avg_costs=True)
+        wizard_id.compute_from_bom()
 
+        # check what recursive returns
+        self.assertEqual(self.producto_e_id.standard_price, 80,
+                         'Recursive cost for E should be keep at 80')
+
+        # check production_cost
+        self.assertEqual(self.producto_e_id.production_cost, 15,
+                         'Production Cost for E should be 15')
+
+    def test_01_test_threshold_th_30_update(self):
+        self.company_id.write({'std_price_neg_threshold': -30})
+        # ============================
+        # ==== PRODUCT D
+        # ============================
+        self.assertEqual(self.producto_d_id.standard_price, 50,
+                         'Standard Price for D should be 50')
+        wizard_id = self.create_wizard(
+            self.producto_d_id, recursive=True, update_avg_costs=True)
+        wizard_id.compute_from_bom()
+
+        # check what recursive returns
+        self.assertEqual(self.producto_d_id.standard_price, 35,
+                         'Recursive cost for D should be keep at 35')
+        # check production_cost
+        self.assertEqual(self.producto_d_id.production_cost, 5,
+                         'Production Cost for D should be 5')
+
+        # ============================
+        # ==== PRODUCT E
+        # ============================
+        self.assertEqual(self.producto_e_id.standard_price, 80,
+                         'Standard Price for E should be 80')
+        wizard_id = self.create_wizard(
+            self.producto_e_id, recursive=True, update_avg_costs=True)
+        wizard_id.compute_from_bom()
+
+        # check what recursive returns
+        self.assertEqual(self.producto_e_id.standard_price, 75,
+                         'Recursive cost for E should be keep at 75')
         # check production_cost
         self.assertEqual(self.producto_e_id.production_cost, 15,
                          'Production Cost for E should be 15')


### PR DESCRIPTION
## Changes made:
- [X] Include bottom threshold for cost update
- [X] Update unit test for threshold behavior with the following use cases:
  - [X] new price is under the threshold, product price is not updated but segments.
  - [X] new price is above the threshold, product price is updated as well segments
  - [X] check default values on wizard

Video showing this feature
[![demo video](http://img.youtube.com/vi/Qv2UR1xZOoc/0.jpg)](http://www.youtube.com/watch?v=Qv2UR1xZOoc)

Use cases taken in count to logic in here

| Threshold | Current Price | New Price | Price Diff | Action |
| --: | --: | --: | --: | --- |
| 0 | 0 | 0 | 0 | update only segments |
| 0 | 0 | 10 | 10 | update cost and segments |
| 10 | 0 | 0 | 0 | update only segments |
| 10 | 0 | 10 | 0 | update cost and segments |
| 0 | 100 | 90 | -10 | update only segments |
| 10 | 100 | 80 | -20 | update only segments |
| 10 | 100 | 95 | -5 | update cost and segments |
| 10 | 0 | -5 | -5 | do nothing |
