### PR TITLE
[8.0][mrp_partial_production] Using default value at the momento to get the quantities reserved by move

### DIFF
--- a/mrp_partial_production/models/mrp.py
+++ b/mrp_partial_production/models/mrp.py
@@ -92,7 +92,8 @@ class MrpProduction(models.Model):
             for line in consume_lines and consume_lines[0] or ():
                 product_id = line.get('product_id')
                 val = line.get('product_qty') and \
-                    int(result.get(product_id) / line.get('product_qty')) or 0
+                    int(result.get(product_id, 0) /
+                        line.get('product_qty')) or 0
                 qty.append(val)
 
         return min(qty)


### PR DESCRIPTION
There is not a constraint to avoid change a BOM if you have a manufacturing order alive. Because of this when we try to compute the quantity available to produce basing us in the BOM used in manufacturing order, we have a difference between the moves created against lines of the BOM, we have a traceback for the differences between the products.

To avoid this we will use the default value at the moment to get the quantities reserved for the move created in the manufacturing order
