### PR TITLE
[FIX] validate_stock_picking: Remove act_window that references to stock.picking.in and stock.picking.out depreciated in odoo 8.0

### DIFF
--- a/validate_stock_picking/model/stock.py
+++ b/validate_stock_picking/model/stock.py
@@ -105,9 +105,8 @@ class InheritStockMove(osv.Model):
                 cr,
                 uid,
                 move_ids,
-                {'state': 'done', 'date': time.strftime(
-                    DEFAULT_SERVER_DATETIME_FORMAT)
-                },
+                {'state': 'done',
+                 'date': time.strftime(DEFAULT_SERVER_DATETIME_FORMAT)},
                 context=context)
 
         for id in move_ids:

--- a/validate_stock_picking/model/stock.py
+++ b/validate_stock_picking/model/stock.py
@@ -9,8 +9,8 @@
 #    Audited by: Vauxoo C.A.
 #############################################################################
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
@@ -61,20 +61,34 @@ class InheritStockMove(osv.Model):
             if move.move_dest_id.id and (move.state != 'done'):
                 # Downstream move should only be triggered if this move is the
                 # last pending upstream move
-                other_upstream_move_ids = self.search(cr, uid, [('id', '!=', move.id), ('state', 'not in', ['done', 'cancel']),
-                                                                ('move_dest_id', '=', move.move_dest_id.id)], context=context)
+                other_upstream_move_ids = self.search(
+                    cr,
+                    uid,
+                    [('id', '!=', move.id),
+                     ('state', 'not in', ['done', 'cancel']),
+                     ('move_dest_id', '=', move.move_dest_id.id)],
+                    context=context)
                 if not other_upstream_move_ids:
-                    self.write(cr, uid, [move.id], {
-                               'move_history_ids': [(4, move.move_dest_id.id)]})
+                    self.write(
+                        cr,
+                        uid,
+                        [move.id],
+                        {'move_history_ids': [(4, move.move_dest_id.id)]})
                     if move.move_dest_id.state in ('waiting', 'confirmed'):
                         self.force_assign(
                             cr, uid, [move.move_dest_id.id], context=context)
                         if move.move_dest_id.picking_id:
                             wf_service.trg_write(
-                                uid, 'stock.picking', move.move_dest_id.picking_id.id, cr)
+                                uid,
+                                'stock.picking',
+                                move.move_dest_id.picking_id.id,
+                                cr)
                         if move.move_dest_id.auto_validate:
                             self.action_done(
-                                cr, uid, [move.move_dest_id.id], context=context)
+                                cr,
+                                uid,
+                                [move.move_dest_id.id],
+                                context=context)
 
             self._create_product_valuation_moves(
                 cr, uid, move, context=context)
@@ -87,8 +101,14 @@ class InheritStockMove(osv.Model):
         if context.get('no_change_date', False):
             self.write(cr, uid, move_ids, {'state': 'done'}, context=context)
         else:
-            self.write(cr, uid, move_ids, {'state': 'done', 'date': time.strftime(
-                DEFAULT_SERVER_DATETIME_FORMAT)}, context=context)
+            self.write(
+                cr,
+                uid,
+                move_ids,
+                {'state': 'done', 'date': time.strftime(
+                    DEFAULT_SERVER_DATETIME_FORMAT)
+                },
+                context=context)
 
         for id in move_ids:
             wf_service.trg_trigger(uid, 'stock.move', id, cr)

--- a/validate_stock_picking/wizard/validate_picking.py
+++ b/validate_stock_picking/wizard/validate_picking.py
@@ -9,8 +9,8 @@
 #    Audited by: Vauxoo C.A.
 #############################################################################
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
 #    (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
@@ -66,7 +66,8 @@ class ValidatePicking(osv.TransientModel):
                                                             'date'], copy_ctx)
                             dicts.get('move_ids') and \
                                 dicts.update({'move_ids': [(0, 0, i)
-                                                           for i in dicts.get('move_ids')]})
+                                                           for i in dicts.get(
+                                                               'move_ids')]})
                             partial_id = do_partial.create(cr, uid, dicts)
                             do_partial.do_partial(cr, uid,
                                                   [partial_id], copy_ctx)

--- a/validate_stock_picking/wizard/validate_picking_view.xml
+++ b/validate_stock_picking/wizard/validate_picking_view.xml
@@ -28,24 +28,6 @@
             target="new"
             id="validate_stock_picking_action"/>
 
-<act_window name="Validate Picking"
-            key2="client_action_multi"
-            res_model="validate.picking.wz"
-            src_model="stock.picking.in"
-            view_mode="form"
-            view_type="form"
-            target="new"
-            id="validate_stock_picking_action_in"/>
-
-<act_window name="Validate Picking"
-            key2="client_action_multi"
-            res_model="validate.picking.wz"
-            src_model="stock.picking.out"
-            view_mode="form"
-            view_type="form"
-            target="new"
-            id="validate_stock_picking_action_out"/>
-
 <act_window name="Validate Moves"
             key2="client_action_multi"
             res_model="validate.picking.wz"


### PR DESCRIPTION
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module successfully installed after the following fix:
  - [x] Remove `act_window` that references to `stock.picking.in` and `stock.picking.out` because this models are depreciated by `stock.picking` in v. 8.0.

![validate_stock_picking](https://cloud.githubusercontent.com/assets/11741384/13025526/f78ea448-d1ce-11e5-9fb8-638dfc2e8928.png)
