### PR TITLE
[FIX] stock_purchase_requisitor: Remove references to stock.picking.i…

### DIFF
--- a/stock_purchase_requisitor/model/stock.py
+++ b/stock_purchase_requisitor/model/stock.py
@@ -35,17 +35,3 @@ class StockPicking(osv.Model):
     _columns = {
         'responsible_id': fields.many2one('res.users', 'Responsible'),
     }
-
-
-class StockPickingIn(osv.Model):
-    _inherit = 'stock.picking.in'
-    _columns = {
-        'responsible_id': fields.many2one('res.users', 'Responsible'),
-    }
-
-
-class StockPickingOut(osv.Model):
-    _inherit = 'stock.picking.out'
-    _columns = {
-        'responsible_id': fields.many2one('res.users', 'Responsible'),
-    }

--- a/stock_purchase_requisitor/view/stock_picking_view.xml
+++ b/stock_purchase_requisitor/view/stock_picking_view.xml
@@ -2,45 +2,23 @@
 <openerp>
   <data>
 
-    <record model="ir.ui.view" id="stock_picking_in_spt_form">
-        <field name="name">stock.picking.in.spt.form</field>
-        <field name="model">stock.picking.in</field>
-        <field name="inherit_id" ref="stock.view_picking_in_form"/>
+    <record model="ir.ui.view" id="stock_picking_spt_form">
+        <field name="name">stock.picking.spt.form</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='invoice_state']" position="after" >
+            <xpath expr="//field[@name='backorder_id']" position="after" >
                 <field name="responsible_id" readonly='1'/>
             </xpath>
         </field>
     </record>
 
-    <record model="ir.ui.view" id="stock_picking_out_spt_form">
-        <field name="name">stock.picking.out.spt.form</field>
-        <field name="model">stock.picking.out</field>
-        <field name="inherit_id" ref="stock.view_picking_out_form"/>
+    <record model="ir.ui.view" id="stock_picking_spt_tree">
+        <field name="name">stock.picking.spt.tree</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.vpicktree"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='invoice_state']" position="after" >
-                <field name="responsible_id" readonly='1'/>
-            </xpath>
-        </field>
-    </record>
-
-    <record model="ir.ui.view" id="stock_picking_in_spt_tree">
-        <field name="name">stock.picking.in.spt.tree</field>
-        <field name="model">stock.picking.in</field>
-        <field name="inherit_id" ref="stock.view_picking_in_tree"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='invoice_state']" position="after" >
-                <field name="responsible_id" readonly='1'/>
-            </xpath>
-        </field>
-    </record>
-
-    <record model="ir.ui.view" id="stock_picking_out_spt_tree">
-        <field name="name">stock.picking.out.spt.tree</field>
-        <field name="model">stock.picking.out</field>
-        <field name="inherit_id" ref="stock.view_picking_out_tree"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='invoice_state']" position="after" >
+            <xpath expr="//field[@name='backorder_id']" position="after" >
                 <field name="responsible_id" readonly='1'/>
             </xpath>
         </field>


### PR DESCRIPTION
…n and stock.picking.out cause that models are depreciated by stock.picking. Also change xpath expr to locate new field in parent view.
### [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&action=138)
- [x] Module loaded successfully after using the proper model and changing the xpath expression to locate the new field:

![stock_purchase_requisitor](https://cloud.githubusercontent.com/assets/11741384/13067751/84b3f104-d439-11e5-9813-78bfbaeb8fa6.png)
