### PR TITLE
[FIX] website_product_comment_purchased: migrate feature to old api, to avoid no enter to the function

### DIFF
--- a/website_product_comment_purchased/__openerp__.py
+++ b/website_product_comment_purchased/__openerp__.py
@@ -13,6 +13,7 @@
     "data": [
         "views/layout.xml",
         "views/website_comment_purchased.xml",
+        "data/website_settings.yml",
     ],
     "test": [],
     "js": [],

--- a/website_product_comment_purchased/data/website_settings.yml
+++ b/website_product_comment_purchased/data/website_settings.yml
@@ -1,0 +1,10 @@
+-
+    website_product auto setted up to be installed on website
+-
+  !python {model: ir.ui.view}: |
+    self.write(cr, uid, [ref('website_sale.product_comment')], {'active': True}, context={'active_test': True})
+-
+    Website_product_comment_purchased auto setted up to be installed on website
+-
+  !python {model: ir.ui.view}: |
+    self.write(cr, uid, [ref('website_product_comment_purchased.discussion_purchased')], {'active': True}, context={'active_test': True})

--- a/website_product_comment_purchased/models/mail.py
+++ b/website_product_comment_purchased/models/mail.py
@@ -42,7 +42,7 @@ class MailMessage(osv.Model):
                         t.id={res_id} AND s.partner_id={partner_id}
 
                 """.format(res_id=mail.res_id,
-                           partner_id=mail.author_id.id)
+                           partner_id=mail.author_id.id or 'null')
             execute = """
                 {select}
                 FROM ( {_from} )

--- a/website_product_comment_purchased/static/src/js/test_comment_bought.js
+++ b/website_product_comment_purchased/static/src/js/test_comment_bought.js
@@ -3,12 +3,12 @@
     openerp.Tour.register({
         id: 'shop_comment_bought',
         name: 'Shop comment bought',
-        path: '/shop?search=ipod',
+        path: '/shop?search=bose',
         mode: 'test',
         steps: [
             {
-                title:     'select ipod',
-                element:   '.oe_product_cart a:contains("iPod")',
+                title:     'select bose',
+                element:   '.oe_product_cart a:contains("Bose")',
             },
             {
                 title:     "write a comment",
@@ -22,7 +22,6 @@
                 title:     'look for a tag "customer bought the item"',
                 content:   'Waith Not a comment of the current user logged in, that has the tag "Customer bought the item"',
                 waitNot:   'span.label.label-success:contains("Customer bought the item")',
-                element:   'label:contains(32 GB) input',
             },
             {
                 title:     'click on add to cart on ipod details',
@@ -60,15 +59,15 @@
                 element:   'a[href="/shop"]',
             },
             {
-                title:     "search ipod",
+                title:     "search bose",
                 element:   'form:has(input[name="search"]) a.a-submit',
                 onload: function() {
-                    $('input[name="search"]').val("ipod");
+                    $('input[name="search"]').val("bose");
                 }
             },
             {
                 title:     "select ipod",
-                element:   '.oe_product_cart a:contains("iPod")',
+                element:   '.oe_product_cart a:contains("Bose")',
             },
             {
                 title:     "write a comment",
@@ -79,7 +78,7 @@
                 }
             },
             {
-                title:     'Customer bought the intem ipod',
+                title:     'Customer bought the intem bose',
                 content:   'Waith For a comment of the current user logged in, that has the tag "Customer bought the item"',
                 waitFor:   'span.label.label-success:contains("Customer bought the item")',
             },

--- a/website_product_comment_purchased/static/src/js/test_comment_bought.js
+++ b/website_product_comment_purchased/static/src/js/test_comment_bought.js
@@ -1,0 +1,88 @@
+    (function(){
+    'use strict';
+    openerp.Tour.register({
+        id: 'shop_comment_bought',
+        name: 'Shop comment bought',
+        path: '/shop?search=ipod',
+        mode: 'test',
+        steps: [
+            {
+                title:     'select ipod',
+                element:   '.oe_product_cart a:contains("iPod")',
+            },
+            {
+                title:     "write a comment",
+                content:   'Before bought the product, write a comment',
+                element:   'form[id="comment"] div a:contains(Post)',
+                onload: function() {
+                    $('textarea[name="comment"]').val("Comments from test");
+                }
+            },
+            {
+                title:     'look for a tag "customer bought the item"',
+                content:   'Waith Not a comment of the current user logged in, that has the tag "Customer bought the item"',
+                waitNot:   'span.label.label-success:contains("Customer bought the item")',
+                element:   'label:contains(32 GB) input',
+            },
+            {
+                title:     'click on add to cart on ipod details',
+                element:   'form[action^="/shop/cart/update"] .btn',
+            },
+            {
+                title:     'go to checkout',
+                element:   'a:contains("Process Checkout")',
+            },
+            {
+                title:     'fill the checkout',
+                element:   'form[action="/shop/confirm_order"] .btn:contains("Confirm")',
+                onload: function (tour) {
+                    $("input[name='name']").val("website_sale-test-shoptest");
+                    $("input[name='email']").val("website_sale_test_shoptest@websitesaletest.odoo.com");
+                    $("input[name='phone']").val("123");
+                    $("input[name='street2']").val("123");
+                    $("input[name='city']").val("123");
+                    $("input[name='zip']").val("123");
+                    $("select[name='country_id']").val("21");
+                },
+            },
+            {
+                title:     "select payment",
+                element:   '#payment_method label:has(img[title="Wire Transfer"]) input',
+            },
+            {
+                title:     "Pay Now",
+                waitFor:   '#payment_method label:has(input:checked):has(img[title="Wire Transfer"])',
+                element:   '.oe_sale_acquirer_button .btn[type="submit"]:visible',
+            },
+            {
+                title:     "finish Process",
+                waitFor:   '.oe_website_sale:contains("Thank you for your order")',
+                element:   'a[href="/shop"]',
+            },
+            {
+                title:     "search ipod",
+                element:   'form:has(input[name="search"]) a.a-submit',
+                onload: function() {
+                    $('input[name="search"]').val("ipod");
+                }
+            },
+            {
+                title:     "select ipod",
+                element:   '.oe_product_cart a:contains("iPod")',
+            },
+            {
+                title:     "write a comment",
+                content:   'After bought the product, write a comment',
+                element:   'form[id="comment"] div a:contains(Post)',
+                onload: function() {
+                    $('textarea[name="comment"]').val("Comments from test");
+                }
+            },
+            {
+                title:     'Customer bought the intem ipod',
+                content:   'Waith For a comment of the current user logged in, that has the tag "Customer bought the item"',
+                waitFor:   'span.label.label-success:contains("Customer bought the item")',
+            },
+        ],
+    });
+}());

--- a/website_product_comment_purchased/tests/__init__.py
+++ b/website_product_comment_purchased/tests/__init__.py
@@ -1,0 +1,10 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Hugo Adan <hugo@vauxoo.com>
+############################################################################
+from . import test_comment_bought

--- a/website_product_comment_purchased/tests/test_comment_bought.py
+++ b/website_product_comment_purchased/tests/test_comment_bought.py
@@ -1,0 +1,33 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Hugo Adan <hugo@vauxoo.com>
+############################################################################
+import openerp.tests
+
+
+@openerp.tests.common.at_install(False)
+@openerp.tests.common.post_install(True)
+class TestUi(openerp.tests.HttpCase):
+
+    def test_01_shop_comment_bought_admin(self):
+        self.phantom_js("/",
+                        "openerp.Tour.run('shop_comment_bought', 'test')",
+                        "openerp.Tour.tours.shop_comment_bought",
+                        login='admin')
+
+    def test_02_shop_comment_bought_demo(self):
+        self.phantom_js("/",
+                        "openerp.Tour.run('shop_comment_bought', 'test')",
+                        "openerp.Tour.tours.shop_comment_bought",
+                        login='demo')
+
+    def test_03_shop_comment_bought_portal(self):
+        self.phantom_js("/",
+                        "openerp.Tour.run('shop_comment_bought', 'test')",
+                        "openerp.Tour.tours.shop_comment_bought",
+                        login='portal')

--- a/website_product_comment_purchased/views/layout.xml
+++ b/website_product_comment_purchased/views/layout.xml
@@ -1,8 +1,16 @@
 <openerp>
     <data>
+        <!-- HERE ARE ALL THE UI/BEHAVIOUR JS FILES  -->
         <template id="assets_backend" name="web_comment_purchased_assets" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
                 <script type="text/javascript" src="/website_product_comment_purchased/static/src/js/comment_purchased.js"></script>
+            </xpath>
+        </template>
+
+        <!-- HERE ARE THE PHANTOM TESTS  -->
+        <template id="assets_frontend_cooment_bought" name="Comment bought Assets Tests" inherit_id="website.assets_frontend">
+            <xpath expr="//script[last()]" position="after">
+                <script type="text/javascript" src="/website_product_comment_purchased/static/src/js/test_comment_bought.js"></script>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
https://github.com/Vauxoo/yoytec/pull/738

This change is because the field comment_bought is not being calculated when using the new api, using the old api, the field is being calculated, see the next video to show you an easy example.

https://youtu.be/-RcrjbLturE

Also, if we write the record ,decorating the field previsuly with api.depends, the field is not calculated.
