### PR TITLE
[WIP][8.0] Enhance coverage and use cases for stock modules

### DIFF
--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -295,7 +295,7 @@ class ProductTemplate(models.Model):
 
                 # Call compute_price on these subproducts
                 prod_set = set([x.product_id.id for x in bom.bom_line_ids])
-                res = self.compute_price(
+                self.compute_price(
                     cr, uid, product_ids=list(prod_set), template_ids=[],
                     recursive=recursive, test=test,
                     real_time_accounting=real_time, context=context)

--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -299,9 +299,6 @@ class ProductTemplate(models.Model):
                     cr, uid, product_ids=list(prod_set), template_ids=[],
                     recursive=recursive, test=test,
                     real_time_accounting=real_time, context=context)
-                # /!\ NOTE: This is not logical
-                if test:
-                    testdict.update(res)
 
             # Use calc price to calculate and put the price on the product
             # of the BoM if necessary

--- a/product_extended_segmentation/tests/test_avg_costs.py
+++ b/product_extended_segmentation/tests/test_avg_costs.py
@@ -103,3 +103,12 @@ class TestAvgCosts(TransactionCase):
         self.assertEqual(res['producto_a']['material_cost'], 0)
         self.assertEqual(res['producto_b']['material_cost'], 0)
         self.assertEqual(res['producto_c']['material_cost'], 0)
+
+    def test_02_compute_price_with_real_bom(self):
+        template_id = self.prod_e_id.product_tmpl_id
+        self.prod_d_id.write({'cost_method': 'real'})
+        res = self.env['product.template'].compute_price(
+            product_ids=False, recursive=True,  real_time_accounting=False,
+            template_ids=[template_id.id], test=True)
+        self.assertEqual(res,
+                         '{{{0}: 75.0}}'.format(str(template_id.id)))

--- a/product_extended_segmentation/tests/test_avg_costs.py
+++ b/product_extended_segmentation/tests/test_avg_costs.py
@@ -60,7 +60,7 @@ class TestAvgCosts(TransactionCase):
         self.prod_e_id.refresh()
         sgmnts['after'] = [getattr(self.prod_e_id, fieldname)
                            for fieldname in SEGMENTATION_COST]
-        self.assertEqual(sum(sgmnts['after']), 75.0, 'Segments should be 75.0')
+        self.assertEqual(sum(sgmnts['after']), 80.0, 'Segments should be 80.0')
 
     def get_store_product_values(self, product_ids):
         vals = {}

--- a/product_extended_segmentation/tests/test_avg_costs.py
+++ b/product_extended_segmentation/tests/test_avg_costs.py
@@ -32,8 +32,10 @@ class TestAvgCosts(TransactionCase):
 
     def setUp(self):
         super(TestAvgCosts, self).setUp()
+        self.product = self.env['product.product']
         self.prod_template = self.env['product.template']
         self.wizard = self.env['wizard.price']
+        self.company_id = self.env.user.company_id
         self.prod_a_id = self.env.ref(
             'product_extended_segmentation.producto_a')
         self.prod_b_id = self.env.ref(
@@ -47,6 +49,18 @@ class TestAvgCosts(TransactionCase):
         self.product_ids = [self.prod_a_id,
                             self.prod_b_id,
                             self.prod_c_id]
+
+    def test_00_cron_methods(self):
+        sgmnts = {}
+        self.company_id.write({'std_price_neg_threshold': 0})
+        sgmnts['before'] = [getattr(self.prod_e_id, fieldname)
+                            for fieldname in SEGMENTATION_COST]
+        self.assertEqual(sum(sgmnts['before']), 0.0, 'sgmnts should be 0.0')
+        self.product.update_material_cost_on_zero_segmentation()
+        self.prod_e_id.refresh()
+        sgmnts['after'] = [getattr(self.prod_e_id, fieldname)
+                           for fieldname in SEGMENTATION_COST]
+        self.assertEqual(sum(sgmnts['after']), 75.0, 'Segments should be 75.0')
 
     def get_store_product_values(self, product_ids):
         vals = {}

--- a/product_extended_segmentation/tests/test_avg_costs.py
+++ b/product_extended_segmentation/tests/test_avg_costs.py
@@ -110,5 +110,5 @@ class TestAvgCosts(TransactionCase):
         res = self.env['product.template'].compute_price(
             product_ids=False, recursive=True,  real_time_accounting=False,
             template_ids=[template_id.id], test=True)
-        self.assertEqual(res,
+        self.assertEqual(str(res),
                          '{{{0}: 75.0}}'.format(str(template_id.id)))

--- a/product_extended_segmentation/tests/test_wizard.py
+++ b/product_extended_segmentation/tests/test_wizard.py
@@ -21,6 +21,7 @@
 ##############################################################################
 from openerp.tests.common import TransactionCase
 from openerp.tools.safe_eval import safe_eval
+from openerp.exceptions import ValidationError
 
 
 class TestWizard(TransactionCase):
@@ -79,6 +80,10 @@ class TestWizard(TransactionCase):
                          '{{{0}: 35.0}}'.format(str(self.producto_d_id.id)))
 
     def test_01_test_threshold_no_update(self):
+        msg_error = 'Bottom cost threshold must be positive'
+        with self.assertRaisesRegexp(ValidationError, msg_error):
+            self.company_id.write({'std_price_neg_threshold': -1})
+
         self.company_id.write({'std_price_neg_threshold': 0})
         # ============================
         # ==== PRODUCT D

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -24,11 +24,11 @@ class StockCardProduct(models.TransientModel):
 
     def map_field2write(self, field2write):
         res = {}
-        FIELD_NAMES = self._get_fieldnames()
+        field_names = self._get_fieldnames()
         for fn in field2write.keys():
-            if fn not in FIELD_NAMES:
+            if fn not in field_names:
                 continue
-            res[FIELD_NAMES[fn]] = field2write[fn]
+            res[field_names[fn]] = field2write[fn]
         return res
 
     def write_standard_price(self, product_id, field2write):

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -115,15 +115,18 @@ class StockCardProduct(models.TransientModel):
     def _get_price_on_supplier_return(self, row, vals, qntval):
         vals['product_qty'] += (vals['direction'] * row['product_qty'])
         sm_obj = self.env['stock.move']
-        move_id = row['move_id']
-        move_brw = sm_obj.browse(move_id)
+        move_id = sm_obj.browse(row['move_id'])
+        product_id = self.env['product.product'].browse(row['product_id'])
         # Cost is the one record in the stock_move, cost in the
         # quant record includes other segmentation cost: landed_cost,
         # material_cost, production_cost, subcontracting_cost
         # Inventory Value has to be decreased by the amount of purchase
         # TODO: BEWARE price_unit needs to be normalised
-        vals['move_valuation'] = sum([move_brw.price_unit * qnt['qty']
-                                      for qnt in qntval])
+        price = move_id.price_unit
+        if product_id.cost_method == 'average':
+            price = vals['average']
+
+        vals['move_valuation'] = sum([price * qnt['qty'] for qnt in qntval])
         return True
 
     def _get_price_on_supplied(self, row, vals, qntval):

--- a/stock_card/tests/test_stock_card.py
+++ b/stock_card/tests/test_stock_card.py
@@ -96,6 +96,11 @@ class TestStockCard(TransactionCase):
             inv_id = self.create_inventory(self.product_id, val['qty'])
             inv_id.action_done()
 
+        qty = self.scp.get_qty(self.product_id.id)
+        self.assertEqual(qty, 4,
+                         'Current Stock for {0} MUST BE 4 units'.
+                         format(self.product_id.name))
+
         scp_id = self.scp.create({
             'product_id': self.product_id.id
         })

--- a/stock_card/tests/test_stock_card_product_returns.py
+++ b/stock_card/tests/test_stock_card_product_returns.py
@@ -55,12 +55,12 @@ class TestStockCardProductReturns(TransactionCase):
 
         # separate in time all transactions
         delta = 0
-        for k, v in self.values:
-            obj = self.env.ref('stock_card.'+k)
+        for trx in [f[0] for f in self.values]:
+            obj = self.env.ref('stock_card.'+trx)
             move_ids = {}
-            if k.startswith('sc_'):
+            if trx.startswith('sc_'):
                 move_ids = obj.picking_ids.mapped('move_lines')
-            elif k.startswith('pick_'):
+            elif trx.startswith('pick_'):
                 move_ids = obj.move_lines
             for move_id in move_ids:
                 delta += 1

--- a/stock_card/tests/test_stock_card_product_returns.py
+++ b/stock_card/tests/test_stock_card_product_returns.py
@@ -49,7 +49,7 @@ class TestStockCardProductReturns(TransactionCase):
                           'mov_val': 1100, 'inv_val': 1450}),
             ('sc_po_04', {'cost': 400, 'qty': 10, 'avg': 265, 'mov_val': 1200,
                           'inv_val': 2650}),
-            ('pick_02_sc_po_03', {'cost': 220, 'qty': 8, 'avg': 276.25,
+            ('pick_02_sc_po_03', {'cost': 220, 'qty': 8, 'avg': 265.0,
                                   'mov_val': -440, 'inv_val': 2210}),
         ]
 
@@ -89,28 +89,28 @@ class TestStockCardProductReturns(TransactionCase):
                                               precision_rounding=1),
                              "Average Cost current={0} expected={1} is not "
                              "the expected: {2}".
-                             format(expected['avg'],
-                                    succeed['average'], expected))
+                             format(succeed['avg'],
+                                    expected['average'], expected))
 
             self.assertEqual(expected['cost'],
                              succeed['cost_unit'],
                              "Unit Cost current={0} expected={1} is not "
                              "the expected: {2}".
-                             format(expected['cost'],
-                                    succeed['cost_unit'], expected))
+                             format(succeed['cost'],
+                                    expected['cost_unit'], expected))
 
             self.assertEqual(0, float_compare(expected['inv_val'],
                                               succeed['inventory_valuation'],
                                               precision_rounding=1),
                              "Inventory Value current={0} expected={1} is not "
                              "match: {2}".
-                             format(expected['inv_val'],
-                                    succeed['inventory_valuation'], expected))
+                             format(succeed['inv_val'],
+                                    expected['inventory_valuation'], expected))
 
             self.assertEqual(0, float_compare(expected['mov_val'],
                                               succeed['move_valuation'],
                                               precision_rounding=1),
                              "Movement Value current={0} expected={1} is not "
                              "match: {2}".
-                             format(expected['mov_val'],
-                                    succeed['move_valuation'], expected))
+                             format(succeed['mov_val'],
+                                    expected['move_valuation'], expected))

--- a/stock_card/tests/test_stock_card_product_returns.py
+++ b/stock_card/tests/test_stock_card_product_returns.py
@@ -89,28 +89,28 @@ class TestStockCardProductReturns(TransactionCase):
                                               precision_rounding=1),
                              "Average Cost current={0} expected={1} is not "
                              "the expected: {2}".
-                             format(succeed['avg'],
-                                    expected['average'], expected))
+                             format(succeed['average'],
+                                    expected['avg'], expected))
 
             self.assertEqual(expected['cost'],
                              succeed['cost_unit'],
                              "Unit Cost current={0} expected={1} is not "
                              "the expected: {2}".
-                             format(succeed['cost'],
-                                    expected['cost_unit'], expected))
+                             format(succeed['cost_unit'],
+                                    expected['cost'], expected))
 
             self.assertEqual(0, float_compare(expected['inv_val'],
                                               succeed['inventory_valuation'],
                                               precision_rounding=1),
                              "Inventory Value current={0} expected={1} is not "
                              "match: {2}".
-                             format(succeed['inv_val'],
-                                    expected['inventory_valuation'], expected))
+                             format(succeed['inventory_valuation'],
+                                    expected['inv_val'], expected))
 
             self.assertEqual(0, float_compare(expected['mov_val'],
                                               succeed['move_valuation'],
                                               precision_rounding=1),
                              "Movement Value current={0} expected={1} is not "
                              "match: {2}".
-                             format(succeed['mov_val'],
-                                    expected['move_valuation'], expected))
+                             format(succeed['move_valuation'],
+                                    expected['mov_val'], expected))

--- a/stock_card/tests/test_stock_card_product_returns.py
+++ b/stock_card/tests/test_stock_card_product_returns.py
@@ -49,7 +49,7 @@ class TestStockCardProductReturns(TransactionCase):
                           'mov_val': 1100, 'inv_val': 1450}),
             ('sc_po_04', {'cost': 400, 'qty': 10, 'avg': 265, 'mov_val': 1200,
                           'inv_val': 2650}),
-            ('pick_02_sc_po_03', {'cost': 220, 'qty': 8, 'avg': 265.0,
+            ('pick_02_sc_po_03', {'cost': 220, 'qty': 8, 'avg': 276.25,
                                   'mov_val': -440, 'inv_val': 2210}),
         ]
 

--- a/stock_landed_costs_average/demo/account_invoice_demo.xml
+++ b/stock_landed_costs_average/demo/account_invoice_demo.xml
@@ -91,5 +91,14 @@
             <field name="split_method">by_quantity</field>
             <field name="price_unit">100</field>
         </record>
+        <record id="product_mouse" model="product.product">
+           <field name="name">Targus White Mouse</field>
+           <field name="type">product</field>
+           <field name="cost_method">average</field>
+           <field name="valuation">real_time</field>
+           <field name="standard_price">10</field>
+           <field name="property_stock_account_input" ref="account.o_expense"/>
+           <field name="property_stock_account_output" ref="account.o_income"/>
+        </record>
     </data>
 </openerp>

--- a/stock_landed_costs_average/demo/account_invoice_demo.xml
+++ b/stock_landed_costs_average/demo/account_invoice_demo.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" ?>
 <openerp>
     <data noupdate="1">
+        <record id="freight_account" model="account.account">
+            <field name="code">X2016-FACCT</field>
+            <field name="name">freight cost acct</field>
+            <field ref="account.cli" name="parent_id"/>
+            <field name="type">other</field>
+            <field name="user_type" ref="account.data_account_type_expense"/>
+        </record>
         <record id="product_average_realtime_landed_cost_1" model="product.product">
             <field name="name">Average Product to Valuate with Landed Costs</field>
             <field name="cost_method">average</field>

--- a/stock_landed_costs_average/tests/__init__.py
+++ b/stock_landed_costs_average/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_basics
 from . import test_stock_landed_costs_average
 from . import test_landed_costs_with_std
+from . import test_landed_cost_average

--- a/stock_landed_costs_average/tests/__init__.py
+++ b/stock_landed_costs_average/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_basics
 from . import test_stock_landed_costs_average
 from . import test_landed_costs_with_std
 from . import test_landed_cost_average
+from . import test_landed_cost_revert

--- a/stock_landed_costs_average/tests/__init__.py
+++ b/stock_landed_costs_average/tests/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from . import test_stock_landed_common
 from . import test_basics
 from . import test_stock_landed_costs_average
 from . import test_landed_costs_with_std

--- a/stock_landed_costs_average/tests/test_basics.py
+++ b/stock_landed_costs_average/tests/test_basics.py
@@ -2,6 +2,7 @@
 
 from openerp.tests.common import TransactionCase
 from openerp.exceptions import except_orm, Warning as UserError
+from openerp.osv import osv
 
 
 class TestBasics(TransactionCase):
@@ -11,6 +12,9 @@ class TestBasics(TransactionCase):
         self.company_id = self.env.ref('base.main_company')
         self.slc = self.env['stock.landed.cost']
         self.slc_id = self.env.ref('stock_landed_costs_average.slc_02')
+        self.invoice_id = self.env.ref('stock_landed_costs_average.'
+                                       'invoice_landing_costs_average_1')
+        self.attacher = self.env['attach.invoice.to.landed.costs.wizard']
         self.vals = {
             'gain_acct_id':
             self.company_id.gain_inventory_deviation_account_id.id,
@@ -86,3 +90,20 @@ class TestBasics(TransactionCase):
         msg_error = 'The selected picking does not contain any move that.*'
         with self.assertRaisesRegexp(except_orm, msg_error):
             self.slc_id.get_valuation_lines(picking_ids)
+
+    def test_07_attach_invoice_to_landed_cost(self):
+        self.attach_id = self.attacher.with_context({
+            'active_id': self.invoice_id.id,
+            'active_ids': self.invoice_id.ids,
+            'res_model': self.invoice_id.name
+        }).create({'stock_landed_cost_id': self.slc_id.id})
+        self.attach_id.add_landed_costs()
+        self.assertTrue(self.invoice_id.stock_landed_cost_id.id,
+                        "Invoice doesn't have Landed Cost document related")
+
+        self.slc_id.write({
+            'state': 'done'
+        })
+        msg_error = 'You cannot change to another Landed Costs.*'
+        with self.assertRaisesRegexp(osv.except_osv, msg_error):
+            self.attach_id.add_landed_costs()

--- a/stock_landed_costs_average/tests/test_basics.py
+++ b/stock_landed_costs_average/tests/test_basics.py
@@ -76,3 +76,13 @@ class TestBasics(TransactionCase):
         self.assertEquals(
             self.slc_id.valuation_adjustment_lines[0].additional_landed_cost,
             -100)
+
+    def test_06_real_time_valuations(self):
+        self.assertEqual(self.slc_id.get_valuation_lines(), [])
+        for picking_id in self.slc_id.picking_ids:
+            for move_id in picking_id.move_lines:
+                move_id.product_id.write({'valuation': 'manual_periodic'})
+        picking_ids = [pid.id for pid in self.slc_id.picking_ids]
+        msg_error = 'The selected picking does not contain any move that.*'
+        with self.assertRaisesRegexp(except_orm, msg_error):
+            res = self.slc_id.get_valuation_lines(picking_ids)

--- a/stock_landed_costs_average/tests/test_basics.py
+++ b/stock_landed_costs_average/tests/test_basics.py
@@ -85,4 +85,4 @@ class TestBasics(TransactionCase):
         picking_ids = [pid.id for pid in self.slc_id.picking_ids]
         msg_error = 'The selected picking does not contain any move that.*'
         with self.assertRaisesRegexp(except_orm, msg_error):
-            res = self.slc_id.get_valuation_lines(picking_ids)
+            self.slc_id.get_valuation_lines(picking_ids)

--- a/stock_landed_costs_average/tests/test_landed_cost_average.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_average.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+
+from openerp.tests.common import TransactionCase
+from openerp.exceptions import except_orm, Warning as UserError
+
+
+class TestLandedCostAverage(TransactionCase):
+
+    def setUp(self):
+        super(TestLandedCostAverage, self).setUp()
+        self.company_id = self.env.ref('base.main_company')
+        self.slc = self.env['stock.landed.cost']
+        self.slc_id = self.env.ref('stock_landed_costs_average.slc_02')
+        self.delta = 0
+        self.next_hour = datetime.strptime('2016-01-01 01:00:00',
+                                           '%Y-%m-%d %H:%M:%S')
+        self.picking = self.env['stock.picking']
+        self.move = self.env['stock.move']
+        self.customer_location = self.env.ref('stock.stock_location_customers')
+        self.supplier_location = self.env.ref('stock.stock_location_suppliers')
+        self.stock_location = self.env.ref('stock.stock_location_stock')
+
+        self.transactions = [
+            {  # 1 buy 8 items
+                'name': 'slca_po_01',
+                'is_po': True, 'is_return': False, 'cost': 10, 'qty': 8,
+                'avg': 10, 'move_val': 80, 'inv_val': 80,
+            },
+            {  # 2 buy 4 items
+                'name': 'slca_po_02',
+                'is_po': True, 'is_return': False, 'cost': 16, 'qty': 4,
+                'avg': 20, 'move_val': 40, 'inv_val': 40,
+            },
+            {  # 3 sale 10 items
+                'name': 'slca_so_01',
+                'is_po': False, 'is_return': False, 'cost': 12, 'qty': 10,
+                'avg': 12, 'move_val': 120, 'inv_val': 24,
+            },
+            {  # 4 sale 1 item
+                'name': 'slca_so_02',
+                'is_po': False, 'is_return': False, 'cost': 12, 'qty': 1,
+                'avg': 12, 'move_val': 12, 'inv_val': 12,
+            },
+            {  # 5 vendor return 1 item
+                'name': 'slca_ret_po_01',
+                'is_po': True, 'is_return': True, 'cost': 12, 'qty': 1,
+                'avg': 12, 'move_val': 12, 'inv_val': 0,
+                'origin_name': 'po_01',
+            },
+        ]
+
+    def dummy_function(self, move_lines):
+        for move_id in move_lines:
+            self.delta += 1
+            self.next_hour = datetime.strptime(
+                '2016-01-01 01:00:00',
+                '%Y-%m-%d %H:%M:%S') + timedelta(hours=self.delta)
+            move_id.write({'date': self.next_hour})
+
+    def do_picking_wf(self, picking_id):
+        picking_id.action_confirm()
+        wizard_id = self.wizard.create({
+            'picking_id': picking_id.id,
+        })
+
+        for move_id in picking_id.move_lines:
+            self.wizard_item.create({
+                'transfer_id': wizard_id.id,
+                'product_id': move_id.product_id.id,
+                'quantity': move_id.product_qty,
+                'sourceloc_id': move_id.location_id.id,
+                'destinationloc_id': move_id.location_dest_id.id,
+                'product_uom_id': move_id.product_uom.id,
+            })
+
+        wizard_id.do_detailed_transfer()
+
+    def do_picking(self, picking_ids):
+        if not picking_ids:
+            return
+
+        for picking_id in picking_ids:
+            self.do_picking_wf(picking_id)
+            self.assertEqual(picking_id.state, 'done')
+            self.dummy_function(picking_id.move_lines)
+
+    def create_purchase_order(self, vals):
+        qty = vals['qty']
+        cost = vals['cost']
+        purchase_order_id = self.purchase_order.create({
+            'partner_id': self.partner_id.id,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'pricelist_id': self.ref('purchase.list0'),
+            'order_line': [(0, 0, {
+                'name': "{0} (qty={1}, cost={2})".format(self.product_id.name,
+                                                         qty, cost),
+                'product_id': self.product_id.id,
+                'price_unit': cost,
+                'product_qty': qty,
+                'date_planned': datetime.now().strftime('%Y-%m-%d'),
+            })]
+        })
+
+        purchase_order_id.wkf_confirm_order()
+        purchase_order_id.action_invoice_create()
+        purchase_order_id.action_picking_create()
+        self.do_picking(purchase_order_id.picking_ids)
+
+    def create_sale_order(self, vals):
+        qty = vals['qty']
+        price = vals['cost']
+        sale_order_id = self.sale_order.create({
+            'partner_id': self.partner_id.id,
+            'client_order_ref': "Sale Order (qty={0}, price={1})".format(
+                str(qty), str(price)),
+            'order_policy': 'manual',
+            'order_line': [(0, 0, {
+                'product_id': self.product_id.id,
+                'product_uom_qty': qty,
+                'price_unit': price,
+            })]
+        })
+
+        sale_order_id.action_button_confirm()
+        self.do_picking(sale_order_id.picking_ids)
+        return sale_order_id
+
+    def get_location(self, is_po, is_return):
+
+        if is_po and not is_return:
+            return self.supplier_location.id, self.stock_location.id
+        if is_po and is_return:
+            return self.stock_location.id, self.supplier_location.id
+        if not is_po and not is_return:
+            return self.stock_location.id, self.customer_location.id
+        if not is_po and is_return:
+            return self.customer_location.id, self.stock_location.id
+
+    def get_origin_by_name(self, origin_name):
+        for trx in self.transactions:
+            if trx['name'] == origin_name:
+                return trx['id']
+        return False
+
+    def create_return(self, vals):
+        qty = vals['qty']
+        location_id, location_dest_id = self.get_locations(vals['is_po'],
+                                                           vals['is_return'])
+        picking_id = self.picking.create({
+            'name': vals['partner_id'].name + ' ' + str(qty),
+            'partner_id': vals['partner_id'].id,
+            'move_type': one,
+            'priority': 1,
+            'picking_type': self.ref('stock.picking_type_internal'),
+        })
+
+        move_id = self.move.create({
+            'origin': vals['partner_id'].name + ' ' + str(picking_id.id),
+            'name': vals['partner_id'].name + ' ' + str(picking_id.id),
+            'picking_id': picking_id.id,
+            'location_id': location_id,
+            'location_dest_id': location_dest_id,
+            'product_uom': self.ref('product.product_uom_unit'),
+            'product_uom_qty': 1,
+            'price_unit': qty,
+            'origin_returned_move_id': vals['origin_id'],
+        })
+
+        do_picking_wf(picking_id)
+        self.assertEqual(picking_id.state, 'done')
+        self.dummy_function(picking_id.move_lines)
+
+    def test_01_do_transactions(self):
+        for trx in self.transactions:
+
+            # purchase
+            if trx['is_po'] and not trx['is_return']:
+                self.create_purchase_order(trx)
+
+            # vendor return
+            if trx['is_po'] and trx['is_return']:
+                trx['id'] = self.create_supplier_return(trx)
+
+            # sale
+            if not trx['is_po'] and not trx['is_return']:
+                id = self.create_sale_order(trx)

--- a/stock_landed_costs_average/tests/test_landed_cost_average.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_average.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from openerp.tests.common import TransactionCase
-from openerp.exceptions import except_orm, Warning as UserError
 from datetime import datetime, timedelta
 from openerp.tools.safe_eval import safe_eval
 

--- a/stock_landed_costs_average/tests/test_landed_cost_average.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_average.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from test_stock_landed_common import TestStockLandedCommon
+from openerp.addons.stock_landed_costs_average.tests.test_stock_landed_common \
+    import TestStockLandedCommon
 
 
 class TestLandedCostAverage(TestStockLandedCommon):

--- a/stock_landed_costs_average/tests/test_landed_cost_average.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_average.py
@@ -2,6 +2,8 @@
 
 from openerp.tests.common import TransactionCase
 from openerp.exceptions import except_orm, Warning as UserError
+from datetime import datetime, timedelta
+from openerp.tools.safe_eval import safe_eval
 
 
 class TestLandedCostAverage(TransactionCase):
@@ -19,7 +21,17 @@ class TestLandedCostAverage(TransactionCase):
         self.customer_location = self.env.ref('stock.stock_location_customers')
         self.supplier_location = self.env.ref('stock.stock_location_suppliers')
         self.stock_location = self.env.ref('stock.stock_location_stock')
-
+        self.supplier_id = self.env.ref('base.res_partner_13')
+        self.customer_id = self.env.ref('base.res_partner_23')
+        self.purchase_order = self.env['purchase.order']
+        self.sale_order = self.env['sale.order']
+        self.product_id = self.env.ref(
+            'stock_landed_costs_average.product_mouse')
+        self.wizard = self.env['stock.transfer_details']
+        self.wizard_item = self.env['stock.transfer_details_items']
+        self.transfer_details = self.env['stock.transfer_details']
+        self.return_picking = self.env['stock.return.picking']
+        self.return_picking_line = self.env['stock.return.picking.line']
         self.transactions = [
             {  # 1 buy 8 items
                 'name': 'slca_po_01',
@@ -40,12 +52,13 @@ class TestLandedCostAverage(TransactionCase):
                 'name': 'slca_so_02',
                 'is_po': False, 'is_return': False, 'cost': 12, 'qty': 1,
                 'avg': 12, 'move_val': 12, 'inv_val': 12,
+                'origin_name': 'po_01',
             },
             {  # 5 vendor return 1 item
                 'name': 'slca_ret_po_01',
                 'is_po': True, 'is_return': True, 'cost': 12, 'qty': 1,
                 'avg': 12, 'move_val': 12, 'inv_val': 0,
-                'origin_name': 'po_01',
+                'origin_name': 'slca_po_01', 'partner_id': self.supplier_id,
             },
         ]
 
@@ -88,7 +101,7 @@ class TestLandedCostAverage(TransactionCase):
         qty = vals['qty']
         cost = vals['cost']
         purchase_order_id = self.purchase_order.create({
-            'partner_id': self.partner_id.id,
+            'partner_id': self.supplier_id.id,
             'location_id': self.ref('stock.stock_location_stock'),
             'pricelist_id': self.ref('purchase.list0'),
             'order_line': [(0, 0, {
@@ -105,12 +118,13 @@ class TestLandedCostAverage(TransactionCase):
         purchase_order_id.action_invoice_create()
         purchase_order_id.action_picking_create()
         self.do_picking(purchase_order_id.picking_ids)
+        return purchase_order_id
 
     def create_sale_order(self, vals):
         qty = vals['qty']
         price = vals['cost']
         sale_order_id = self.sale_order.create({
-            'partner_id': self.partner_id.id,
+            'partner_id': self.customer_id.id,
             'client_order_ref': "Sale Order (qty={0}, price={1})".format(
                 str(qty), str(price)),
             'order_policy': 'manual',
@@ -125,7 +139,7 @@ class TestLandedCostAverage(TransactionCase):
         self.do_picking(sale_order_id.picking_ids)
         return sale_order_id
 
-    def get_location(self, is_po, is_return):
+    def get_locations(self, is_po, is_return):
 
         if is_po and not is_return:
             return self.supplier_location.id, self.stock_location.id
@@ -136,51 +150,56 @@ class TestLandedCostAverage(TransactionCase):
         if not is_po and is_return:
             return self.customer_location.id, self.stock_location.id
 
-    def get_origin_by_name(self, origin_name):
+    def get_origin_picking(self, origin_name):
         for trx in self.transactions:
             if trx['name'] == origin_name:
-                return trx['id']
+                return trx['id'].picking_ids
         return False
 
     def create_return(self, vals):
         qty = vals['qty']
         location_id, location_dest_id = self.get_locations(vals['is_po'],
                                                            vals['is_return'])
-        picking_id = self.picking.create({
-            'name': vals['partner_id'].name + ' ' + str(qty),
-            'partner_id': vals['partner_id'].id,
-            'move_type': one,
-            'priority': 1,
-            'picking_type': self.ref('stock.picking_type_internal'),
-        })
+        for picking_id in vals['origin_id']:
+            return_id = self.return_picking.with_context({
+                'active_id': picking_id.id,
+                'active_ids': picking_id.ids,
+                'active_model': 'stock.picking',
+            }).create({})
 
-        move_id = self.move.create({
-            'origin': vals['partner_id'].name + ' ' + str(picking_id.id),
-            'name': vals['partner_id'].name + ' ' + str(picking_id.id),
-            'picking_id': picking_id.id,
-            'location_id': location_id,
-            'location_dest_id': location_dest_id,
-            'product_uom': self.ref('product.product_uom_unit'),
-            'product_uom_qty': 1,
-            'price_unit': qty,
-            'origin_returned_move_id': vals['origin_id'],
-        })
-
-        do_picking_wf(picking_id)
-        self.assertEqual(picking_id.state, 'done')
-        self.dummy_function(picking_id.move_lines)
+            return_lines = []
+            for move_id in picking_id.move_lines:
+                return_line_id = self.return_picking_line.create({
+                    'product_id': self.product_id.id,
+                    'quantity': qty,
+                    'wizard_id': return_id.id,
+                    'move_id': move_id.id
+                })
+                return_lines.append(return_line_id)
+            res = return_id.create_returns()
+            picking_id = safe_eval(res['domain'])[0][2][0]
+            picking_id = self.picking.browse(picking_id)
+            self.do_picking_wf(picking_id)
+            self.assertEqual(picking_id.state, 'done')
+            self.dummy_function(picking_id.move_lines)
+        return picking_id.id
 
     def test_01_do_transactions(self):
         for trx in self.transactions:
-
             # purchase
             if trx['is_po'] and not trx['is_return']:
-                self.create_purchase_order(trx)
+                trx['id'] = self.create_purchase_order(trx)
 
             # vendor return
             if trx['is_po'] and trx['is_return']:
-                trx['id'] = self.create_supplier_return(trx)
+                trx['origin_id'] = self.get_origin_picking(trx['origin_name'])
+                trx['id'] = self.create_return(trx)
 
             # sale
             if not trx['is_po'] and not trx['is_return']:
-                id = self.create_sale_order(trx)
+                trx['id'] = self.create_sale_order(trx)
+        card_lines = self.env['stock.card.product'].\
+            _stock_card_move_get(self.product_id.id)['res']
+        last_item = card_lines[-1]
+        self.assertEqual(last_item['product_qty'], 0)
+        self.assertEqual(last_item['inventory_valuation'], 0)

--- a/stock_landed_costs_average/tests/test_landed_cost_average.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_average.py
@@ -1,36 +1,21 @@
 # -*- coding: utf-8 -*-
 
-from openerp.tests.common import TransactionCase
-from datetime import datetime, timedelta
-from openerp.tools.safe_eval import safe_eval
+from stock_landed_costs_average.tests.test_stock_landed_common \
+    import TestStockLandedCommon
 
 
-class TestLandedCostAverage(TransactionCase):
+class TestLandedCostAverage(TestStockLandedCommon):
 
     def setUp(self):
         super(TestLandedCostAverage, self).setUp()
         self.company_id = self.env.ref('base.main_company')
-        self.slc = self.env['stock.landed.cost']
         self.slc_id = self.env.ref('stock_landed_costs_average.slc_02')
-        self.delta = 0
-        self.next_hour = datetime.strptime('2016-01-01 01:00:00',
-                                           '%Y-%m-%d %H:%M:%S')
-        self.picking = self.env['stock.picking']
-        self.move = self.env['stock.move']
         self.customer_location = self.env.ref('stock.stock_location_customers')
         self.supplier_location = self.env.ref('stock.stock_location_suppliers')
-        self.stock_location = self.env.ref('stock.stock_location_stock')
         self.supplier_id = self.env.ref('base.res_partner_13')
         self.customer_id = self.env.ref('base.res_partner_23')
-        self.purchase_order = self.env['purchase.order']
-        self.sale_order = self.env['sale.order']
         self.product_id = self.env.ref(
             'stock_landed_costs_average.product_mouse')
-        self.wizard = self.env['stock.transfer_details']
-        self.wizard_item = self.env['stock.transfer_details_items']
-        self.transfer_details = self.env['stock.transfer_details']
-        self.return_picking = self.env['stock.return.picking']
-        self.return_picking_line = self.env['stock.return.picking.line']
         self.transactions = [
             {  # 1 buy 8 items
                 'name': 'slca_po_01',
@@ -61,127 +46,11 @@ class TestLandedCostAverage(TransactionCase):
             },
         ]
 
-    def dummy_function(self, move_lines):
-        for move_id in move_lines:
-            self.delta += 1
-            self.next_hour = datetime.strptime(
-                '2016-01-01 01:00:00',
-                '%Y-%m-%d %H:%M:%S') + timedelta(hours=self.delta)
-            move_id.write({'date': self.next_hour})
-
-    def do_picking_wf(self, picking_id):
-        picking_id.action_confirm()
-        wizard_id = self.wizard.create({
-            'picking_id': picking_id.id,
-        })
-
-        for move_id in picking_id.move_lines:
-            self.wizard_item.create({
-                'transfer_id': wizard_id.id,
-                'product_id': move_id.product_id.id,
-                'quantity': move_id.product_qty,
-                'sourceloc_id': move_id.location_id.id,
-                'destinationloc_id': move_id.location_dest_id.id,
-                'product_uom_id': move_id.product_uom.id,
-            })
-
-        wizard_id.do_detailed_transfer()
-
-    def do_picking(self, picking_ids):
-        if not picking_ids:
-            return
-
-        for picking_id in picking_ids:
-            self.do_picking_wf(picking_id)
-            self.assertEqual(picking_id.state, 'done')
-            self.dummy_function(picking_id.move_lines)
-
-    def create_purchase_order(self, vals):
-        qty = vals['qty']
-        cost = vals['cost']
-        purchase_order_id = self.purchase_order.create({
-            'partner_id': self.supplier_id.id,
-            'location_id': self.ref('stock.stock_location_stock'),
-            'pricelist_id': self.ref('purchase.list0'),
-            'order_line': [(0, 0, {
-                'name': "{0} (qty={1}, cost={2})".format(self.product_id.name,
-                                                         qty, cost),
-                'product_id': self.product_id.id,
-                'price_unit': cost,
-                'product_qty': qty,
-                'date_planned': datetime.now().strftime('%Y-%m-%d'),
-            })]
-        })
-
-        purchase_order_id.wkf_confirm_order()
-        purchase_order_id.action_invoice_create()
-        purchase_order_id.action_picking_create()
-        self.do_picking(purchase_order_id.picking_ids)
-        return purchase_order_id
-
-    def create_sale_order(self, vals):
-        qty = vals['qty']
-        price = vals['cost']
-        sale_order_id = self.sale_order.create({
-            'partner_id': self.customer_id.id,
-            'client_order_ref': "Sale Order (qty={0}, price={1})".format(
-                str(qty), str(price)),
-            'order_policy': 'manual',
-            'order_line': [(0, 0, {
-                'product_id': self.product_id.id,
-                'product_uom_qty': qty,
-                'price_unit': price,
-            })]
-        })
-
-        sale_order_id.action_button_confirm()
-        self.do_picking(sale_order_id.picking_ids)
-        return sale_order_id
-
-    def get_locations(self, is_po, is_return):
-
-        if is_po and not is_return:
-            return self.supplier_location.id, self.stock_location.id
-        if is_po and is_return:
-            return self.stock_location.id, self.supplier_location.id
-        if not is_po and not is_return:
-            return self.stock_location.id, self.customer_location.id
-        if not is_po and is_return:
-            return self.customer_location.id, self.stock_location.id
-
     def get_origin_picking(self, origin_name):
         for trx in self.transactions:
             if trx['name'] == origin_name:
                 return trx['id'].picking_ids
         return False
-
-    def create_return(self, vals):
-        qty = vals['qty']
-        location_id, location_dest_id = self.get_locations(vals['is_po'],
-                                                           vals['is_return'])
-        for picking_id in vals['origin_id']:
-            return_id = self.return_picking.with_context({
-                'active_id': picking_id.id,
-                'active_ids': picking_id.ids,
-                'active_model': 'stock.picking',
-            }).create({})
-
-            return_lines = []
-            for move_id in picking_id.move_lines:
-                return_line_id = self.return_picking_line.create({
-                    'product_id': self.product_id.id,
-                    'quantity': qty,
-                    'wizard_id': return_id.id,
-                    'move_id': move_id.id
-                })
-                return_lines.append(return_line_id)
-            res = return_id.create_returns()
-            picking_id = safe_eval(res['domain'])[0][2][0]
-            picking_id = self.picking.browse(picking_id)
-            self.do_picking_wf(picking_id)
-            self.assertEqual(picking_id.state, 'done')
-            self.dummy_function(picking_id.move_lines)
-        return picking_id.id
 
     def test_01_do_transactions(self):
         for trx in self.transactions:

--- a/stock_landed_costs_average/tests/test_landed_cost_average.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_average.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from stock_landed_costs_average.tests.test_stock_landed_common \
-    import TestStockLandedCommon
+from test_stock_landed_common import TestStockLandedCommon
 
 
 class TestLandedCostAverage(TestStockLandedCommon):

--- a/stock_landed_costs_average/tests/test_landed_cost_revert.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_revert.py
@@ -1,33 +1,23 @@
 # -*- coding: utf-8 -*-
 
-from openerp.tests.common import TransactionCase
-from datetime import datetime, timedelta
+from stock_landed_costs_average.tests.test_stock_landed_common \
+    import TestStockLandedCommon
 
 
-class TestLandedCostRevert(TransactionCase):
+class TestLandedCostRevert(TestStockLandedCommon):
 
     def setUp(self):
         super(TestLandedCostRevert, self).setUp()
         self.company_id = self.env.ref('base.main_company')
-        self.slc = self.env['stock.landed.cost']
         self.slc_id = self.env.ref('stock_landed_costs_average.slc_02')
-        self.delta = 0
-        self.next_hour = datetime.strptime('2016-01-01 01:00:00',
-                                           '%Y-%m-%d %H:%M:%S')
+
         self.product_freight_id = self.env.ref(
             'stock_landed_costs_average'
             '.service_standard_periodic_landed_cost_1')
         self.account_freight_id = self.env.ref(
             'stock_landed_costs_average.freight_account')
-        self.picking = self.env['stock.picking']
-        self.move = self.env['stock.move']
-        self.purchase_order = self.env['purchase.order']
-        self.sale_order = self.env['sale.order']
         self.product_id = self.env.ref(
             'stock_landed_costs_average.product_mouse')
-        self.wizard = self.env['stock.transfer_details']
-        self.wizard_item = self.env['stock.transfer_details_items']
-        self.transfer_details = self.env['stock.transfer_details']
         self.supplier_id = self.env.ref('base.res_partner_13')
         self.customer_id = self.env.ref('base.res_partner_23')
         self.transactions = [
@@ -67,87 +57,6 @@ class TestLandedCostRevert(TransactionCase):
             },
         }
 
-    def dummy_function(self, move_lines):
-        for move_id in move_lines:
-            self.delta += 1
-            self.next_hour = datetime.strptime(
-                '2016-01-01 01:00:00',
-                '%Y-%m-%d %H:%M:%S') + timedelta(hours=self.delta)
-            move_id.write({'date': self.next_hour})
-
-    def do_picking_wf(self, picking_id):
-        picking_id.action_confirm()
-        wizard_id = self.wizard.create({
-            'picking_id': picking_id.id,
-        })
-
-        for move_id in picking_id.move_lines:
-            self.wizard_item.create({
-                'transfer_id': wizard_id.id,
-                'product_id': move_id.product_id.id,
-                'quantity': move_id.product_qty,
-                'sourceloc_id': move_id.location_id.id,
-                'destinationloc_id': move_id.location_dest_id.id,
-                'product_uom_id': move_id.product_uom.id,
-            })
-
-        wizard_id.do_detailed_transfer()
-
-    def do_picking(self, picking_ids):
-        if not picking_ids:
-            return
-
-        for picking_id in picking_ids:
-            self.do_picking_wf(picking_id)
-            self.assertEqual(picking_id.state, 'done')
-            self.dummy_function(picking_id.move_lines)
-
-    def create_purchase_order(self, vals):
-        qty = vals['qty']
-        cost = vals['cost']
-        purchase_order_id = self.purchase_order.create({
-            'partner_id': self.supplier_id.id,
-            'location_id': self.ref('stock.stock_location_stock'),
-            'pricelist_id': self.ref('purchase.list0'),
-            'order_line': [(0, 0, {
-                'name': "{0} (qty={1}, cost={2})".format(self.product_id.name,
-                                                         qty, cost),
-                'product_id': self.product_id.id,
-                'price_unit': cost,
-                'product_qty': qty,
-                'date_planned': datetime.now().strftime('%Y-%m-%d'),
-            })]
-        })
-
-        purchase_order_id.wkf_confirm_order()
-        purchase_order_id.action_invoice_create()
-        purchase_order_id.action_picking_create()
-        self.do_picking(purchase_order_id.picking_ids)
-        return purchase_order_id
-
-    def create_sale_order(self, vals):
-        qty = vals['qty']
-        price = vals['cost']
-        sale_order_id = self.sale_order.create({
-            'partner_id': self.customer_id.id,
-            'client_order_ref': "Sale Order (qty={0}, price={1})".format(
-                str(qty), str(price)),
-            'order_policy': 'manual',
-            'order_line': [(0, 0, {
-                'product_id': self.product_id.id,
-                'product_uom_qty': qty,
-                'price_unit': price,
-            })]
-        })
-
-        sale_order_id.action_button_confirm()
-        self.do_picking(sale_order_id.picking_ids)
-        return sale_order_id
-
-    def get_stock_card_lines(self, product_id):
-        return self.env['stock.card.product'].\
-            _stock_card_move_get(product_id)['res']
-
     def create_and_validate_landed_costs(self, picking_id):
         slc_id = self.slc.create({
             'account_journal_id': self.ref(
@@ -170,20 +79,6 @@ class TestLandedCostRevert(TransactionCase):
         slc_id.button_validate()
 
         return slc_id
-
-    def revert_landed_cost(self, landed_cost_id):
-        reverted_lc_id = landed_cost_id.copy()
-        reverted_lc_id.write({
-            'picking_ids': [(6, 0, landed_cost_id.picking_ids.mapped('id'))],
-        })
-
-        for line in reverted_lc_id.cost_lines:
-            line.write({
-                'price_unit': -1 * line.price_unit
-            })
-        reverted_lc_id.compute_landed_cost()
-        reverted_lc_id.button_validate()
-        return reverted_lc_id
 
     def test_01_landed_cost_revert(self):
         card_lines = {}

--- a/stock_landed_costs_average/tests/test_landed_cost_revert.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_revert.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from test_stock_landed_common import TestStockLandedCommon
+from openerp.addons.stock_landed_costs_average.tests.test_stock_landed_common \
+    import TestStockLandedCommon
 
 
 class TestLandedCostRevert(TestStockLandedCommon):

--- a/stock_landed_costs_average/tests/test_landed_cost_revert.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_revert.py
@@ -158,15 +158,10 @@ class TestLandedCostRevert(TestStockLandedCommon):
         self.assertTrue(registered_lines,
                         "There weren't lines to check for {0}".format(vals))
 
-    def test_02_landed_cost_2_standard(self):
-        card_lines = {}
+    def test_02_landed_cost_for_standard(self):
         self.product_id.write({'cost_method': 'standard'})
         self.process_transactions()
-
-        card_lines['before_landed'] = self.get_stock_card_lines(
-            self.product_id.id)
         picking_id = self.transactions[0]['picking_ids']
-
         landed_cost_id = self.create_and_validate_landed_costs(picking_id)
         revert_landed_cost_id = self.revert_landed_cost(landed_cost_id)
         vals = {

--- a/stock_landed_costs_average/tests/test_landed_cost_revert.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_revert.py
@@ -192,3 +192,22 @@ class TestLandedCostRevert(TestStockLandedCommon):
         landed_cost_id = self.process_with_price_manually(46)
         self.validate_acct_entries_values(
             landed_cost_id, self.product_id, self.vals['gain'])
+
+    def test_04_landed_cost_for_real(self):
+        self.product_id.write({'cost_method': 'real'})
+        self.process_transactions()
+        picking_id = self.transactions[0]['picking_ids']
+        landed_cost_id = self.create_and_validate_landed_costs(picking_id)
+        revert_landed_cost_id = self.revert_landed_cost(landed_cost_id)
+        vals = {
+            self.account_freight_id.id: {
+                'debit': [40],
+                'credit': [0],
+            },
+            self.loss_acct_id: {
+                'credit': [40],
+                'debit': [0],
+            },
+        }
+        self.validate_acct_entries_values(revert_landed_cost_id,
+                                          self.product_id, vals)

--- a/stock_landed_costs_average/tests/test_landed_cost_revert.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_revert.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from stock_landed_costs_average.tests.test_stock_landed_common \
-    import TestStockLandedCommon
+from test_stock_landed_common import TestStockLandedCommon
 
 
 class TestLandedCostRevert(TestStockLandedCommon):

--- a/stock_landed_costs_average/tests/test_landed_cost_revert.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_revert.py
@@ -122,15 +122,24 @@ class TestLandedCostRevert(TestStockLandedCommon):
     def validate_acct_entries_values(self, landed_cost_id, product_id, vals):
         acct_move_id = landed_cost_id.account_move_id
         self.assertEqual(acct_move_id.mapped('line_id.product_id'), product_id)
+        registered_lines = False
         for aml_id in acct_move_id.line_id:
             acct_id = aml_id.account_id.id
+
+            if acct_id not in vals:
+                continue
+
             debit = aml_id.debit
             credit = aml_id.credit
 
             # check values expected for credit and debit
-            self.assertTrue(
-                credit and credit in vals[acct_id]['credit'] or
-                debit and debit in vals[acct_id]['debit'])
+            registered_lines = credit and credit in vals[acct_id]['credit'] or\
+                debit and debit in vals[acct_id]['debit']
+            self.assertTrue(registered_lines)
+
+        # validate at least one journal entry line was checked
+        self.assertTrue(registered_lines,
+                        "There weren't lines to check for {0}".format(vals))
 
     def test_02_landed_cost_2_standard(self):
         card_lines = {}

--- a/stock_landed_costs_average/tests/test_landed_cost_revert.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_revert.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+
+from openerp.tests.common import TransactionCase
+from datetime import datetime, timedelta
+
+
+class TestLandedCostRevert(TransactionCase):
+
+    def setUp(self):
+        super(TestLandedCostRevert, self).setUp()
+        self.company_id = self.env.ref('base.main_company')
+        self.slc = self.env['stock.landed.cost']
+        self.slc_id = self.env.ref('stock_landed_costs_average.slc_02')
+        self.delta = 0
+        self.next_hour = datetime.strptime('2016-01-01 01:00:00',
+                                           '%Y-%m-%d %H:%M:%S')
+        self.product_freight_id = self.env.ref(
+            'stock_landed_costs_average'
+            '.service_standard_periodic_landed_cost_1')
+        self.account_freight_id = self.env.ref(
+            'stock_landed_costs_average.freight_account')
+        self.picking = self.env['stock.picking']
+        self.move = self.env['stock.move']
+        self.purchase_order = self.env['purchase.order']
+        self.sale_order = self.env['sale.order']
+        self.product_id = self.env.ref(
+            'stock_landed_costs_average.product_mouse')
+        self.wizard = self.env['stock.transfer_details']
+        self.wizard_item = self.env['stock.transfer_details_items']
+        self.transfer_details = self.env['stock.transfer_details']
+        self.supplier_id = self.env.ref('base.res_partner_13')
+        self.customer_id = self.env.ref('base.res_partner_23')
+        self.transactions = [
+            {
+                'cost': 20, 'qty': 2,
+                'avg': 20, 'is_po': True,
+            },
+            {
+                'cost': 40, 'qty': 3,
+                'avg': 32, 'is_po': True,
+            },
+            {
+                'cost': 32, 'qty': 1,
+                'avg': 32, 'is_po': False,
+            },
+            {
+                'cost': 64, 'qty': 4,
+                'avg': 48, 'is_po': True,
+            },
+            {
+                'cost': 48, 'qty': 4,
+                'avg': 48, 'is_po': False,
+            },
+        ]
+        self.expected_values = {
+            self.ref('account.stk'): {
+                'credit': [40, 24],
+                'debit': [40, 24],
+            },
+            self.ref('account.a_expense'): {
+                'credit': [24],
+                'debit': [24],
+            },
+            self.account_freight_id.id: {
+                'credit': [40],
+                'debit': [40],
+            },
+        }
+
+    def dummy_function(self, move_lines):
+        for move_id in move_lines:
+            self.delta += 1
+            self.next_hour = datetime.strptime(
+                '2016-01-01 01:00:00',
+                '%Y-%m-%d %H:%M:%S') + timedelta(hours=self.delta)
+            move_id.write({'date': self.next_hour})
+
+    def do_picking_wf(self, picking_id):
+        picking_id.action_confirm()
+        wizard_id = self.wizard.create({
+            'picking_id': picking_id.id,
+        })
+
+        for move_id in picking_id.move_lines:
+            self.wizard_item.create({
+                'transfer_id': wizard_id.id,
+                'product_id': move_id.product_id.id,
+                'quantity': move_id.product_qty,
+                'sourceloc_id': move_id.location_id.id,
+                'destinationloc_id': move_id.location_dest_id.id,
+                'product_uom_id': move_id.product_uom.id,
+            })
+
+        wizard_id.do_detailed_transfer()
+
+    def do_picking(self, picking_ids):
+        if not picking_ids:
+            return
+
+        for picking_id in picking_ids:
+            self.do_picking_wf(picking_id)
+            self.assertEqual(picking_id.state, 'done')
+            self.dummy_function(picking_id.move_lines)
+
+    def create_purchase_order(self, vals):
+        qty = vals['qty']
+        cost = vals['cost']
+        purchase_order_id = self.purchase_order.create({
+            'partner_id': self.supplier_id.id,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'pricelist_id': self.ref('purchase.list0'),
+            'order_line': [(0, 0, {
+                'name': "{0} (qty={1}, cost={2})".format(self.product_id.name,
+                                                         qty, cost),
+                'product_id': self.product_id.id,
+                'price_unit': cost,
+                'product_qty': qty,
+                'date_planned': datetime.now().strftime('%Y-%m-%d'),
+            })]
+        })
+
+        purchase_order_id.wkf_confirm_order()
+        purchase_order_id.action_invoice_create()
+        purchase_order_id.action_picking_create()
+        self.do_picking(purchase_order_id.picking_ids)
+        return purchase_order_id
+
+    def create_sale_order(self, vals):
+        qty = vals['qty']
+        price = vals['cost']
+        sale_order_id = self.sale_order.create({
+            'partner_id': self.customer_id.id,
+            'client_order_ref': "Sale Order (qty={0}, price={1})".format(
+                str(qty), str(price)),
+            'order_policy': 'manual',
+            'order_line': [(0, 0, {
+                'product_id': self.product_id.id,
+                'product_uom_qty': qty,
+                'price_unit': price,
+            })]
+        })
+
+        sale_order_id.action_button_confirm()
+        self.do_picking(sale_order_id.picking_ids)
+        return sale_order_id
+
+    def get_stock_card_lines(self, product_id):
+        return self.env['stock.card.product'].\
+            _stock_card_move_get(product_id)['res']
+
+    def create_and_validate_landed_costs(self, picking_id):
+        slc_id = self.slc.create({
+            'account_journal_id': self.ref(
+                'stock_landed_costs_average.stock_landed_cost_1'),
+            'picking_ids': [(4, picking_id.id), ],
+            'cost_lines': [
+                (0, 0, {
+                    'name': 'freight',
+                    'product_id': self.product_freight_id.id,
+                    'account_id': self.account_freight_id.id,
+                    'split_method': 'by_quantity',
+                    'price_unit': 40,
+                }),
+            ]
+        })
+        self.assertEqual(len(slc_id.picking_ids), 1)
+        self.assertEqual(len(slc_id.cost_lines), 1)
+        slc_id.compute_landed_cost()
+        self.assertEqual(len(slc_id.valuation_adjustment_lines), 1)
+        slc_id.button_validate()
+
+        return slc_id
+
+    def revert_landed_cost(self, landed_cost_id):
+        reverted_lc_id = landed_cost_id.copy()
+        reverted_lc_id.write({
+            'picking_ids': [(6, 0, landed_cost_id.picking_ids.mapped('id'))],
+        })
+
+        for line in reverted_lc_id.cost_lines:
+            line.write({
+                'price_unit': -1 * line.price_unit
+            })
+        reverted_lc_id.compute_landed_cost()
+        reverted_lc_id.button_validate()
+        return reverted_lc_id
+
+    def test_01_landed_cost_revert(self):
+        card_lines = {}
+        for trx in self.transactions:
+            # purchase
+            if trx['is_po']:
+                trx['id'] = self.create_purchase_order(trx)
+            else:  # sale
+                trx['id'] = self.create_sale_order(trx)
+            trx['picking_ids'] = trx['id'].picking_ids
+
+        card_lines['before_landed'] = self.get_stock_card_lines(
+            self.product_id.id)
+        picking_id = self.transactions[0]['picking_ids']
+
+        landed_cost_id = self.create_and_validate_landed_costs(picking_id)
+        self.validate_acct_entries_values(
+            landed_cost_id, self.product_id,  self.expected_values)
+
+        card_lines['after_landed'] = self.get_stock_card_lines(
+            self.product_id.id)
+
+        revert_landed_cost_id = self.revert_landed_cost(landed_cost_id)
+        self.validate_acct_entries_values(
+            revert_landed_cost_id, self.product_id, self.expected_values)
+
+        card_lines['after_revert'] = self.get_stock_card_lines(
+            self.product_id.id)
+
+        # check for values before applying landed cost and after revert landed
+        # cost are the same
+        self.assertEqual(
+            card_lines['before_landed'], card_lines['after_revert'],
+            'Something is not right with before_landed={0} '
+            'and after_revert={1}'.format(card_lines['before_landed'],
+                                          card_lines['after_revert']))
+
+    def validate_acct_entries_values(self, landed_cost_id, product_id, vals):
+        acct_move_id = landed_cost_id.account_move_id
+        self.assertEqual(acct_move_id.mapped('line_id.product_id'), product_id)
+        for aml_id in acct_move_id.line_id:
+            acct_id = aml_id.account_id.id
+            debit = aml_id.debit
+            credit = aml_id.credit
+
+            # check values expected for credit and debit
+            self.assertTrue(
+                credit and credit in vals[acct_id]['credit'] or
+                debit and debit in vals[acct_id]['debit'])

--- a/stock_landed_costs_average/tests/test_landed_costs_with_std.py
+++ b/stock_landed_costs_average/tests/test_landed_costs_with_std.py
@@ -10,11 +10,6 @@ class TestLandedCostsWithStd(TestStockCommon):
         basic method to define some basic data to be re use in all test cases.
         """
         super(TestLandedCostsWithStd, self).setUp()
-        self.quant = self.env['stock.quant']
-        self.invoice_obj = self.env['account.invoice']
-        self.return_obj = self.env['stock.return.picking']
-        self.picking_type_internal = self.ModelDataObj.xmlid_to_res_id(
-            'stock.picking_type_internal')
         self.invoice_id = self.env.ref(
             'stock_landed_costs_average.invoice_landing_costs_average_1')
 
@@ -121,7 +116,7 @@ class TestLandedCostsWithStd(TestStockCommon):
         self.assertEquals(
             self.product_standard.standard_price, 1000.0,
             'Something went wrong. Standard Product should cost 1000.00!!!')
-        quant_std = self.quant.search(
+        quant_std = self.env['stock.quant'].search(
             [('product_id', '=', self.product_standard.id)])
         self.assertEquals(
             (quant_std.inventory_value, quant_std.cost),
@@ -134,7 +129,7 @@ class TestLandedCostsWithStd(TestStockCommon):
         self.assign_landing_invoice()
         self.validate_landed_cost()
 
-    def validate_acct_entries_values(self, product_id):
+    def validate_acct_entries(self, product_id):
         stock_valuation_acct_id = product_id.categ_id.\
             property_stock_valuation_account_id
         acct_move_id = self.landed_cost_id.account_move_id
@@ -159,4 +154,4 @@ class TestLandedCostsWithStd(TestStockCommon):
 
     def test_02_account_entries(self):
         self.create_and_validate_landed_cost()
-        self.validate_acct_entries_values(self.product_standard)
+        self.validate_acct_entries(self.product_standard)

--- a/stock_landed_costs_average/tests/test_stock_landed_common.py
+++ b/stock_landed_costs_average/tests/test_stock_landed_common.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+
+from openerp.tests.common import TransactionCase
+from datetime import datetime, timedelta
+from openerp.tools.safe_eval import safe_eval
+
+
+class TestStockLandedCommon(TransactionCase):
+
+    def setUp(self):
+        super(TestStockLandedCommon, self).setUp()
+        self.slc = self.env['stock.landed.cost']
+        self.picking = self.env['stock.picking']
+        self.move = self.env['stock.move']
+        self.purchase_order = self.env['purchase.order']
+        self.sale_order = self.env['sale.order']
+        self.wizard = self.env['stock.transfer_details']
+        self.wizard_item = self.env['stock.transfer_details_items']
+        self.transfer_details = self.env['stock.transfer_details']
+        self.return_picking = self.env['stock.return.picking']
+        self.return_picking_line = self.env['stock.return.picking.line']
+        self.delta = 0
+        self.next_hour = datetime.strptime('2016-01-01 01:00:00',
+                                           '%Y-%m-%d %H:%M:%S')
+
+    def dummy_function(self, move_lines):
+        for move_id in move_lines:
+            self.delta += 1
+            self.next_hour = datetime.strptime(
+                '2016-01-01 01:00:00',
+                '%Y-%m-%d %H:%M:%S') + timedelta(hours=self.delta)
+            move_id.write({'date': self.next_hour})
+
+    def do_picking_wf(self, picking_id):
+        picking_id.action_confirm()
+        wizard_id = self.wizard.create({
+            'picking_id': picking_id.id,
+        })
+
+        for move_id in picking_id.move_lines:
+            self.wizard_item.create({
+                'transfer_id': wizard_id.id,
+                'product_id': move_id.product_id.id,
+                'quantity': move_id.product_qty,
+                'sourceloc_id': move_id.location_id.id,
+                'destinationloc_id': move_id.location_dest_id.id,
+                'product_uom_id': move_id.product_uom.id,
+            })
+
+        wizard_id.do_detailed_transfer()
+
+    def do_picking(self, picking_ids):
+        if not picking_ids:
+            return
+
+        for picking_id in picking_ids:
+            self.do_picking_wf(picking_id)
+            self.assertEqual(picking_id.state, 'done')
+            self.dummy_function(picking_id.move_lines)
+
+    def create_purchase_order(self, vals):
+        qty = vals['qty']
+        cost = vals['cost']
+        purchase_order_id = self.purchase_order.create({
+            'partner_id': self.supplier_id.id,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'pricelist_id': self.ref('purchase.list0'),
+            'order_line': [(0, 0, {
+                'name': "{0} (qty={1}, cost={2})".format(self.product_id.name,
+                                                         qty, cost),
+                'product_id': self.product_id.id,
+                'price_unit': cost,
+                'product_qty': qty,
+                'date_planned': datetime.now().strftime('%Y-%m-%d'),
+            })]
+        })
+
+        purchase_order_id.wkf_confirm_order()
+        purchase_order_id.action_invoice_create()
+        purchase_order_id.action_picking_create()
+        self.do_picking(purchase_order_id.picking_ids)
+        return purchase_order_id
+
+    def create_sale_order(self, vals):
+        qty = vals['qty']
+        price = vals['cost']
+        sale_order_id = self.sale_order.create({
+            'partner_id': self.customer_id.id,
+            'client_order_ref': "Sale Order (qty={0}, price={1})".format(
+                str(qty), str(price)),
+            'order_policy': 'manual',
+            'order_line': [(0, 0, {
+                'product_id': self.product_id.id,
+                'product_uom_qty': qty,
+                'price_unit': price,
+            })]
+        })
+
+        sale_order_id.action_button_confirm()
+        self.do_picking(sale_order_id.picking_ids)
+        return sale_order_id
+
+    def create_return(self, vals):
+        qty = vals['qty']
+        picking_id = vals['origin_id']
+        return_id = self.return_picking.with_context({
+            'active_id': picking_id.id,
+            'active_ids': picking_id.ids,
+            'active_model': 'stock.picking',
+        }).create({})
+
+        return_lines = []
+        for move_id in picking_id.move_lines:
+            return_line_id = self.return_picking_line.create({
+                'product_id': self.product_id.id,
+                'quantity': qty,
+                'wizard_id': return_id.id,
+                'move_id': move_id.id
+            })
+            return_lines.append(return_line_id)
+        res = return_id.create_returns()
+        picking_id = safe_eval(res['domain'])[0][2][0]
+        picking_id = self.picking.browse(picking_id)
+        self.do_picking_wf(picking_id)
+        self.assertEqual(picking_id.state, 'done')
+        self.dummy_function(picking_id.move_lines)
+        return picking_id.id
+
+    def get_stock_card_lines(self, product_id):
+        return self.env['stock.card.product'].\
+            _stock_card_move_get(product_id)['res']
+
+    def revert_landed_cost(self, landed_cost_id):
+        reverted_lc_id = landed_cost_id.copy()
+        reverted_lc_id.write({
+            'picking_ids': [(6, 0, landed_cost_id.picking_ids.mapped('id'))],
+        })
+
+        for line in reverted_lc_id.cost_lines:
+            line.write({
+                'price_unit': -1 * line.price_unit
+            })
+        reverted_lc_id.compute_landed_cost()
+        reverted_lc_id.button_validate()
+        return reverted_lc_id

--- a/stock_landed_costs_average/tests/test_stock_landed_costs_average.py
+++ b/stock_landed_costs_average/tests/test_stock_landed_costs_average.py
@@ -23,8 +23,6 @@ class TestsLandedCosts(TestStockCommon):
         basic method to define some basic data to be re use in all test cases.
         """
         super(TestsLandedCosts, self).setUp()
-        self.quant = self.env['stock.quant']
-        self.invoice_obj = self.env['account.invoice']
         self.return_obj = self.env['stock.return.picking']
         self.picking_type_internal = self.ModelDataObj.xmlid_to_res_id(
             'stock.picking_type_internal')
@@ -173,9 +171,9 @@ class TestsLandedCosts(TestStockCommon):
         self.assertEquals(
             self.product_real.standard_price, 0.0,
             'Something went wrong. Real Product should cost 0.00!!!')
-        quant_real = self.quant.search(
+        quant_real = self.env['stock.quant'].search(
             [('product_id', '=', self.product_real.id)])
-        quant_average = self.quant.search(
+        quant_average = self.env['stock.quant'].search(
             [('product_id', '=', self.product_average.id)])
 
         self.assertEquals(

--- a/stock_landed_costs_segmentation/tests/test_landed_costs_segmentation.py
+++ b/stock_landed_costs_segmentation/tests/test_landed_costs_segmentation.py
@@ -128,6 +128,15 @@ class TestLandedCostsSegmentation(TransactionCase):
     def test_00_user_validations(self):
         self.do_picking(self.picking_01_id)
         landed_cost_id = self.create_landed_cost(self.picking_01_id)
+        landed_cost_id.compute_landed_cost()
+        landed_cost_id.cost_lines.write({
+            'segmentation_cost': False,
+        })
+        msg_error = 'Please fill the segmentation field in Cost Lines'
+        with self.assertRaisesRegexp(UserError, msg_error):
+            landed_cost_id.button_validate()
+
+        landed_cost_id = self.create_landed_cost(self.picking_01_id)
         msg_error = 'You cannot validate a landed cost which has no valid.*'
         with self.assertRaisesRegexp(UserError, msg_error):
             landed_cost_id.button_validate()


### PR DESCRIPTION
This is intended to get enhanced unit testing for stock modules including new cases of use and coverage as well
## Changes made:
### Use cases
- [x] Supplier return movement following (to be discussed)
- [x] Revert Landed Cost document and its effects over in Stock Card
  - [x] Check values before applying landed cost vs. after reverting landed cost
  - [x] Check journal entries after reverting landed cost 
- [x] When product price is set manually before apply Landed Cost
  - [x] A Loss journal entry is registered because price set is higher than the current one.
  - [x] A Gain journal entry is registered because price set is lesser than the current one.
- [X] Emulate trx flow where inventory valuation doesn't match with the product stock. [ more info ](https://www.odoo.com/documentation/user/9.0/accounting/others/inventory/avg_price_valuation.html#explanation-counter-example) 
### Coverage
- [x] Cron methods for **`product_extended_segmentation`** where material cost product value it gets updated where it have not value in any segmentation
### At the end
- [x] Rebase
