### PR TITLE
[8.0][product_do_merge] Handled the new object returned by browse method

### DIFF
--- a/product_do_merge/model/product.py
+++ b/product_do_merge/model/product.py
@@ -21,13 +21,11 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from openerp.osv import osv, fields
+from openerp import models, fields
 
 
-class ProductProduct(osv.Model):
+class ProductProduct(models.Model):
     _description = 'Product'
     _inherit = "product.product"
 
-    _columns = {
-        'create_date': fields.datetime('Create Date', readonly=True),
-    }
+    create_date = fields.Datetime('Create Date', readonly=True)


### PR DESCRIPTION
In the last version when you call the brwose method sending a list of ids this returned a list of browse records. Now in the new version the browse method returns a recordsset, this object does not have the append attribute, to avoid this error we will use the attribute ids from the recordset object

fix #714 
