### PR TITLE
[8.0][mrp_partial_production] Changed the value returned from test_ready method

### DIFF
--- a/mrp_partial_production/models/mrp.py
+++ b/mrp_partial_production/models/mrp.py
@@ -55,8 +55,6 @@ class MrpProduction(models.Model):
         for record in self:
             if record.qty_available_to_produce > 0:
                 res = True
-            else:
-                res = False
         return res
 
     @api.multi


### PR DESCRIPTION
If the amount available to product is 0 the value returned must be the original value returned from the main call of the test_ready method
