### PR TITLE
[FIX] website_variants_extra: When selecting a invalid combination of attributes the price dissapears, now the message "Product not available" appears instead.

### DIFF
--- a/website_product_availability/views/templates.xml
+++ b/website_product_availability/views/templates.xml
@@ -3,7 +3,8 @@
     <data>
          <template id="product_stock_available_website" inherit_id="website_variants_extra.product_variants_description_3columns">
              <xpath expr="//div[@class='css_quantity input-group oe_website_spinner']" position="before">
-                <t t-set="attr_value_ids" t-value="get_locations_variant_ids(product)"/>
+                <div class="warehouse-availability">
+                    <t t-set="attr_value_ids" t-value="get_locations_variant_ids(product)"/>
                     <t t-if="attr_value_ids">
                         <t t-foreach="attr_value_ids" t-as="variant">
                             <t t-if="variant[4]">
@@ -68,6 +69,7 @@
                     <t t-if="not product_variants">
                         <h2> No Variants</h2>
                     </t>
+                </div>
              </xpath>
          </template>
          <template id="product_stock_state" inherit_id="website_sale.product">

--- a/website_variants_extra/static/src/js/website_sale.js
+++ b/website_variants_extra/static/src/js/website_sale.js
@@ -20,6 +20,9 @@
             $('#product_with_variants').html(variants_str);
         });
         $('input.js_variant_change, select.js_variant_change', this).first().trigger('click');
+        $('.warehouse-availability').addClass('product_price');
+        $('.website-sale-actions').addClass('product_price');
+        $('#add_to_cart').addClass('product_price');
     });
 }());
 

--- a/website_variants_extra/static/src/less/website.less
+++ b/website_variants_extra/static/src/less/website.less
@@ -30,6 +30,12 @@
     .js_quantity.form-control {
         background-color: white;
     }
+    .css_not_available_msg{
+        font-size: 20px;
+        margin-top: 16px;
+        margin-bottom: 16px;
+
+    }
     .add-to-cart .btn{
         background-color:#f39c12;
         font-weight: bold;

--- a/website_variants_extra/views/templates.xml
+++ b/website_variants_extra/views/templates.xml
@@ -78,6 +78,7 @@
                                              </li>
                                         </ul>
                                     </div>
+                                    <strong t-if="len(product.product_variant_ids) > 1" class="css_not_available_msg text-danger">Product not available</strong>
                                     <div class="css_quantity input-group oe_website_spinner" style="margin-top: 20px;">
                                         <span class="input-group-addon">
                                             <a t-attf-href="#" class="mb8 js_add_cart_json">


### PR DESCRIPTION
fixes https://github.com/Vauxoo/yoytec/issues/816
dummy https://github.com/Vauxoo/yoytec/pull/817
When product does not exists product price disappear and then product not available product message is triggered.This happen when unavailable product variant (memory 32 gb and black color) are selected.
Before
![screenshot from 2016-03-04 01-21-13](https://cloud.githubusercontent.com/assets/10885517/13520609/6e4ef5d2-e1a7-11e5-932b-53ab69187263.png)
After
![screenshot from 2016-03-08 21-17-13](https://cloud.githubusercontent.com/assets/10885517/13624390/319d7dfa-e573-11e5-9599-fde375c271bc.png)
