### PR TITLE
[FIX] website_product_filters: if public category is not send by get parameters, this value is getting  from product model.

### DIFF
--- a/website_product_filters/controllers/main.py
+++ b/website_product_filters/controllers/main.py
@@ -183,6 +183,8 @@ class WebsiteSale(website_sale):
         cr, uid, context, pool =\
             request.cr, request.uid, request.context, request.registry
         template_obj = pool['product.template']
+        if not category and len(product.public_categ_ids) >= 1:
+            category = product.public_categ_ids[0]
         viewed = product.views + 1
         template_obj.write(cr, uid, [product.id],
                            {'views': viewed}, context=context)


### PR DESCRIPTION
fixes https://github.com/Vauxoo/yoytec/issues/799
Dummy https://github.com/Vauxoo/yoytec/pull/818
The breadcrumb must be always showed . Before this change the breadcrumb appears if only the user  follow the categories links flow not when open directly the flow.
Before 
![screenshot from 2016-03-03 23-20-56](https://cloud.githubusercontent.com/assets/10885517/13518734/9dc27bf6-e196-11e5-8718-e605740c57bb.png)
After
![screenshot from 2016-03-03 23-10-22](https://cloud.githubusercontent.com/assets/10885517/13518588/3fa757e0-e195-11e5-83b2-cbdf3fa0a2d1.png)
