### PR TITLE
[FIX] Using update.({'cost_lines': [(6, False, {})]}) instead cost_li…

### DIFF
--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -33,7 +33,7 @@ class StockLandedCost(models.Model):
     @api.onchange('invoice_ids')
     def onchange_invoice_ids(self):
         for lc_brw in self:
-            lc_brw.cost_lines.unlink()
+            lc_brw.update({'cost_lines': [(6, False, {})]})
             cost_lines = []
             for inv_brw in lc_brw.invoice_ids:
                 company_currency = inv_brw.company_id.currency_id

--- a/stock_landed_costs_average/tests/test_landed_cost_average.py
+++ b/stock_landed_costs_average/tests/test_landed_cost_average.py
@@ -87,7 +87,7 @@ class TestLandedCostAverage(TestStockLandedCommon):
         landed_cost_id = self.create_and_validate_landed_costs(
             po_01_id.picking_ids)
         landed_cost_id.write({'invoice_ids': [(4, invoice_01_id.id)]})
-        landed_cost_id.onchange_invoice_ids()
+        landed_cost_id.get_costs_from_invoices()
         landed_cost_id.compute_landed_cost()
         self.assertEqual(landed_cost_id.cost_lines.product_id.ids,
                          self.product_freight_id.ids)


### PR DESCRIPTION
Using update.({'cost_lines': [(6, False, {})]}) instead cost_lines.unlink()
This is the reason of not using unlink
https://drive.google.com/file/d/0B1w9gokcJL9hTXRBNVFRSmJmMVE/view
