### PR TITLE
[IMP] Server Action to update Journal Items in Manufacturing Orders

### DIFF
--- a/mrp_workcenter_account_move/__openerp__.py
+++ b/mrp_workcenter_account_move/__openerp__.py
@@ -21,6 +21,7 @@
     "data": [
         'view/view.xml',
         'view/wizard.xml',
+        'data/data.xml',
     ],
     "installable": True,
     "auto_install": False,

--- a/mrp_workcenter_account_move/data/data.xml
+++ b/mrp_workcenter_account_move/data/data.xml
@@ -1,5 +1,24 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <openerp>
     <data noupdate="1">
+           <record model="ir.actions.server" id="update_aml_production_id">
+            <field name="name">Update Production on Journal Items</field>
+            <field name="model_id" eval="ref('mrp.model_mrp_production')"/>
+            <field name="state">code</field>
+            <field name="condition"></field>
+            <field name="sequence">5</field>
+            <field name="code">
+# Available locals:
+#  - time, datetime, dateutil: Python libraries
+#  - env: Odoo Environement
+#  - model: Model of the record on which the action is triggered
+#  - object: Record on which the action is triggered if there is one, otherwise None
+#  - workflow: Workflow engine
+#  - Warning: Warning Exception to use with raise
+# To return an action, assign: action = {...}
+
+env['mrp.production'].update_production_journal_items()
+            </field>
+        </record>
     </data>
 </openerp>

--- a/mrp_workcenter_account_move/data/data.xml
+++ b/mrp_workcenter_account_move/data/data.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<openerp>
+    <data noupdate="1">
+    </data>
+</openerp>

--- a/mrp_workcenter_account_move/model/mrp.py
+++ b/mrp_workcenter_account_move/model/mrp.py
@@ -30,8 +30,8 @@ class MrpProduction(models.Model):
                 self._cr.execute(
                     ''' UPDATE account_move_line
                         SET production_id = %s
-                        WHERE id IN (%s);''',
-                    (mrp_brw.id, ', '.join([str(aml) for aml in aml_ids])))
+                        WHERE id IN %s;''',
+                    (mrp_brw.id, tuple(aml_ids)))
         return True
 
     @api.multi

--- a/mrp_workcenter_account_move/model/mrp.py
+++ b/mrp_workcenter_account_move/model/mrp.py
@@ -18,6 +18,22 @@ class MrpProduction(models.Model):
         copy=False,
     )
 
+    def update_production_journal_items(self):
+        mrp_ids = self.search([('state', '=', 'in_production')])
+        for mrp_brw in mrp_ids:
+            aml_ids = []
+            for raw_brw in mrp_brw.move_lines2:
+                aml_ids += [aml.id for aml in raw_brw.aml_all_ids]
+            for fg_brw in mrp_brw.move_created_ids2:
+                aml_ids += [aml.id for aml in fg_brw.aml_all_ids]
+            if aml_ids:
+                self._cr.execute(
+                    ''' UPDATE account_move_line
+                        SET production_id = %s
+                        WHERE id IN (%s);''',
+                    (mrp_brw.id, ', '.join([str(aml) for aml in aml_ids])))
+        return True
+
     @api.multi
     def test_accounting_setting(self):
         self.ensure_one()


### PR DESCRIPTION
There are Manufacturing Order already started which have already created Journal Entries
because of the stock move consumed or produced,

Those Journal Entries need to be properly associated the manufacturing order to properly
create Final Journal Entries
