### PR TITLE
[FIX] Getting rid of wired variable

### DIFF
--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -186,7 +186,6 @@ class ProductTemplate(models.Model):
                 # /!\ NOTE: If not segmentation set on WC fallback to
                 # production_cost segmentation
                 fn = wc.segmentation_cost or 'production_cost'
-                fn = 'production_cost'
                 sgmnt_dict[fn] += routing_price
 
         # Convert on product UoM quantities


### PR DESCRIPTION
Stupid error that was leave behind when adding segmentation to product_extended_segmentation
