### PR TITLE
[FIX] website_variants_extra: add an empty line between product Manufacturer and product characteristics, and display product characteristics if it exists

### DIFF
--- a/website_variants_extra/views/templates.xml
+++ b/website_variants_extra/views/templates.xml
@@ -30,8 +30,12 @@
                                           <t t-set="ul_class" t-value="'nav-stacked'"/>
                                       </t>
                                     </t>
-                                    <strong>Characteristics</strong>
-                                    <hr t-if="product.description_sale" style="margin-top: 0px; margin-bottom: 0px;"/>
+                                    <hr t-if="product.description_sale" class="hidden"/>
+                                    <br/>
+                                    <t t-if="product.attribute_line_ids">
+                                        <strong class="text-muted" >Characteristics</strong>
+                                        <hr style="margin-top: 0px; margin-bottom: 0px;"/>
+                                    </t>
                                     <div class="row">
                                       <t t-foreach="product.attribute_line_ids" t-as="variant_id">
                                           <t t-if="len(variant_id.value_ids)==1">


### PR DESCRIPTION
FIXES: https://github.com/Vauxoo/yoytec/issues/970
BUILD: https://github.com/Vauxoo/yoytec/pull/977
![screenshot from 2016-04-04 20-26-39](https://cloud.githubusercontent.com/assets/10885517/14268930/5c69b7f0-faa5-11e5-9a3d-643841510a01.png)
