### PR TITLE
[IMP] crm_claim_summary_report: include supplier as part labels when printing the report

### DIFF
--- a/crm_claim_summary_report/i18n/crm_claim_summary_report.pot
+++ b/crm_claim_summary_report/i18n/crm_claim_summary_report.pot
@@ -36,6 +36,11 @@ msgid "CUSTOMER COPY"
 msgstr ""
 
 #. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.template_page_copy_title
+msgid "SUPPLIER COPY"
+msgstr ""
+
+#. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.page_summary_report
 msgid "Claim"
 msgstr ""
@@ -113,7 +118,12 @@ msgstr ""
 
 #. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.page_summary_report
-msgid "Name"
+msgid "Supplier name"
+msgstr ""
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.page_summary_report
+msgid "Customer name"
 msgstr ""
 
 #. module: crm_claim_summary_report
@@ -179,4 +189,19 @@ msgstr ""
 #. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.page_summary_report
 msgid "Pick the product in the store"
+msgstr ""
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.external_layout_header
+msgid "RMA Receipt"
+msgstr ""
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.external_layout_header
+msgid "RMA Receipt for Customer"
+msgstr ""
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.external_layout_header
+msgid "RMA for Supplier"
 msgstr ""

--- a/crm_claim_summary_report/i18n/es.po
+++ b/crm_claim_summary_report/i18n/es.po
@@ -33,7 +33,12 @@ msgstr "COPIA PARA SOPORTE INTERNO"
 #. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.template_page_copy_title
 msgid "CUSTOMER COPY"
-msgstr "COPIA DEL CLIENTE"
+msgstr "COPIA CLIENTE"
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.template_page_copy_title
+msgid "SUPPLIER COPY"
+msgstr "COPIA PROVEEDOR"
 
 #. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.page_summary_report
@@ -119,8 +124,13 @@ msgstr "Serial"
 
 #. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.page_summary_report
-msgid "Name"
-msgstr "Nombre"
+msgid "Supplier name"
+msgstr "Nombre del Proveedor"
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.page_summary_report
+msgid "Customer name"
+msgstr "Nombre del Cliente"
 
 #. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.page_summary_report
@@ -247,3 +257,18 @@ msgstr "NOTA IMPORTANTE"
 #: view:website:crm_claim_summary_report.page_summary_report
 msgid "Pick the product in the store"
 msgstr "Retira el producto en la tienda"
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.external_layout_header
+msgid "RMA Receipt"
+msgstr "Recibo de Reclamo"
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.external_layout_header
+msgid "RMA Receipt for Customer"
+msgstr "Recibo de Reclamo de Cliente"
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.external_layout_header
+msgid "RMA for Supplier"
+msgstr "Reclamo al Proveedor"

--- a/crm_claim_summary_report/reports/claim_summary_report.xml
+++ b/crm_claim_summary_report/reports/claim_summary_report.xml
@@ -10,7 +10,7 @@
             <t t-set="body_classname" t-value="'container'"/>
             <t t-foreach="docs" t-as="doc">
                 <t t-call="crm_claim_summary_report.layout">
-                    <t t-set="page_copy_title" t-value="'customer'"/>
+                    <t t-set="page_copy_title" t-value="doc.claim_type.name.lower()"/>
                     <t t-call="crm_claim_summary_report.claim_copy_page"/>
                     <t t-set="page_copy_title" t-value="'internal'"/>
                     <t t-call="crm_claim_summary_report.claim_copy_page"/>
@@ -46,19 +46,22 @@
             </div>
             <div class="row" >
                 <div class="col-xs-2" style="text-align:right;">
-                    <t t-if="claim.partner_id.customer">
-                        <p class="row" style="font-size:12px"><strong>Customer Name<span>:</span></strong></p>
-                    </t>
-                        <p class="row" style="font-size:12px"><strong>Delivery Address<span>:</span></strong></p>
+                    <p class="row" style="font-size:12px">
+                        <strong>
+                            <t t-if="page_copy_title == 'customer'">Customer name</t>
+                            <t t-if="page_copy_title == 'supplier'">Supplier name</t>
+                            <t t-if="page_copy_title not in ['supplier','customer']">Name</t>
+                            <span>:</span>
+                        </strong>
+                    </p>
+                    <p class="row" style="font-size:12px"><strong>Delivery Address<span>:</span></strong></p>
                 </div>
                 <!-- DATA -->
-                <div class="col-xs-2">
+                <div class="col-xs-3">
 
-                    <t t-if="claim.partner_id.customer">
-                        <t t-if="claim.claim_type">
-                            <p t-field="claim.partner_id.name" style="font-size:12px"/>
-                        </t>
-                    </t>
+                    <p t-if="claim.claim_type">
+                        <span t-field="claim.partner_id.name" style="font-size:12px"/>
+                    </p>
 
                     <t t-if="not claim.pick and claim.delivery_address_id">
                         <p style="font-size:12px;white-space: nowrap;">
@@ -191,8 +194,10 @@
                     </tbody>
                 </table>
                 <br/> <br/> <br/> <br/>
-                <p align="center">_______________________________________________</p>
-                <p align="center">Customer's signature</p>
+                <t t-if="page_copy_title == 'customer'">
+                    <p align="center">_______________________________________________</p>
+                    <p align="center">Customer's signature</p>
+                </t>
             </div>
         </template>
         <template id="product_on_claim">

--- a/crm_claim_summary_report/reports/claim_summary_report_layouts.xml
+++ b/crm_claim_summary_report/reports/claim_summary_report_layouts.xml
@@ -117,12 +117,15 @@
                             <h3><small><span>TIN</span>: <span t-field="company.vat"/> </small></h3>
                         </t>
                         <p><h4>
-                            <t t-if="claim.claim_type">
-                                RMA Receipt for
-                                <t t-esc="claim.claim_type.name"/>
+                            <t t-if="page_copy_title == 'customer'">
+                                RMA Receipt for Customer
                             </t>
-                            <t t-if="not claim.claim_type">RMA Receipt</t>
-                            <span> </span>
+                            <t t-if="page_copy_title == 'supplier'">
+                                RMA for Supplier
+                            </t>
+                            <t t-if="page_copy_title not in ['customer','supplier']">
+                                RMA Receipt
+                            </t>
                         </h4></p>
                     </div>
                 </div>
@@ -161,8 +164,15 @@
         <template id="crm_claim_summary_report.template_page_copy_title">
             <t t-if="page_copy_title">
                 <div class="text-center page-copy-title">
-                    <t t-if="page_copy_title == 'customer'"> CUSTOMER COPY </t>
-                    <t t-if="page_copy_title == 'internal'"> COPY FOR INTERNAL SUPPORT </t>
+                    <t t-if="page_copy_title == 'internal'">
+                        COPY FOR INTERNAL SUPPORT
+                    </t>
+                    <t t-if="page_copy_title == 'customer'">
+                        CUSTOMER COPY
+                    </t>
+                    <t t-if="page_copy_title == 'supplier'">
+                        SUPPLIER COPY
+                    </t>
                 </div>
             </t>
         </template>


### PR DESCRIPTION
## [Task 5123](https://www.vauxoo.com/web?#id=5123&view_type=form&model=project.task&menu_id=136&action=138)
# Changes included
- [X] Based on claim's type (indicated by `claim_type`) the report will be targeted for customer or supplier
- [X] Include translations for both context
- Customer versions: [[ENGLISH]](https://cloud.githubusercontent.com/assets/2961943/14295292/e27c2d34-fb3e-11e5-9980-3f895074e553.png) [[SPANISH]](https://cloud.githubusercontent.com/assets/2961943/14295344/f71f953c-fb3e-11e5-8b12-0862abe9efcc.png)
- Supplier version: [[ENGLISH]](https://cloud.githubusercontent.com/assets/2961943/14295378/19c26646-fb3f-11e5-895c-be864404fb87.png) [[SPANISH]](https://cloud.githubusercontent.com/assets/2961943/14295394/2936c432-fb3f-11e5-8346-2b84074de222.png)
##### A more detailed samples can be found [here](https://drive.google.com/drive/folders/0BzqRx_KjnyMQY3J5S3U5b2FZUGs)

---
### This gets solved Vauxoo/yoytec#967
