### PR TITLE
[ADD] sale_order_dates_max: Add missing translation files to module f…

### DIFF
--- a/sale_order_dates_max/i18n/es.po
+++ b/sale_order_dates_max/i18n/es.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_dates_max
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-06 04:43+0000\n"
+"PO-Revision-Date: 2016-04-06 04:43+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_order_dates_max
+#: model:ir.model,name:sale_order_dates_max.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+

--- a/sale_order_dates_max/i18n/es_MX.po
+++ b/sale_order_dates_max/i18n/es_MX.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_dates_max
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-06 04:43+0000\n"
+"PO-Revision-Date: 2016-04-06 04:43+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/sale_order_dates_max/i18n/es_PA.po
+++ b/sale_order_dates_max/i18n/es_PA.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_dates_max
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-06 04:43+0000\n"
+"PO-Revision-Date: 2016-04-06 04:43+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/sale_order_dates_max/i18n/es_VE.po
+++ b/sale_order_dates_max/i18n/es_VE.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_dates_max
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-06 04:43+0000\n"
+"PO-Revision-Date: 2016-04-06 04:43+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+


### PR DESCRIPTION
…or convention, even if doesn't have translatable fields or views.
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translations to `sale_order_dates_max`
- [x] Create [PR#991](https://github.com/Vauxoo/yoytec/pull/991) dummy. 
- [x] Rebase.
