### PR TITLE
[ADD] stock_transfer_avoid_lot_repeated_split: Add missing translatio…

### DIFF
--- a/stock_transfer_avoid_lot_repeated_split/i18n/es.po
+++ b/stock_transfer_avoid_lot_repeated_split/i18n/es.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_transfer_avoid_lot_repeated_split
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-06 14:28+0000\n"
+"PO-Revision-Date: 2016-04-06 14:28+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_transfer_avoid_lot_repeated_split
+#: model:ir.model,name:stock_transfer_avoid_lot_repeated_split.model_stock_transfer_details_items
+msgid "Picking wizard items"
+msgstr "Elementos del asistente de albarán"
+

--- a/stock_transfer_avoid_lot_repeated_split/i18n/es_MX.po
+++ b/stock_transfer_avoid_lot_repeated_split/i18n/es_MX.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_transfer_avoid_lot_repeated_split
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-06 14:28+0000\n"
+"PO-Revision-Date: 2016-04-06 14:28+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/stock_transfer_avoid_lot_repeated_split/i18n/es_PA.po
+++ b/stock_transfer_avoid_lot_repeated_split/i18n/es_PA.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_transfer_avoid_lot_repeated_split
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-06 14:28+0000\n"
+"PO-Revision-Date: 2016-04-06 14:28+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/stock_transfer_avoid_lot_repeated_split/i18n/es_VE.po
+++ b/stock_transfer_avoid_lot_repeated_split/i18n/es_VE.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_transfer_avoid_lot_repeated_split
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-06 14:28+0000\n"
+"PO-Revision-Date: 2016-04-06 14:28+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+


### PR DESCRIPTION
…n files to module for convention, even if doesn't have translatable fields or views.
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translations to `stock_transfer_avoid_lot_repeated_split`
- [x] Create [PR#993](https://github.com/Vauxoo/yoytec/pull/993) dummy. 
- [x] Rebase.
