### PR TITLE
[IMP] crm_claim_summary_report: fix title, hide footer when context i…

### DIFF
--- a/crm_claim_summary_report/i18n/crm_claim_summary_report.pot
+++ b/crm_claim_summary_report/i18n/crm_claim_summary_report.pot
@@ -205,3 +205,14 @@ msgstr ""
 #: view:website:crm_claim_summary_report.external_layout_header
 msgid "RMA for Supplier"
 msgstr ""
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.page_summary_report
+msgid "Customer's signature"
+msgstr ""
+
+#. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.page_summary_report
+msgid "Stamp of "
+msgstr ""
+

--- a/crm_claim_summary_report/i18n/crm_claim_summary_report.pot
+++ b/crm_claim_summary_report/i18n/crm_claim_summary_report.pot
@@ -213,6 +213,6 @@ msgstr ""
 
 #. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.page_summary_report
-msgid "Stamp of "
+msgid "Stamp of"
 msgstr ""
 

--- a/crm_claim_summary_report/i18n/es.po
+++ b/crm_claim_summary_report/i18n/es.po
@@ -163,6 +163,11 @@ msgid "Customer's signature"
 msgstr "Firma del Cliente"
 
 #. module: crm_claim_summary_report
+#: view:website:crm_claim_summary_report.page_summary_report
+msgid "Stamp of "
+msgstr "Sello de "
+
+#. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.product_on_claim
 #: view:website:crm_claim_summary_report.page_summary_report
 msgid "Priority"

--- a/crm_claim_summary_report/i18n/es.po
+++ b/crm_claim_summary_report/i18n/es.po
@@ -164,8 +164,8 @@ msgstr "Firma del Cliente"
 
 #. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.page_summary_report
-msgid "Stamp of "
-msgstr "Sello de "
+msgid "Stamp of"
+msgstr "Sello de"
 
 #. module: crm_claim_summary_report
 #: view:website:crm_claim_summary_report.product_on_claim

--- a/crm_claim_summary_report/reports/__init__.py
+++ b/crm_claim_summary_report/reports/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    Copyright 2015 Vauxoo
+#    Copyright 2016 Vauxoo
 #    Author : Osval Reyes <osval@vauxoo.com>
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -18,5 +18,4 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from . import models
-from . import reports
+from . import report

--- a/crm_claim_summary_report/reports/claim_summary_report.xml
+++ b/crm_claim_summary_report/reports/claim_summary_report.xml
@@ -9,6 +9,7 @@
         <template id="summary_report">
             <t t-set="body_classname" t-value="'container'"/>
             <t t-foreach="docs" t-as="doc">
+                <t t-set="rma_ctx" t-value="doc.claim_type.name.lower()"/>
                 <t t-call="crm_claim_summary_report.layout">
                     <t t-set="page_copy_title" t-value="doc.claim_type.name.lower()"/>
                     <t t-call="crm_claim_summary_report.claim_copy_page"/>
@@ -48,9 +49,9 @@
                 <div class="col-xs-2" style="text-align:right;">
                     <p class="row" style="font-size:12px">
                         <strong>
-                            <t t-if="page_copy_title == 'customer'">Customer name</t>
-                            <t t-if="page_copy_title == 'supplier'">Supplier name</t>
-                            <t t-if="page_copy_title not in ['supplier','customer']">Name</t>
+                            <t t-if="rma_ctx == 'customer'">Customer name</t>
+                            <t t-if="rma_ctx == 'supplier'">Supplier name</t>
+                            <t t-if="rma_ctx not in ['supplier','customer']">Name</t>
                             <span>:</span>
                         </strong>
                     </p>
@@ -194,7 +195,7 @@
                     </tbody>
                 </table>
                 <br/> <br/> <br/> <br/>
-                <t t-if="page_copy_title == 'customer'">
+                <t t-if="rma_ctx == 'customer'">
                     <p align="center">_______________________________________________</p>
                     <p align="center">Customer's signature</p>
                 </t>

--- a/crm_claim_summary_report/reports/claim_summary_report.xml
+++ b/crm_claim_summary_report/reports/claim_summary_report.xml
@@ -9,7 +9,8 @@
         <template id="summary_report">
             <t t-set="body_classname" t-value="'container'"/>
             <t t-foreach="docs" t-as="doc">
-                <t t-set="rma_ctx" t-value="doc.claim_type.name.lower()"/>
+                <t t-set="rma_ctx" t-value="(doc.claim_type.id == ref('crm_claim_type.crm_claim_type_supplier') and 'supplier')
+                    or (doc.claim_type.id == ref('crm_claim_type.crm_claim_type_customer') and 'customer') or 'internal'"/>
                 <t t-call="crm_claim_summary_report.layout">
                     <t t-set="page_copy_title" t-value="doc.claim_type.name.lower()"/>
                     <t t-call="crm_claim_summary_report.claim_copy_page"/>

--- a/crm_claim_summary_report/reports/claim_summary_report.xml
+++ b/crm_claim_summary_report/reports/claim_summary_report.xml
@@ -9,10 +9,9 @@
         <template id="summary_report">
             <t t-set="body_classname" t-value="'container'"/>
             <t t-foreach="docs" t-as="doc">
-                <t t-set="rma_ctx" t-value="(doc.claim_type.id == ref('crm_claim_type.crm_claim_type_supplier') and 'supplier')
-                    or (doc.claim_type.id == ref('crm_claim_type.crm_claim_type_customer') and 'customer') or 'internal'"/>
+                <t t-set="rma_ctx" t-value="get_report_ctx(doc.claim_type)"/>
                 <t t-call="crm_claim_summary_report.layout">
-                    <t t-set="page_copy_title" t-value="doc.claim_type.name.lower()"/>
+                    <t t-set="page_copy_title" t-value="rma_ctx"/>
                     <t t-call="crm_claim_summary_report.claim_copy_page"/>
                     <t t-set="page_copy_title" t-value="'internal'"/>
                     <t t-call="crm_claim_summary_report.claim_copy_page"/>
@@ -50,8 +49,8 @@
                 <div class="col-xs-2" style="text-align:right;">
                     <p class="row" style="font-size:12px">
                         <strong>
-                            <t t-if="rma_ctx == 'customer'">Customer name</t>
-                            <t t-if="rma_ctx == 'supplier'">Supplier name</t>
+                            <t t-if="rma_ctx in ['customer']">Customer name</t>
+                            <t t-if="rma_ctx in ['supplier']">Supplier name</t>
                             <t t-if="rma_ctx not in ['supplier','customer']">Name</t>
                             <span>:</span>
                         </strong>
@@ -198,7 +197,12 @@
                 <br/> <br/> <br/> <br/>
                 <t t-if="rma_ctx == 'customer'">
                     <p align="center">_______________________________________________</p>
+                    <t t-if="page_copy_title == 'internal'">
                     <p align="center">Customer's signature</p>
+                    </t>
+                    <t t-if="page_copy_title == 'customer'">
+                    <p align="center">Stamp of <span t-field="company.name"/></p>
+                    </t>
                 </t>
             </div>
         </template>

--- a/crm_claim_summary_report/reports/claim_summary_report_layouts.xml
+++ b/crm_claim_summary_report/reports/claim_summary_report_layouts.xml
@@ -117,13 +117,13 @@
                             <h3><small><span>TIN</span>: <span t-field="company.vat"/> </small></h3>
                         </t>
                         <p><h4>
-                            <t t-if="page_copy_title == 'customer'">
+                            <t t-if="rma_ctx == 'customer'">
                                 RMA Receipt for Customer
                             </t>
-                            <t t-if="page_copy_title == 'supplier'">
+                            <t t-if="rma_ctx == 'supplier'">
                                 RMA for Supplier
                             </t>
-                            <t t-if="page_copy_title not in ['customer','supplier']">
+                            <t t-if="rma_ctx not in ['customer','supplier']">
                                 RMA Receipt
                             </t>
                         </h4></p>
@@ -177,10 +177,12 @@
             </t>
         </template>
         <template id="crm_claim_summary_report.external_layout_footer">
-            <div class="footer rma-page-note" t-if="page_copy_title">
-                <div class="row" >
+            <div class="row" >
+                <div class="footer rma-page-note" >
+                    <t t-if="rma_ctx == 'customer'">
                     <p style="font-size: 7pt;"><b>IMPORTANT NOTE</b><span>: </span><span t-field="company.rma_footer_note"/>
                     </p>
+                    </t>
                 </div>
             </div>
         </template>

--- a/crm_claim_summary_report/reports/report.py
+++ b/crm_claim_summary_report/reports/report.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2016 Vauxoo
+#    Author : Osval Reyes <osval@vauxoo.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.report import report_sxw
+from openerp import models
+
+
+class CrmClaimSummaryReport(report_sxw.rml_parse):
+
+    def __init__(self, cr, uid, name, context):
+        super(CrmClaimSummaryReport, self).__init__(
+            cr, uid, name, context=context)
+        self.localcontext.update({
+            'get_report_ctx': self.get_report_ctx,
+        })
+
+    def get_report_ctx(self, claim_type):
+        supplier_id = self.get_xml_id('crm_claim_type',
+                                      'crm_claim_type_supplier')
+        customer_id = self.get_xml_id('crm_claim_type',
+                                      'crm_claim_type_customer')
+        return 'customer' if claim_type.id == customer_id else \
+            ('supplier' if claim_type.id == supplier_id else 'internal')
+
+    def get_xml_id(self, module, xml_id_str):
+        return self.pool.get('ir.model.data').\
+            get_object_reference(self.cr, self.uid,
+                                 module, xml_id_str)[1]
+
+
+class CrmClaimSummaryReportParser(models.AbstractModel):
+    _name = 'report.crm_claim_summary_report.report_translated'
+    _inherit = 'report.abstract_report'
+    _template = 'crm_claim_summary_report.report_translated'
+    _wrapped_report_class = CrmClaimSummaryReport


### PR DESCRIPTION
## [Task 5123](https://www.vauxoo.com/web?#id=5123&view_type=form&model=project.task&menu_id=136&action=138)

Reports in both context (supplier and customer) can be seen in [here](https://drive.google.com/drive/folders/0BzqRx_KjnyMQb2dTcVZEVGRCWlU)
- [X] Remove footer note and signature place when is printed for Supplier claim document
- [X] Add report parser to be able and set a ctx-like in order to identify what type of rma document the template is dealing with
- [X] Use ID instead of claim's type name
- [X] Include a YourCompany stamp place in customer copy
