### PR TITLE
[ADD] account_anglo_saxon_missing_key: Add missing translation files.

### DIFF
--- a/account_anglo_saxon_missing_key/i18n/es.po
+++ b/account_anglo_saxon_missing_key/i18n/es.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_anglo_saxon_missing_key
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-13 18:34+0000\n"
+"PO-Revision-Date: 2016-04-13 18:34+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_anglo_saxon_missing_key
+#: model:ir.model,name:account_anglo_saxon_missing_key.model_account_invoice_line
+msgid "Invoice Line"
+msgstr "Línea de factura"
+

--- a/account_anglo_saxon_missing_key/i18n/es_MX.po
+++ b/account_anglo_saxon_missing_key/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_anglo_saxon_missing_key
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-13 18:34+0000\n"
+"PO-Revision-Date: 2016-04-13 18:34+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_anglo_saxon_missing_key/i18n/es_PA.po
+++ b/account_anglo_saxon_missing_key/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_anglo_saxon_missing_key
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-13 18:34+0000\n"
+"PO-Revision-Date: 2016-04-13 18:34+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_anglo_saxon_missing_key/i18n/es_VE.po
+++ b/account_anglo_saxon_missing_key/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_anglo_saxon_missing_key
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-13 18:34+0000\n"
+"PO-Revision-Date: 2016-04-13 18:34+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `account_anglo_saxon_missing_key`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#485](https://github.com/Vauxoo/lodigroup/pull/485) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
