### PR TITLE
[ADD] account_anglo_saxon_stock_move_sale: Add missing translation files.

### DIFF
--- a/account_anglo_saxon_stock_move_sale/i18n/es.po
+++ b/account_anglo_saxon_stock_move_sale/i18n/es.po
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_anglo_saxon_stock_move_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-13 22:51+0000\n"
+"PO-Revision-Date: 2016-04-13 22:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_anglo_saxon_stock_move_sale
+#: field:sale.order,aml_ids:0
+msgid "Account Move Lines"
+msgstr "Account Move Lines"
+
+#. module: account_anglo_saxon_stock_move_sale
+#: code:addons/account_anglo_saxon_stock_move_sale/model/sale.py:52
+#: model:ir.model,name:account_anglo_saxon_stock_move_sale.model_account_move_line
+#, python-format
+msgid "Journal Items"
+msgstr "Elementos diario"
+
+#. module: account_anglo_saxon_stock_move_sale
+#: field:account.move.line,sale_id:0
+msgid "Sale Order"
+msgstr "Sale Order"
+
+#. module: account_anglo_saxon_stock_move_sale
+#: model:ir.model,name:account_anglo_saxon_stock_move_sale.model_sale_order
+msgid "Sales Order"
+msgstr "Pedidos de Venta"
+
+#. module: account_anglo_saxon_stock_move_sale
+#: view:sale.order:account_anglo_saxon_stock_move_sale.sale_stock_accrual_view
+msgid "Stock Accruals"
+msgstr "Stock Accruals"
+

--- a/account_anglo_saxon_stock_move_sale/i18n/es_MX.po
+++ b/account_anglo_saxon_stock_move_sale/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_anglo_saxon_stock_move_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-13 22:51+0000\n"
+"PO-Revision-Date: 2016-04-13 22:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_anglo_saxon_stock_move_sale/i18n/es_PA.po
+++ b/account_anglo_saxon_stock_move_sale/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_anglo_saxon_stock_move_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-13 22:51+0000\n"
+"PO-Revision-Date: 2016-04-13 22:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_anglo_saxon_stock_move_sale/i18n/es_VE.po
+++ b/account_anglo_saxon_stock_move_sale/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_anglo_saxon_stock_move_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-13 22:51+0000\n"
+"PO-Revision-Date: 2016-04-13 22:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `account_anglo_saxon_stock_move_sale`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#488](https://github.com/Vauxoo/lodigroup/pull/488) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
