### PR TITLE
[ADD] account_reconcile_grouping: Add missing translation files.

### DIFF
--- a/account_reconcile_grouping/i18n/es.po
+++ b/account_reconcile_grouping/i18n/es.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_reconcile_grouping
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 14:12+0000\n"
+"PO-Revision-Date: 2016-04-14 14:12+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_reconcile_grouping
+#: view:account.move.line:account_reconcile_grouping.account_move_line_grouping_reconcile_search
+msgid "Parcial Reconcile"
+msgstr "Parcial Reconcile"
+
+#. module: account_reconcile_grouping
+#: view:account.move.line:account_reconcile_grouping.account_move_line_grouping_reconcile_search
+msgid "Total Reconcile"
+msgstr "Total Reconcile"
+

--- a/account_reconcile_grouping/i18n/es_ES.po
+++ b/account_reconcile_grouping/i18n/es_ES.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_reconcile_grouping
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 14:12+0000\n"
+"PO-Revision-Date: 2016-04-14 14:12+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_reconcile_grouping/i18n/es_MX.po
+++ b/account_reconcile_grouping/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_reconcile_grouping
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 14:12+0000\n"
+"PO-Revision-Date: 2016-04-14 14:12+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_reconcile_grouping/i18n/es_PA.po
+++ b/account_reconcile_grouping/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_reconcile_grouping
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 14:12+0000\n"
+"PO-Revision-Date: 2016-04-14 14:12+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_reconcile_grouping/i18n/es_VE.po
+++ b/account_reconcile_grouping/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_reconcile_grouping
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 14:12+0000\n"
+"PO-Revision-Date: 2016-04-14 14:12+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `account_reconcile_grouping`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Add `es_ES.po` file
- [x] Rebase.
- [x] Create [PR#492](https://github.com/Vauxoo/lodigroup/pull/492) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
