### PR TITLE
[ADD] account_refund_early_payment: Add missing translation files.

### DIFF
--- a/account_refund_early_payment/i18n/es.po
+++ b/account_refund_early_payment/i18n/es.po
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_refund_early_payment
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 14:56+0000\n"
+"PO-Revision-Date: 2016-04-14 14:56+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_refund_early_payment
+#: field:account.invoice.refund,active_id:0
+msgid "Active ID"
+msgstr "Active ID"
+
+#. module: account_refund_early_payment
+#: field:account.invoice.refund,amount_total:0
+msgid "Amount"
+msgstr "Amount"
+
+#. module: account_refund_early_payment
+#: model:ir.actions.act_window,name:account_refund_early_payment.act_wizard_refund_invoice
+msgid "Create refund invoice"
+msgstr "Create refund invoice"
+
+#. module: account_refund_early_payment
+#: model:product.template,name:account_refund_early_payment.product_discount_early_payment_product_template
+msgid "Discount Early Payment"
+msgstr "Discount Early Payment"
+
+#. module: account_refund_early_payment
+#: model:ir.model,name:account_refund_early_payment.model_account_invoice_refund
+msgid "Invoice Refund"
+msgstr "Nota de Credito"
+
+#. module: account_refund_early_payment
+#: field:account.invoice.refund,percent:0
+msgid "Percent"
+msgstr "Percent"
+
+#. module: account_refund_early_payment
+#: field:account.invoice.refund,product_id:0
+msgid "Product"
+msgstr "Product"
+

--- a/account_refund_early_payment/i18n/es_MX.po
+++ b/account_refund_early_payment/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_refund_early_payment
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 14:56+0000\n"
+"PO-Revision-Date: 2016-04-14 14:56+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_refund_early_payment/i18n/es_PA.po
+++ b/account_refund_early_payment/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_refund_early_payment
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 14:56+0000\n"
+"PO-Revision-Date: 2016-04-14 14:56+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_refund_early_payment/i18n/es_VE.po
+++ b/account_refund_early_payment/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_refund_early_payment
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 14:56+0000\n"
+"PO-Revision-Date: 2016-04-14 14:56+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `account_refund_early_payment`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#493](https://github.com/Vauxoo/lodigroup/pull/493) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
