### PR TITLE
[ADD] account_voucher_tax_sat: Add missing translation files.

### DIFF
--- a/account_voucher_tax_sat/i18n/es.po
+++ b/account_voucher_tax_sat/i18n/es.po
@@ -1,0 +1,259 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_voucher_tax_sat
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 15:26+0000\n"
+"PO-Revision-Date: 2016-04-14 15:26+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_voucher_tax_sat
+#: view:account.voucher.tax.assigned:account_voucher_tax_sat.view_account_voucher_tax_form2
+#: model:ir.actions.act_window,name:account_voucher_tax_sat.action_view_account_voucher_tax_assigned
+msgid "Account Voucher Tax Assigned"
+msgstr "Account Voucher Tax Assigned"
+
+#. module: account_voucher_tax_sat
+#: view:account.voucher.tax.sat:account_voucher_tax_sat.view_account_voucher_tax_sat_form
+#: view:account.voucher.tax.sat:account_voucher_tax_sat.view_account_voucher_tax_sat_tree
+msgid "Account Voucher Tax SAT"
+msgstr "Account Voucher Tax SAT"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.assigned,account_ids:0
+msgid "Account to Close"
+msgstr "Account to Close"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.sat,date:0
+msgid "Accounting Date Posted"
+msgstr "Accounting Date Posted"
+
+#. module: account_voucher_tax_sat
+#: help:account.voucher.tax.sat,move_id:0
+msgid "Accounting Entry"
+msgstr "Accounting Entry"
+
+#. module: account_voucher_tax_sat
+#: help:account.voucher.tax.sat,journal_id:0
+msgid "Accounting Journal where Entries will be posted"
+msgstr "Accounting Journal where Entries will be posted"
+
+#. module: account_voucher_tax_sat
+#: help:account.voucher.tax.sat,date:0
+msgid "Accounting date affected"
+msgstr "Accounting date affected"
+
+#. module: account_voucher_tax_sat
+#: view:account.voucher.tax.sat:account_voucher_tax_sat.view_account_voucher_tax_sat_form
+msgid "Assigned Account"
+msgstr "Assigned Account"
+
+#. module: account_voucher_tax_sat
+#: view:account.voucher.tax.assigned:account_voucher_tax_sat.view_account_voucher_tax_form2
+#: view:account.voucher.tax.sat:account_voucher_tax_sat.view_account_voucher_tax_sat_form
+msgid "Cancel"
+msgstr "Cancel"
+
+#. module: account_voucher_tax_sat
+#: selection:account.voucher.tax.sat,state:0
+msgid "Cancelled"
+msgstr "Cancelled"
+
+#. module: account_voucher_tax_sat
+#: code:addons/account_voucher_tax_sat/model/account_voucher_tax_sat.py:169
+#: code:addons/account_voucher_tax_sat/model/account_voucher_tax_sat.py:183
+#, python-format
+msgid "Close of IVA Retained"
+msgstr "Close of IVA Retained"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.sat,company_id:0
+#: help:account.voucher.tax.sat,company_id:0
+msgid "Company"
+msgstr "Company"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.assigned,create_uid:0
+#: field:account.voucher.tax.sat,create_uid:0
+msgid "Created by"
+msgstr "Created by"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.assigned,create_date:0
+#: field:account.voucher.tax.sat,create_date:0
+msgid "Created on"
+msgstr "Created on"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.assigned,display_name:0
+#: field:account.voucher.tax.sat,display_name:0
+msgid "Display Name"
+msgstr "Display Name"
+
+#. module: account_voucher_tax_sat
+#: selection:account.voucher.tax.sat,state:0
+msgid "Done"
+msgstr "Done"
+
+#. module: account_voucher_tax_sat
+#: help:account.voucher.tax.sat,aml_iva_ids:0
+msgid "Entries IVA to close"
+msgstr "Entries IVA to close"
+
+#. module: account_voucher_tax_sat
+#: help:account.voucher.tax.sat,aml_ids:0
+msgid "Entries to close"
+msgstr "Entries to close"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.assigned,id:0
+#: field:account.voucher.tax.sat,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: account_voucher_tax_sat
+#: field:res.partner,sat:0
+msgid "Is SAT?"
+msgstr "Is SAT?"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.sat,journal_id:0
+msgid "Journal"
+msgstr "Journal"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.sat,move_id:0
+msgid "Journal Entry"
+msgstr "Journal Entry"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.assigned,__last_update:0
+#: field:account.voucher.tax.sat,__last_update:0
+msgid "Last Modified on"
+msgstr "Last Modified on"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.assigned,write_uid:0
+#: field:account.voucher.tax.sat,write_uid:0
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.assigned,write_date:0
+#: field:account.voucher.tax.sat,write_date:0
+msgid "Last Updated on"
+msgstr "Last Updated on"
+
+#. module: account_voucher_tax_sat
+#: view:account.voucher.tax.sat:account_voucher_tax_sat.view_account_voucher_tax_sat_form
+msgid "Liquidar Cuentas"
+msgstr "Liquidar Cuentas"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.sat,aml_ids:0
+#: field:account.voucher.tax.sat,aml_iva_ids:0
+msgid "Move Lines"
+msgstr "Move Lines"
+
+#. module: account_voucher_tax_sat
+#: view:account.voucher.tax.sat:account_voucher_tax_sat.view_account_voucher_tax_sat_form
+#: field:account.voucher.tax.sat,name:0
+msgid "Name"
+msgstr "Name"
+
+#. module: account_voucher_tax_sat
+#: help:account.voucher.tax.sat,name:0
+msgid "Name of This Document"
+msgstr "Name of This Document"
+
+#. module: account_voucher_tax_sat
+#: selection:account.voucher.tax.sat,state:0
+msgid "New"
+msgstr "New"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.sat,partner_id:0
+#: model:ir.model,name:account_voucher_tax_sat.model_res_partner
+msgid "Partner"
+msgstr "Partner"
+
+#. module: account_voucher_tax_sat
+#: help:account.voucher.tax.sat,partner_id:0
+msgid "Partner of SAT"
+msgstr "Partner of SAT"
+
+#. module: account_voucher_tax_sat
+#: view:account.voucher.tax.sat:account_voucher_tax_sat.view_account_voucher_tax_sat_form
+#: code:addons/account_voucher_tax_sat/model/account_voucher_tax_sat.py:234
+#, python-format
+msgid "Pay SAT"
+msgstr "Pay SAT"
+
+#. module: account_voucher_tax_sat
+#: code:addons/account_voucher_tax_sat/model/account_voucher_tax_sat.py:205
+#, python-format
+msgid "Payment to SAT"
+msgstr "Payment to SAT"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.sat,period_id:0
+msgid "Period"
+msgstr "Period"
+
+#. module: account_voucher_tax_sat
+#: help:account.voucher.tax.sat,period_id:0
+msgid "Period of Entries to find"
+msgstr "Period of Entries to find"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.sat,state:0
+msgid "Status"
+msgstr "Status"
+
+#. module: account_voucher_tax_sat
+#: model:res.groups,name:account_voucher_tax_sat.group_voucher_tax_sat_manager
+msgid "Tax SAT Manager"
+msgstr "Tax SAT Manager"
+
+#. module: account_voucher_tax_sat
+#: model:res.groups,name:account_voucher_tax_sat.group_voucher_tax_sat_user
+msgid "Tax SAT User"
+msgstr "Tax SAT User"
+
+#. module: account_voucher_tax_sat
+#: field:account.voucher.tax.assigned,tax_ids:0
+msgid "Taxes to Close"
+msgstr "Taxes to Close"
+
+#. module: account_voucher_tax_sat
+#: model:ir.actions.act_window,name:account_voucher_tax_sat.account_voucher_tax_sat_action
+#: model:ir.ui.menu,name:account_voucher_tax_sat.account_voucher_tax_sat_menu
+msgid "Voucher Tax SAT"
+msgstr "Voucher Tax SAT"
+
+#. module: account_voucher_tax_sat
+#: code:addons/account_voucher_tax_sat/model/account_voucher_tax_sat.py:98
+#, python-format
+msgid "Warning"
+msgstr "Warning"
+
+#. module: account_voucher_tax_sat
+#: code:addons/account_voucher_tax_sat/model/account_voucher_tax_sat.py:99
+#, python-format
+msgid "You have this jornal items in other voucher tax sat '%s' "
+msgstr "You have this jornal items in other voucher tax sat '%s' "
+
+#. module: account_voucher_tax_sat
+#: view:account.voucher.tax.assigned:account_voucher_tax_sat.view_account_voucher_tax_form2
+msgid "or"
+msgstr "or"
+

--- a/account_voucher_tax_sat/i18n/es_MX.po
+++ b/account_voucher_tax_sat/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_voucher_tax_sat
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 15:26+0000\n"
+"PO-Revision-Date: 2016-04-14 15:26+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `account_voucher_tax_sat`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#494](https://github.com/Vauxoo/lodigroup/pull/494) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
