### PR TITLE
[IMP] Search by HU and CA number in the acceptability criteria tree view

### DIFF
--- a/user_story/model/user_story.py
+++ b/user_story/model/user_story.py
@@ -627,6 +627,21 @@ class AcceptabilityCriteria(osv.Model):
             res[ac.id] = ac.accep_crit_id.state
         return res
 
+    def _get_us_ca_numbers(self, cr, uid, ids, fieldname, arg,
+                           context=None):
+        ''' For acceptability.criteria,
+            returns the state of user.story to which belong '''
+        res = {}.fromkeys(ids)
+        for ac in self.browse(cr, uid, ids, context=context):
+            ac_number = ac.name.split(')')
+            if len(ac_number) > 1:
+                ac_number = ac_number[0]
+            else:
+                ac_number = ac.name[0:3]
+            res[ac.id] = \
+                'HU#' + str(ac.accep_crit_id.id) + ' CA#' + ac_number
+        return res
+
     _columns = {
         'name': fields.char('Title', size=255, required=True, readonly=False,
                             translate=True),
@@ -642,6 +657,12 @@ class AcceptabilityCriteria(osv.Model):
             string='User Story State',
             store={'user.story': (_get_ac_ids_by_us_ids, ['state'], 10)},
         ),
+        'us_ac_numbers': fields.function(
+            _get_us_ca_numbers,
+            type='char',
+            string='US AC #',
+            help='User Story and Acceptability Criteria Numbers',
+            store=True),
         'accepted': fields.boolean('Accepted',
                                    help='Check if this criterion apply'),
         'development': fields.boolean('Development'),

--- a/user_story/view/userstory_view.xml
+++ b/user_story/view/userstory_view.xml
@@ -233,6 +233,7 @@
                     </h1>
                     <group>
                         <field name="scenario"/>
+                        <field name="us_ac_numbers"/>
                         <field name="accepted"/>
                         <field name="development"/>
                         <field name="difficulty" invisible="1"/>
@@ -250,6 +251,7 @@
         <field name="arch" type="xml">
             <tree string="Acceptability Criteria">
                 <field name="id"/>
+                <field name="us_ac_numbers"/>
                 <field name="name"/>
                 <field name="scenario"/>
                 <field name="accep_crit_id"/>
@@ -276,6 +278,7 @@
         <field name="arch" type="xml">
             <search string="Acceptability Criteria">
                 <group string="Filter">
+                    <field name="us_ac_numbers"/>
                     <field name="id"/>
                     <field name="name"/>
                     <field name="scenario"/>


### PR DESCRIPTION
Create a new field and show it in the acceptability criteria tree view.
This new field will be a compute field that shows this string:

```
HU#123 CA#45
```

This is an extra functionality for make the acceptability criteria more easy to review for functional and technical leader in order to search then by user story and CA number.

Best Regards

> NOTE This new functionality is for solve part of the issue https://github.com/Vauxoo/instance/issues/245
