### PR TITLE
[ADD] product_extended_segmentation: Add missing translation files.

### DIFF
--- a/product_extended_segmentation/i18n/es.po
+++ b/product_extended_segmentation/i18n/es.po
@@ -1,0 +1,105 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_extended_segmentation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 18:26+0000\n"
+"PO-Revision-Date: 2016-04-14 18:26+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_extended_segmentation
+#: code:addons/product_extended_segmentation/model/company.py:19
+#, python-format
+msgid "Bottom cost threshold must be positive"
+msgstr "Bottom cost threshold must be positive"
+
+#. module: product_extended_segmentation
+#: model:ir.model,name:product_extended_segmentation.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: product_extended_segmentation
+#: model:ir.model,name:product_extended_segmentation.model_wizard_price
+msgid "Compute price wizard"
+msgstr "Asistente de cálculo de precio"
+
+#. module: product_extended_segmentation
+#: help:res.company,std_price_neg_threshold:0
+msgid "Maximum percentage threshold that Standard Price is allowed to be lower in order to be changed with the update cost wizard"
+msgstr "Maximum percentage threshold that Standard Price is allowed to be lower in order to be changed with the update cost wizard"
+
+#. module: product_extended_segmentation
+#: help:purchase.config.settings,std_price_neg_threshold:0
+msgid "Maximum percentage threshold that Standard Price is allowed to lower"
+msgstr "Maximum percentage threshold that Standard Price is allowed to lower"
+
+#. module: product_extended_segmentation
+#: model:ir.model,name:product_extended_segmentation.model_product_product
+#: view:purchase.config.settings:product_extended_segmentation.view_double_purchase_configuration
+msgid "Product"
+msgstr "Producto"
+
+#. module: product_extended_segmentation
+#: model:ir.model,name:product_extended_segmentation.model_product_template
+msgid "Product Template"
+msgstr "Plantilla de producto"
+
+#. module: product_extended_segmentation
+#: field:purchase.config.settings,std_price_neg_threshold:0
+#: field:res.company,std_price_neg_threshold:0
+msgid "Standard Price Bottom Threshold (%)"
+msgstr "Standard Price Bottom Threshold (%)"
+
+#. module: product_extended_segmentation
+#: view:res.company:product_extended_segmentation.res_company_view_product_extended_segmentation
+msgid "Standard Price Threshold"
+msgstr "Standard Price Threshold"
+
+#. module: product_extended_segmentation
+#: field:wizard.price,update_avg_costs:0
+msgid "Update Average Product Costs"
+msgstr "Update Average Product Costs"
+
+#. module: product_extended_segmentation
+#: model:ir.actions.server,name:product_extended_segmentation.update_material_cost_on_zero_segmentation
+msgid "Update Material Cost on Zero Segmentation"
+msgstr "Update Material Cost on Zero Segmentation"
+
+#. module: product_extended_segmentation
+#: view:wizard.price:product_extended_segmentation.view_compute_price_wizard
+msgid "onchange_recursive(recursive)"
+msgstr "onchange_recursive(recursive)"
+
+#. module: product_extended_segmentation
+#: model:product.template,name:product_extended_segmentation.producto_a_product_template
+msgid "producto_a"
+msgstr "producto_a"
+
+#. module: product_extended_segmentation
+#: model:product.template,name:product_extended_segmentation.producto_b_product_template
+msgid "producto_b"
+msgstr "producto_b"
+
+#. module: product_extended_segmentation
+#: model:product.template,name:product_extended_segmentation.producto_c_product_template
+msgid "producto_c"
+msgstr "producto_c"
+
+#. module: product_extended_segmentation
+#: model:product.template,name:product_extended_segmentation.producto_d_product_template
+msgid "producto_d"
+msgstr "producto_d"
+
+#. module: product_extended_segmentation
+#: model:product.template,name:product_extended_segmentation.producto_e_product_template
+msgid "producto_e"
+msgstr "producto_e"
+

--- a/product_extended_segmentation/i18n/es_MX.po
+++ b/product_extended_segmentation/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_extended_segmentation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 18:26+0000\n"
+"PO-Revision-Date: 2016-04-14 18:26+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/product_extended_segmentation/i18n/es_PA.po
+++ b/product_extended_segmentation/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_extended_segmentation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 18:26+0000\n"
+"PO-Revision-Date: 2016-04-14 18:26+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/product_extended_segmentation/i18n/es_VE.po
+++ b/product_extended_segmentation/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_extended_segmentation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 18:26+0000\n"
+"PO-Revision-Date: 2016-04-14 18:26+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `product_extended_segmentation`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#500](https://github.com/Vauxoo/lodigroup/pull/500) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
