### PR TITLE
[IMP] US AC Number is updated when AC name is updated.

### DIFF
--- a/user_story/model/user_story.py
+++ b/user_story/model/user_story.py
@@ -662,7 +662,9 @@ class AcceptabilityCriteria(osv.Model):
             type='char',
             string='US AC #',
             help='User Story and Acceptability Criteria Numbers',
-            store=True),
+            store={'acceptability.criteria': (lambda s, c, u, i, ctx: i,
+                                             ['accep_crit_id', 'name'], 16)}
+        ),
         'accepted': fields.boolean('Accepted',
                                    help='Check if this criterion apply'),
         'development': fields.boolean('Development'),


### PR DESCRIPTION
[ADD] us_ac_numbers field to identify acceptability criteria data will be updated when the ac name or hu is updated.

Close Vauxoo/instance#245 (Issue)
Close Vauxoo/instance#246 (Testing PR)
Related to #839  (First Part of the functionality early merged)
