### PR TITLE
[ADD] product_extended_variants: Add missing translation files.

### DIFF
--- a/product_extended_variants/i18n/es.po
+++ b/product_extended_variants/i18n/es.po
@@ -1,0 +1,71 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_extended_variants
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:10+0000\n"
+"PO-Revision-Date: 2016-04-14 23:10+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_extended_variants
+#: code:addons/product_extended_variants/wizard/wizard_price.py:236
+#: code:addons/product_extended_variants/wizard/wizard_price.py:258
+#, python-format
+msgid "Active ID is not set in Context."
+msgstr "Active ID is not set in Context."
+
+#. module: product_extended_variants
+#: model:ir.model,name:product_extended_variants.model_wizard_price
+msgid "Compute price wizard"
+msgstr "Asistente de cálculo de precio"
+
+#. module: product_extended_variants
+#: field:product.product,landed_cost:0
+msgid "Landed Cost"
+msgstr "Landed Cost"
+
+#. module: product_extended_variants
+#: field:product.product,material_cost:0
+msgid "Material Cost"
+msgstr "Material Cost"
+
+#. module: product_extended_variants
+#: model:ir.model,name:product_extended_variants.model_product_product
+msgid "Product"
+msgstr "Producto"
+
+#. module: product_extended_variants
+#: model:ir.model,name:product_extended_variants.model_product_template
+msgid "Product Template"
+msgstr "Plantilla de producto"
+
+#. module: product_extended_variants
+#: field:product.product,production_cost:0
+msgid "Production Cost"
+msgstr "Production Cost"
+
+#. module: product_extended_variants
+#: view:product.product:product_extended_variants.product_extend_form_view
+msgid "Recompute price from BoM"
+msgstr "Recompute price from BoM"
+
+#. module: product_extended_variants
+#: code:addons/product_extended_variants/model/template.py:169
+#: code:addons/product_extended_variants/model/template.py:176
+#, python-format
+msgid "Standard Price changed"
+msgstr "Standard Price changed"
+
+#. module: product_extended_variants
+#: field:product.product,subcontracting_cost:0
+msgid "Subcontracting Cost"
+msgstr "Subcontracting Cost"
+

--- a/product_extended_variants/i18n/es_MX.po
+++ b/product_extended_variants/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_extended_variants
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:10+0000\n"
+"PO-Revision-Date: 2016-04-14 23:10+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/product_extended_variants/i18n/es_PA.po
+++ b/product_extended_variants/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_extended_variants
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:10+0000\n"
+"PO-Revision-Date: 2016-04-14 23:10+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/product_extended_variants/i18n/es_VE.po
+++ b/product_extended_variants/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_extended_variants
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:10+0000\n"
+"PO-Revision-Date: 2016-04-14 23:10+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `product_extended_variants`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#501](https://github.com/Vauxoo/lodigroup/pull/501) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
