### PR TITLE
[ADD] purchase_order_line_quantity: Add missing translation files.

### DIFF
--- a/purchase_order_line_quantity/i18n/es.po
+++ b/purchase_order_line_quantity/i18n/es.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_order_line_quantity
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:21+0000\n"
+"PO-Revision-Date: 2016-04-14 23:21+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_order_line_quantity
+#: model:ir.model,name:purchase_order_line_quantity.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Línea pedido de compra"
+
+#. module: purchase_order_line_quantity
+#: field:purchase.order.line,qty_delivered:0
+#: help:purchase.order.line,qty_delivered:0
+msgid "Quantity Delivered"
+msgstr "Quantity Delivered"
+
+#. module: purchase_order_line_quantity
+#: field:purchase.order.line,qty_invoiced:0
+#: help:purchase.order.line,qty_invoiced:0
+msgid "Quantity Invoiced"
+msgstr "Quantity Invoiced"
+

--- a/purchase_order_line_quantity/i18n/es_MX.po
+++ b/purchase_order_line_quantity/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_order_line_quantity
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:21+0000\n"
+"PO-Revision-Date: 2016-04-14 23:21+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/purchase_order_line_quantity/i18n/es_PA.po
+++ b/purchase_order_line_quantity/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_order_line_quantity
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:21+0000\n"
+"PO-Revision-Date: 2016-04-14 23:21+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/purchase_order_line_quantity/i18n/es_VE.po
+++ b/purchase_order_line_quantity/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_order_line_quantity
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:21+0000\n"
+"PO-Revision-Date: 2016-04-14 23:21+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `purchase_order_line_quantity`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#502](https://github.com/Vauxoo/lodigroup/pull/502) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
