### PR TITLE
[ADD] sale_order_line_quantity: Add missing translation files.

### DIFF
--- a/sale_order_line_quantity/i18n/es.po
+++ b/sale_order_line_quantity/i18n/es.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_line_quantity
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:33+0000\n"
+"PO-Revision-Date: 2016-04-14 23:33+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_order_line_quantity
+#: field:sale.order.line,qty_delivered:0
+#: help:sale.order.line,qty_delivered:0
+msgid "Quantity Delivered"
+msgstr "Quantity Delivered"
+
+#. module: sale_order_line_quantity
+#: field:sale.order.line,qty_invoiced:0
+#: help:sale.order.line,qty_invoiced:0
+msgid "Quantity Invoiced"
+msgstr "Quantity Invoiced"
+
+#. module: sale_order_line_quantity
+#: model:ir.model,name:sale_order_line_quantity.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea pedido de venta"
+

--- a/sale_order_line_quantity/i18n/es_MX.po
+++ b/sale_order_line_quantity/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_line_quantity
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:33+0000\n"
+"PO-Revision-Date: 2016-04-14 23:33+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/sale_order_line_quantity/i18n/es_PA.po
+++ b/sale_order_line_quantity/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_line_quantity
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:33+0000\n"
+"PO-Revision-Date: 2016-04-14 23:33+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/sale_order_line_quantity/i18n/es_VE.po
+++ b/sale_order_line_quantity/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_line_quantity
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:33+0000\n"
+"PO-Revision-Date: 2016-04-14 23:33+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `sale_order_line_quantity`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#503](https://github.com/Vauxoo/lodigroup/pull/503) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
