### PR TITLE
[ADD] stock_accrual_report: Add missing translation files.

### DIFF
--- a/stock_accrual_report/i18n/es.po
+++ b/stock_accrual_report/i18n/es.po
@@ -1,0 +1,508 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_accrual_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:51+0000\n"
+"PO-Revision-Date: 2016-04-14 23:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_footer
+msgid "&bull;"
+msgstr "&bull;"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.minimal_layout
+msgid "<!DOCTYPE html>"
+msgstr "<!DOCTYPE html>"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,accrual_filter:0
+msgid "Accrual on Lines:"
+msgstr "Accrual on Lines:"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_header
+msgid "Accrual on Lines: Bring All Order Lines"
+msgstr "Accrual on Lines: Bring All Order Lines"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_header
+msgid "Accrual on Lines: Only with Accruals"
+msgstr "Accrual on Lines: Only with Accruals"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,time_span:0
+msgid "All Periods"
+msgstr "All Periods"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,reconcile_filter:0
+msgid "Bring All Accruals"
+msgstr "Bring All Accruals"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,accrual_filter:0
+msgid "Bring All Order Lines"
+msgstr "Bring All Order Lines"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,filter:0
+msgid "By Date"
+msgstr "By Date"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,filter:0
+msgid "By Period"
+msgstr "By Period"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.stock_accrual_document
+msgid "CREDIT"
+msgstr "CREDITO"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard:stock_accrual_report.view_wizard_stock_accrual
+msgid "Cancel"
+msgstr "Cancel"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard:stock_accrual_report.view_wizard_stock_accrual
+#: view:stock.accrual.wizard.line:stock_accrual_report.view_wizard_stock_accrual_line
+msgid "Choose your date"
+msgstr "Choose your date"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,company_id:0
+msgid "Company"
+msgstr "Company"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,create_uid:0
+#: field:stock.accrual.wizard.line,create_uid:0
+msgid "Created by"
+msgstr "Created by"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,create_date:0
+#: field:stock.accrual.wizard.line,create_date:0
+msgid "Created on"
+msgstr "Created on"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,credit:0
+#: help:stock.accrual.wizard,credit:0
+#: field:stock.accrual.wizard.line,credit:0
+msgid "Credit"
+msgstr "Credit"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.stock_accrual_document
+msgid "DEBIT"
+msgstr "DÉBITO"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.stock_accrual_document
+msgid "DELIVERED QTY"
+msgstr "DELIVERED QTY"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.stock_accrual_document
+msgid "DESCRIPTION"
+msgstr "DESCRIPTION"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,filter:0
+msgid "Date/Period Filter"
+msgstr "Date/Period Filter"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,debit:0
+#: help:stock.accrual.wizard,debit:0
+#: field:stock.accrual.wizard.line,debit:0
+msgid "Debit"
+msgstr "Debit"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard.line,qty_delivered:0
+msgid "Delivered Quantity"
+msgstr "Delivered Quantity"
+
+#. module: stock_accrual_report
+#: field:report.stock_accrual_report.stock_accrual_report_name,display_name:0
+#: field:stock.accrual.wizard,display_name:0
+#: field:stock.accrual.wizard.line,display_name:0
+msgid "Display Name"
+msgstr "Display Name"
+
+#. module: stock_accrual_report
+#: code:addons/stock_accrual_report/wizard/wizard.py:163
+#, python-format
+msgid "Error!"
+msgstr "Error!"
+
+#. module: stock_accrual_report
+#: constraint:stock.accrual.wizard:0
+msgid "Error!\n"
+"Beginning and Ending Dates in report are not logical."
+msgstr "Error!\n"
+"Beginning and Ending Dates in report are not logical."
+
+#. module: stock_accrual_report
+#: help:stock.accrual.wizard,fy_start_id:0
+#: help:stock.accrual.wizard,fy_stop_id:0
+msgid "Fiscal Year"
+msgstr "Fiscal Year"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,date_start:0
+msgid "From Date"
+msgstr "From Date"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,fy_start_id:0
+msgid "From Fiscal Year"
+msgstr "From Fiscal Year"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,period_start_id:0
+msgid "From Period"
+msgstr "From Period"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_header
+msgid "From:"
+msgstr "From:"
+
+#. module: stock_accrual_report
+#: field:report.stock_accrual_report.stock_accrual_report_name,id:0
+#: field:stock.accrual.wizard,id:0
+#: field:stock.accrual.wizard.line,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.stock_accrual_document
+msgid "INVOICED QTY"
+msgstr "INVOICED QTY"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard.line,qty_invoiced:0
+msgid "Invoiced Quantity"
+msgstr "Invoiced Quantity"
+
+#. module: stock_accrual_report
+#: field:report.stock_accrual_report.stock_accrual_report_name,__last_update:0
+#: field:stock.accrual.wizard,__last_update:0
+#: field:stock.accrual.wizard.line,__last_update:0
+msgid "Last Modified on"
+msgstr "Last Modified on"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,write_uid:0
+#: field:stock.accrual.wizard.line,write_uid:0
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,write_date:0
+#: field:stock.accrual.wizard.line,write_date:0
+msgid "Last Updated on"
+msgstr "Last Updated on"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,line_ids:0
+msgid "Lines"
+msgstr "Lines"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_header
+msgid "Lines from: All Periods"
+msgstr "Lines from: All Periods"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_header
+msgid "Lines from: This Period"
+msgstr "Lines from: This Period"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,time_span:0
+msgid "Lines on:"
+msgstr "Lines on:"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.stock_accrual_document
+msgid "ORDERED QTY"
+msgstr "ORDERED QTY"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,reconcile_filter:0
+msgid "Only Fully Reconciled Accruals"
+msgstr "Only Fully Reconciled Accruals"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,accrual_filter:0
+msgid "Only with Accruals"
+msgstr "Only with Accruals"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard.line,order_id:0
+msgid "Order"
+msgstr "Order"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard.line,line_id:0
+msgid "Order Line"
+msgstr "Order Line"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard:stock_accrual_report.view_wizard_stock_accrual
+msgid "Order Options"
+msgstr "Order Options"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard:stock_accrual_report.view_wizard_stock_accrual
+msgid "Output Options"
+msgstr "Output Options"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,report_format:0
+msgid "PDF"
+msgstr "PDF"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.stock_accrual_document
+msgid "PURCHASE ORDER"
+msgstr "PURCHASE ORDER"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_footer
+msgid "Page:"
+msgstr "Página:"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard:stock_accrual_report.view_wizard_stock_accrual
+msgid "Print Report"
+msgstr "Print Report"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_footer
+msgid "Printed"
+msgstr "Impreso"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,type:0
+#: selection:stock.accrual.wizard.line,order_id:0
+msgid "Purchase Order"
+msgstr "Purchase Order"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard.line,line_id:0
+msgid "Purchase Order Line"
+msgstr "Purchase Order Line"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_footer
+#: view:website:stock_accrual_report.external_layout_header
+msgid "Purchase Order Stock Accrual Report"
+msgstr "Purchase Order Stock Accrual Report"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard.line,product_qty:0
+msgid "Quantity"
+msgstr "Quantity"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.stock_accrual_document
+msgid "RECEIVED QTY"
+msgstr "RECEIVED QTY"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,reconcile_filter:0
+msgid "Reconciliation:"
+msgstr "Reconciliation:"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_header
+msgid "Reconciliation: Bring All Accruals"
+msgstr "Reconciliation: Bring All Accruals"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_header
+msgid "Reconciliation: Only Fully Reconciled Accruals"
+msgstr "Reconciliation: Only Fully Reconciled Accruals"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_header
+msgid "Reconciliation: Unreconciled & Partial Reconciled Accruals"
+msgstr "Reconciliation: Unreconciled & Partial Reconciled Accruals"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,report_format:0
+msgid "Report Format"
+msgstr "Report Format"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard:stock_accrual_report.view_wizard_stock_accrual
+msgid "Retrieval Options"
+msgstr "Retrieval Options"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.stock_accrual_document
+msgid "SALES ORDER"
+msgstr "SALES ORDER"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard.line,line_id:0
+msgid "Sale Order Line"
+msgstr "Sale Order Line"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,type:0
+#: selection:stock.accrual.wizard.line,order_id:0
+msgid "Sales Order"
+msgstr "Sales Order"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_footer
+#: view:website:stock_accrual_report.external_layout_header
+msgid "Sales Order Stock Accrual Report"
+msgstr "Sales Order Stock Accrual Report"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,report_format:0
+msgid "Spreadsheet"
+msgstr "Spreadsheet"
+
+#. module: stock_accrual_report
+#: model:ir.actions.act_window,name:stock_accrual_report.action_wizard_stock_accrual
+#: model:ir.ui.menu,name:stock_accrual_report.menu_action_wizard_valuation_history
+msgid "Stock Accrual"
+msgstr "Stock Accrual"
+
+#. module: stock_accrual_report
+#: code:addons/stock_accrual_report/wizard/wizard.py:520
+#, python-format
+msgid "Stock Accrual Lines"
+msgstr "Stock Accrual Lines"
+
+#. module: stock_accrual_report
+#: model:ir.actions.report.xml,name:stock_accrual_report.stock_accrual_report_id
+msgid "Stock Accrual Report"
+msgstr "Stock Accrual Report"
+
+#. module: stock_accrual_report
+#: code:addons/stock_accrual_report/wizard/wizard.py:164
+#, python-format
+msgid "There is no default company for the current user!"
+msgstr "There is no default company for the current user!"
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,time_span:0
+msgid "This Period Only"
+msgstr "This Period Only"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard:stock_accrual_report.view_wizard_stock_accrual
+msgid "Time Options"
+msgstr "Time Options"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,date_stop:0
+msgid "To Date"
+msgstr "To Date"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,fy_stop_id:0
+msgid "To Fiscal Year"
+msgstr "To Fiscal Year"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,period_stop_id:0
+msgid "To Period"
+msgstr "To Period"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard.line:stock_accrual_report.view_wizard_stock_accrual_line
+msgid "Total Credit"
+msgstr "Total Credit"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard.line:stock_accrual_report.view_wizard_stock_accrual_line
+msgid "Total Debit"
+msgstr "Total Debit"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,type:0
+msgid "Type"
+msgstr "Type"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.stock_accrual_document
+msgid "UOM"
+msgstr "UOM"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard.line,product_uom:0
+msgid "Unit of Measure "
+msgstr "Unit of Measure "
+
+#. module: stock_accrual_report
+#: selection:stock.accrual.wizard,reconcile_filter:0
+msgid "Unreconciled & Partial Reconciled Accruals"
+msgstr "Unreconciled & Partial Reconciled Accruals"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard,user_id:0
+msgid "User"
+msgstr "User"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard:stock_accrual_report.view_wizard_stock_accrual
+msgid "View Report"
+msgstr "View Report"
+
+#. module: stock_accrual_report
+#: field:stock.accrual.wizard.line,wzd_id:0
+msgid "Wizard"
+msgstr "Wizard"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.layout
+msgid "data_report_dpi if data_report_dpi else None"
+msgstr "data_report_dpi if data_report_dpi else None"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.layout
+msgid "data_report_header_spacing if data_report_header_spacing else None"
+msgstr "data_report_header_spacing if data_report_header_spacing else None"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.layout
+msgid "data_report_margin_top if data_report_margin_top else None"
+msgstr "data_report_margin_top if data_report_margin_top else None"
+
+#. module: stock_accrual_report
+#: view:stock.accrual.wizard:stock_accrual_report.view_wizard_stock_accrual
+msgid "or"
+msgstr "or"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.layout
+msgid "stock_accrual_report.layout"
+msgstr "stock_accrual_report.layout"
+
+#. module: stock_accrual_report
+#: view:website:stock_accrual_report.external_layout_header
+msgid "to:"
+msgstr "to:"
+

--- a/stock_accrual_report/i18n/es_MX.po
+++ b/stock_accrual_report/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_accrual_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:51+0000\n"
+"PO-Revision-Date: 2016-04-14 23:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/stock_accrual_report/i18n/es_PA.po
+++ b/stock_accrual_report/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_accrual_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:51+0000\n"
+"PO-Revision-Date: 2016-04-14 23:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/stock_accrual_report/i18n/es_VE.po
+++ b/stock_accrual_report/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_accrual_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 23:51+0000\n"
+"PO-Revision-Date: 2016-04-14 23:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `stock_accrual_report`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#504](https://github.com/Vauxoo/lodigroup/pull/504) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
