### PR TITLE
[ADD] stock_hide_set_zero_button: Add missing translation files.

### DIFF
--- a/stock_hide_set_zero_button/i18n/es.po
+++ b/stock_hide_set_zero_button/i18n/es.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_hide_set_zero_button
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-15 00:36+0000\n"
+"PO-Revision-Date: 2016-04-15 00:36+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_hide_set_zero_button
+#: view:stock.inventory:stock_hide_set_zero_button.view_stock_hide_set_zero_button_form
+msgid "URGENT ALERT:  You will set all your lines to 0, It can not be undone. Are you sure ?"
+msgstr "URGENT ALERT:  You will set all your lines to 0, It can not be undone. Are you sure ?"
+
+#. module: stock_hide_set_zero_button
+#: view:stock.inventory:stock_hide_set_zero_button.view_stock_hide_set_zero_button_form
+msgid "⇒ Set quantities to 0"
+msgstr "⇒ Establecer cantidad a 0"
+

--- a/stock_hide_set_zero_button/i18n/es_MX.po
+++ b/stock_hide_set_zero_button/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_hide_set_zero_button
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-15 00:36+0000\n"
+"PO-Revision-Date: 2016-04-15 00:36+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/stock_hide_set_zero_button/i18n/es_PA.po
+++ b/stock_hide_set_zero_button/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_hide_set_zero_button
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-15 00:36+0000\n"
+"PO-Revision-Date: 2016-04-15 00:36+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/stock_hide_set_zero_button/i18n/es_VE.po
+++ b/stock_hide_set_zero_button/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_hide_set_zero_button
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-15 00:36+0000\n"
+"PO-Revision-Date: 2016-04-15 00:36+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `stock_hide_set_zero_button`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#506](https://github.com/Vauxoo/lodigroup/pull/506) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
