### PR TITLE
[ADD] stock_sale_order_line: Add missing translation files.

### DIFF
--- a/stock_sale_order_line/i18n/es.po
+++ b/stock_sale_order_line/i18n/es.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_sale_order_line
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-15 01:31+0000\n"
+"PO-Revision-Date: 2016-04-15 01:31+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_sale_order_line
+#: field:sale.order.line,move_ids:0
+msgid "Reservation"
+msgstr "Reserva"
+
+#. module: stock_sale_order_line
+#: field:stock.move,sale_line_id:0
+msgid "Sale Order Line"
+msgstr "Línea pedido de venta"
+
+#. module: stock_sale_order_line
+#: model:ir.model,name:stock_sale_order_line.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea pedido de venta"
+
+#. module: stock_sale_order_line
+#: model:ir.model,name:stock_sale_order_line.model_stock_move
+msgid "Stock Move"
+msgstr "Movimiento de stock"
+

--- a/stock_sale_order_line/i18n/es_MX.po
+++ b/stock_sale_order_line/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_sale_order_line
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-15 01:31+0000\n"
+"PO-Revision-Date: 2016-04-15 01:31+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/stock_sale_order_line/i18n/es_PA.po
+++ b/stock_sale_order_line/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_sale_order_line
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-15 01:31+0000\n"
+"PO-Revision-Date: 2016-04-15 01:31+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/stock_sale_order_line/i18n/es_VE.po
+++ b/stock_sale_order_line/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_sale_order_line
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-15 01:31+0000\n"
+"PO-Revision-Date: 2016-04-15 01:31+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `stock_sale_order_line`:
  - The `es.po` file has the original translations from Odoo without changes, that's the reason why the  translations are in english too in some cases. This is in order to not add translations with the client disagrees.
- [x] Rebase.
- [x] Create [PR#510](https://github.com/Vauxoo/lodigroup/pull/510) dummy.
- [ ] Edit translations according @dsabrinarg 's feedback.
