### PR TITLE
[ADD] account_group_auditory: Add missing translation files.

### DIFF
--- a/account_group_auditory/i18n/es.po
+++ b/account_group_auditory/i18n/es.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_group_auditory
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-16 01:09+0000\n"
+"PO-Revision-Date: 2016-04-16 01:09+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_group_auditory
+#: model:res.groups,name:account_group_auditory.group_account_user_audit
+msgid "Auditor (Read-Only)"
+msgstr "Auditor (Solo lectura)"
+

--- a/account_group_auditory/i18n/es_ES.po
+++ b/account_group_auditory/i18n/es_ES.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_group_auditory
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-16 01:09+0000\n"
+"PO-Revision-Date: 2016-04-16 01:09+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_group_auditory/i18n/es_PA.po
+++ b/account_group_auditory/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_group_auditory
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-16 01:09+0000\n"
+"PO-Revision-Date: 2016-04-16 01:09+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_group_auditory/i18n/es_VE.po
+++ b/account_group_auditory/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_group_auditory
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-16 01:09+0000\n"
+"PO-Revision-Date: 2016-04-16 01:09+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/account_group_auditory/security/account_user_group.xml
+++ b/account_group_auditory/security/account_user_group.xml
@@ -5,48 +5,19 @@
         <record id="group_account_user_audit" model="res.groups">
             <field name="name">Auditor (Read-Only)</field>
             <field name="category_id" ref="base.module_category_accounting_and_finance"/>
-        </record>
-
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_finance'))]"/>
-        </record>
-
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_action_account_moves_all'))]"/>
-        </record>
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_tax_report'))]"/>
-        </record>
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_finance_bank_and_cash'))]"/>
-        </record>
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_finance_entries'))]"/>
-        </record>
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_action_move_journal_line_form'))]"/>
-        </record>
-
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_journals_report'))]"/>
-        </record>
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_unrealized_gains_losses'))]"/>
-        </record>
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_general_ledger'))]"/>
-        </record>
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_account_partner_ledger'))]"/>
-        </record>
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_action_tax_code_tree'))]"/>
-        </record>
-        <record id="group_account_user_audit" model="res.groups">
-            <field name="menu_access" eval="[(4, ref('account.menu_finance_reports'))]"/>
-        </record>
-
-        <record id="group_account_user_audit" model="res.groups">
+            <field name="menu_access"
+                eval="[(4, ref('account.menu_finance')),
+                       (4, ref('account.menu_action_account_moves_all')),
+                       (4, ref('account.menu_tax_report')),
+                       (4, ref('account.menu_finance_bank_and_cash')),
+                       (4, ref('account.menu_finance_entries')),
+                       (4, ref('account.menu_action_move_journal_line_form')),
+                       (4, ref('account.menu_journals_report')),
+                       (4, ref('account.menu_unrealized_gains_losses')),
+                       (4, ref('account.menu_general_ledger')),
+                       (4, ref('account.menu_account_partner_ledger')),
+                       (4, ref('account.menu_action_tax_code_tree')),
+                       (4, ref('account.menu_finance_reports'))]"/>
             <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         </record>
     </data>

--- a/account_group_auditory/security/auditor_user.xml
+++ b/account_group_auditory/security/auditor_user.xml
@@ -2,13 +2,13 @@
 
 <openerp>
     <data noupdate="1">
-        <record model="res.users" id="res_auditor_user">
+        <record model="res.users" id="res_auditor_user" context="{'no_reset_password': True}">
             <field name="name">Auditor user</field>
             <field name="login">auditor</field>
             <field name="tz">America/Mexico_City</field>
             <field name="password">auditor</field>
             <field name="alias_name">auditor</field>
-            <field name="company_id" eval="ref('base.main_company')"/> 
+            <field name="company_id" eval="ref('base.main_company')"/>
             <field name="groups_id"  eval="[(6,0,[ref('account_group_auditory.group_account_user_audit')])]"/>
         </record>
     </data>

--- a/account_group_auditory/tests/test_group.py
+++ b/account_group_auditory/tests/test_group.py
@@ -1,13 +1,15 @@
 # coding: utf-8
+import time
+from datetime import date
+
 from openerp import SUPERUSER_ID
 from openerp.osv.orm import except_orm
-from openerp.tests.common import TransactionCase
-import time
-from openerp.tools.misc import mute_logger
 from openerp.tests import common
+from openerp.tests.common import TransactionCase
+from openerp.tools.misc import mute_logger
+
 UID = common.ADMIN_USER_ID
 DB = common.DB
-from datetime import date
 
 
 class TestAuditorGroup(TransactionCase):


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `account_group_auditory`.
- [x] Add `es_ES.po` file used in the instance.
- [x] Fix pylint and flake8 errors in order to obtain a green:
  - Fix flake8 error E402 using isort in `from datetime import date`.
  - Fix pylint errors W7902(duplicate-xml-record-id) and W7905(create-user-wo-reset-password).
- [x] Make functional test.
  ![auditor_user_menus](https://cloud.githubusercontent.com/assets/11741384/14794696/e5897c8c-0aea-11e6-96b6-ac4805637214.png)
- [x] Rebase.
- [x] Create [PR#249](https://github.com/Vauxoo/instance/pull/249) dummy instance and [PR#519](https://github.com/Vauxoo/lodigroup/pull/519) dummy lodigroup.
- [x] ~~Edit translations according @dsabrinarg 's feedback.~~

**Note:**
This module doesn't need _() translations.
