### PR TITLE
[REF] partner_credit_limit: Refactor mail.message that sends when a s…

### DIFF
--- a/partner_credit_limit/i18n/es.po
+++ b/partner_credit_limit/i18n/es.po
@@ -20,30 +20,30 @@ msgstr ""
 #, python-format
 msgid "\n"
 "<br><br>Have exceeded the credit limit.\n"
-"<br>The credit available is $%s\n"
-"<br>And the credit is being requested is $%s"
+"<br>The credit available is <b>$%s</b>\n"
+"<br>And the credit is being requested is <b>$%s</b>"
 msgstr "\n"
 "<br><br>Ha excedido su límite de cŕedito.\n"
-"<br>El crédito disponible es $%s\n"
-"<br>Y el crédito que se esta solicitando es de $%s"
+"<br>El crédito disponible es <b>$%s</b>\n"
+"<br>Y el crédito que se esta solicitando es de <b>$%s</b>"
 
 #. module: partner_credit_limit
 #: code:addons/partner_credit_limit/model/sale.py:69
 #, python-format
 msgid "\n"
 "<br><br>It has the overdue payment period.\n"
-"<br>The expiration date was %s, <br>the amount payable is: $%s"
+"<br>The expiration date was <b>%s</b>, <br>the amount payable is: <b>$%s</b>"
 msgstr "\n"
 "<br><br>Tiene el plazo de pago vencido.\n"
-"<br>La fecha de vencimiento fue %s, <br>El monto a pagar es: $%s"
+"<br>La fecha de vencimiento fue <b>%s</b>, <br>El monto a pagar es: <b>$%s</b>"
 
 #. module: partner_credit_limit
 #: code:addons/partner_credit_limit/model/sale.py:56
 #, python-format
-msgid "<div><p>The Sale order pass to state of Exception Credit.\n"
-" <br>The partner %s:"
-msgstr "<div><p>La Orden de venta paso a estado Excepción de crédito.\n"
-" <br>El cliente %s:"
+msgid "<div><p>The Sale order pass to state of <b>Exception Credit</b>.\n"
+" <br>The partner <b>%s</b>:"
+msgstr "<div><p>La Orden de venta paso a estado <b>Excepción de crédito</b>.\n"
+" <br>El cliente <b>%s</b>:"
 
 #. module: partner_credit_limit
 #: field:res.company,payment_terms_ids:0

--- a/partner_credit_limit/model/partner.py
+++ b/partner_credit_limit/model/partner.py
@@ -94,11 +94,7 @@ class ResPartner(models.Model):
             new_credit = partner.credit + new_amount_currency
             credit = partner.credit if partner.credit > 0 else 0
             partner.credit_available = partner.credit_limit - credit
-
-            if new_credit > partner.credit_limit:
-                partner.credit_overloaded = True
-            else:
-                partner.credit_overloaded = False
+            partner.credit_overloaded = new_credit > partner.credit_limit
 
     @api.multi
     def _get_overdue_credit(self):
@@ -127,11 +123,7 @@ class ResPartner(models.Model):
             pending_ids = [move.id for move in movelines
                            if move.id not in lines]
             partner.pending_payments_ids = pending_ids
-
-            if balance_maturity > 0.0:
-                partner.overdue_credit = True
-            else:
-                partner.overdue_credit = False
+            partner.overdue_credit = balance_maturity > 0.0
 
     def get_limit_date(self, line):
         if line.date_maturity and line.partner_id.grace_payment_days:
@@ -153,7 +145,5 @@ class ResPartner(models.Model):
     @api.multi
     def get_allowed_sale(self):
         for partner in self:
-            if not partner.credit_overloaded and not partner.overdue_credit:
-                partner.allowed_sale = True
-            else:
-                partner.allowed_sale = False
+            partner.allowed_sale = not partner.credit_overloaded \
+                and not partner.overdue_credit

--- a/partner_credit_limit/tests/test_sale_credit_limit.py
+++ b/partner_credit_limit/tests/test_sale_credit_limit.py
@@ -65,7 +65,7 @@ class TestSalesCreditLimits(TransactionCase):
             ('type', '=', 'notification'),
         ])
         self.assertIn(
-            'The Sale order pass to state of Exception Credit.',
+            'The Sale order pass to state of <b>Exception Credit</b>.',
             mail_message.body)
 
     def test_partner_with_late_payments(self):
@@ -120,5 +120,6 @@ class TestSalesCreditLimits(TransactionCase):
             ('subject', '=', 'Exception Credit'),
             ('type', '=', 'notification')
         ])
-        self.assertIn('The Sale order pass to state of Exception Credit.',
-                      mail_message.body)
+        self.assertIn(
+            'The Sale order pass to state of <b>Exception Credit</b>.',
+            mail_message.body)


### PR DESCRIPTION
…ale.order is on 'Credit Exception' state
Dummy: https://github.com/Vauxoo/yoytec/pull/1062
- [x] Bold font on partner.name, "Credit Exception" state, dates and amounts
- [x] Modify test/test_sale_credit_limit.py for support the previous point
- [x] Modify translations for support bold fonts on messages
- [x] Date format must be "%d-%m-%Y"
- [x] Payment amount must be the overdue amount to pay
- [x] Rounding to amounts
- [x] Pylint "R0102(simplifiable-if-statement)" errors solved on partner_credit_limit/model/partner.py

Screenshot:
![captura de pantalla 2016-04-21 a las 10 47 10 a m](https://cloud.githubusercontent.com/assets/6345953/14716142/4aea74d8-07b1-11e6-8ee2-3b9fb6d841b6.png)
