### PR TITLE
[IMP] work items in task form view should be editable bottom to do not scroll down the page when adding new items

### DIFF
--- a/user_story/view/project_view.xml
+++ b/user_story/view/project_view.xml
@@ -16,6 +16,10 @@
         <xpath expr="//field[@name='name']" position="attributes">
             <attribute name="class"></attribute>
         </xpath>
+
+        <xpath expr="//field[@name='work_ids']/tree" position="attributes">
+            <attribute name="editable">bottom</attribute>
+        </xpath>
         
       </field>
     </record>


### PR DESCRIPTION
This to improve the time spent to add more work items to a task.
Do not need to scroll down in the task page.
- currently has `editable='top'`
- change to `editable='bottom'`

Fix Vauxoo/instance#260 (main issue)
Fix Vauxoo/instance#261 (dummy pr)
