### PR TITLE
[ADD] send_author_mail: Add missing translation files.

### DIFF
--- a/send_author_mail/i18n/es.po
+++ b/send_author_mail/i18n/es.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* send_author_mail
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-20 14:25+0000\n"
+"PO-Revision-Date: 2016-04-20 14:25+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: send_author_mail
+#: model:ir.model,name:send_author_mail.model_mail_notification
+msgid "Notifications"
+msgstr "Notificaciones"
+
+#. module: send_author_mail
+#: model:ir.model,name:send_author_mail.model_res_partner
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: send_author_mail
+#: field:res.partner,receive_my_emails:0
+msgid "receive your own email?"
+msgstr "¿Recibir su propio correo electrónico?"
+
+#. module: send_author_mail
+#: help:res.partner,receive_my_emails:0
+msgid "receives its own messages if you have enabled this option"
+msgstr "Recibe sus propios mensajes si se ha activado esta opción"
+

--- a/send_author_mail/i18n/es_ES.po
+++ b/send_author_mail/i18n/es_ES.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* send_author_mail
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-20 14:25+0000\n"
+"PO-Revision-Date: 2016-04-20 14:25+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/send_author_mail/i18n/es_MX.po
+++ b/send_author_mail/i18n/es_MX.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* send_author_mail
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-20 14:25+0000\n"
+"PO-Revision-Date: 2016-04-20 14:25+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/send_author_mail/i18n/es_PA.po
+++ b/send_author_mail/i18n/es_PA.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* send_author_mail
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-20 14:25+0000\n"
+"PO-Revision-Date: 2016-04-20 14:25+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/send_author_mail/i18n/es_VE.po
+++ b/send_author_mail/i18n/es_VE.po
@@ -1,0 +1,16 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* send_author_mail
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-20 14:25+0000\n"
+"PO-Revision-Date: 2016-04-20 14:25+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"

--- a/send_author_mail/model/mail_notification.py
+++ b/send_author_mail/model/mail_notification.py
@@ -36,7 +36,7 @@ class MailNotification(osv.Model):
         res = super(MailNotification, self).get_partners_to_email(
             cr, uid, ids, message, context=context)
 
-        for notification in self.browse(cr, uid, ids, context=context):
+        for element in self.browse(cr, uid, ids, context=context):
             if message.author_id and\
                 (message.author_id.receive_my_emails and
                     message.author_id.notify_email != "none"):

--- a/send_author_mail/model/res_partner.py
+++ b/send_author_mail/model/res_partner.py
@@ -21,15 +21,13 @@
 ###############################################################################
 
 
-from openerp.osv import osv, fields
+from openerp import models, fields
 
 
-class ResPartner(osv.Model):
+class ResPartner(models.Model):
 
     _inherit = 'res.partner'
 
-    _columns = {
-        'receive_my_emails': fields.boolean(
-            'receive your own email?',
-            help="receives its own messages if you have enabled this option")
-    }
+    receive_my_emails = fields.Boolean(
+        'receive your own email?',
+        help="receives its own messages if you have enabled this option")


### PR DESCRIPTION
## [VX#5101](https://www.vauxoo.com/web#id=5101&view_type=form&model=project.task&action=138)
- [x] Add missing translation files to `send_author_mail`.
- [x] Add `es_ES.po` file used in the instance.
- [x] Fix pylint errors in order to obtain a green:
  - Unused variable notification.
  - Migrate the field `receive_my_emails` to new api avoiding the deprecated _columns error.
- [x] Make functional test.
  ![captura de pantalla de 2016-04-24 23 45 04](https://cloud.githubusercontent.com/assets/11741384/14774119/f44437a8-0a77-11e6-93fe-b42171b35bbe.png)
- [x] Rebase.
- [x] Create [PR#263](https://github.com/Vauxoo/instance/pull/263) dummy.

**Note:**
This module doesn't need _() translations.
