### PR TITLE
[FIX] sale_team_warehouse: monkey patch is a bad approach.

### DIFF
--- a/sale_team_warehouse/README.rst
+++ b/sale_team_warehouse/README.rst
@@ -1,11 +1,27 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
     :alt: License: AGPL-3
 
-Sale Team Warehouse
-===================
+Sales Team Warehouse by default
+===============================
 
-This module allows to set a default warehouse on the sales team of the user.
+Add a field `default_warehouse` in sales team.
 
-The default warehouse can be set on the field "Default Warehouse" of the sales team for the related user.
+Create sort kind of api where any object with field called warehouse_id will
+take the default value from the sales team field.
 
-If the user is not related to a sales team, the default warehouse will be set using the default behavior of the system which is assign the main warehouse.
+To use it simple do this:
+
+1. inherit the class that you want to set the field warehouse_id:
+
+    class SomeClass(models.Model):
+        _name = 'some.class'
+        _inherit = ['some.class', 'default.warehouse']
+        warehouse_id = fields.Many2one('stock.warehouse', help='Warehouse were'
+        'this object will belong to')
+
+2. Don't forget depends of this module adding it to the list into `__openerp__.py`
+
+The default value from this field will be the warehouse setted in the section 
+If the user is not related to a sales team or not warehouse setted on the
+section the default warehouse will be set using the default behavior of the
+system which is assign the main warehouse.

--- a/sale_team_warehouse/__openerp__.py
+++ b/sale_team_warehouse/__openerp__.py
@@ -1,33 +1,25 @@
 # coding: utf-8
 {
     'name': "Sale Team Warehouse",
-    'summary': """
-Adding a field for the default user warehouse and
-modifing the global default method for asign in any
-realted field the correct default warehuse.
+    'summary': """Adding a field for the default user warehouse and modifying
+    the global default method for assign in any related field the correct
+    default warehouse.
     """,
-    # Autoloaded on v8.0 from README.rst
-    # 'description': """
     'author': "Vauxoo",
     'website': "http://www.vauxoo.com",
     'license': 'AGPL-3',
     'category': '',
-    'version': '8.0.0.0.1',
+    'version': '8.0.0.0.2',
     'depends': [
-        # We must respect the "sequence" now due to demo data in testing
-        # process may fail unspectly.
-        'base',
-        'sale',
-        'stock',
-        'crm',
+        'sale_stock',
         'sales_team',
     ],
     'test': [
     ],
     'data': [
         'views/sales_team_view.xml',
+        'security/ir.model.access.csv',
     ],
-    # only loaded in demonstration mode
     'demo': [
     ],
 }

--- a/sale_team_warehouse/models/sales_team.py
+++ b/sale_team_warehouse/models/sales_team.py
@@ -1,14 +1,10 @@
 # coding: utf-8
 
 from openerp import api, fields, models
-from openerp.models import BaseModel
 
 
 class InheritedCrmSaseSection(models.Model):
 
-    '''
-        inheriting the class to add additional field
-    '''
     _inherit = "crm.case.section"
 
     default_warehouse = fields.Many2one('stock.warehouse',
@@ -18,34 +14,42 @@ class InheritedCrmSaseSection(models.Model):
                                         'the related users to the sales team.')
 
 
-@api.model
-def default_get(self, fields_list):
-    '''
-        This method modifies global default_get method
-        using _patch_method that allows Monkey-patch
-        that allows access the original method and get its
-        result. Also is possible restore the original
-        method using _revert_method
-    '''
-    defaults = default_get.origin(self, fields_list)
-    res_users_obj = self.env['res.users']
-    res_users_brw = res_users_obj.browse(self._uid)
-    warehouse_id = hasattr(res_users_brw, 'default_section_id')\
-        and res_users_brw.default_section_id and \
-        res_users_brw.default_section_id.default_warehouse.id
-    if warehouse_id:
-        model_obj = self.env['ir.model']
-        fields_obj = self.env['ir.model.fields']
-        model_id = model_obj.search([('model', '=', self._model._name)])
-        fields_data = fields_obj.search(
-            [('model_id', '=', model_id.id),
-             ('relation', '=', 'stock.warehouse'),
-             ('ttype', '=', 'many2one')])
-        names_list = []
-        [names_list.append(field.name) for field in fields_data if
-         field.name not in names_list]
-        defaults.update({name: warehouse_id for name in names_list if
-                        defaults.get(name)})
-    return defaults
+class WarehouseDefault(models.Model):
+    """If you inherit from this model and add a field called warehouse_id into
+    the model itself then the default value for such model will be the one
+    setted into the sales team.
+    """
 
-BaseModel._patch_method('default_get', default_get)
+    _auto = False
+    _name = "default.warehouse"
+
+    @api.model
+    def default_get(self, fields_list):
+        """Force that if model has a field called warehouse_id the default
+        value is the one in the sales team in the user setted
+        """
+        defaults = super(WarehouseDefault,
+                         self).default_get(fields_list)
+        res_users_obj = self.env['res.users']
+        user_brw = res_users_obj.browse(self._uid)
+        warehouse = user_brw.default_section_id.default_warehouse
+        if warehouse:
+            warehouse_id = warehouse.id
+            model_obj = self.env['ir.model']
+            fields_obj = self.env['ir.model.fields']
+            model_id = model_obj.search([('model', '=', self._model._name)])
+            fields_data = fields_obj.search(
+                [('model_id', '=', model_id.id),
+                 ('relation', '=', 'stock.warehouse'),
+                 ('ttype', '=', 'many2one')])
+            names_list = list(set([field.name for field in fields_data]))
+            defaults.update(
+                {name: warehouse_id for name in names_list
+                 if defaults.get(name)})
+        return defaults
+
+
+class SaleOrder(models.Model):
+
+    _name = "sale.order"
+    _inherit = ['sale.order', 'default.warehouse']

--- a/sale_team_warehouse/security/ir.model.access.csv
+++ b/sale_team_warehouse/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_default_warehouse,default.warehouse,model_default_warehouse,,1,0,0,0


### PR DESCRIPTION
Avoiding the usage of monkey patching flaky tests appear when it is
done.

With this refactor 2 things need to be considered:
1. To use the feature of set the default value of warehouse in a model we
   need to inherit (ala mail.thread) the model where the field warehouse_id
   will be filled if it exists.
2. If the model default.warehouse is inherited and the field is not
   setted properly as Many2one related to warehouse model, then the
   inheritance will be simply ignored.

Read the test cases to understand the usage.

Is closes #694
