### PR TITLE
[IMP][sale_block_cancellation]Better that not check in all sales, only in sales with state in manual-progress

### DIFF
--- a/sale_block_cancellation/models/sale.py
+++ b/sale_block_cancellation/models/sale.py
@@ -22,8 +22,12 @@ class SaleOrder(models.Model):
         in "Waiting another move" state, the cancellation of this must be
         allowed, or even whit pickings on different states, if the moved
         product quantities are correctly returned."""
-        for sale in self:
-            if sale.state in ('manual', 'progress') and sale.picking_ids.ids:
+        sales = self.search([
+            ('id', 'in', self.ids),
+            ('state', 'in', ('manual', 'progress')),
+        ])
+        for sale in sales:
+            if sale.picking_ids.ids:
                 self._cr.execute(
                     """SELECT id FROM stock_picking
                     WHERE state not in (

--- a/sale_block_cancellation/models/sale.py
+++ b/sale_block_cancellation/models/sale.py
@@ -44,7 +44,6 @@ class SaleOrder(models.Model):
             sale.picking_ids = res.get(sale.id)
 
     def _search_pickings(self, operator, value):
-        res = []
         pick_obj = self.env["stock.picking"]
         pick_ids = []
         if operator == 'in' and value:
@@ -53,13 +52,8 @@ class SaleOrder(models.Model):
             pick_ids = pick_obj.search([('name', operator, value)])
         else:
             pick_ids = pick_obj.search([])
-        if pick_ids:
-            for pick in pick_ids:
-                proc_gp = pick.group_id
-                if proc_gp:
-                    sale_ids = self.search([
-                        ('procurement_group_id', '=', proc_gp.id)])
-                    res.extend(sale_ids.ids)
+        groups = [p.group_id.id for p in pick_ids if p.group_id]
+        res = self.search([('procurement_group_id', 'in', groups)]).ids
         if operator == '=' and not value:
             return [('id', 'not in', res)]
         return [('id', 'in', res)]


### PR DESCRIPTION
Make this change because on production instances where have many SO late many in update.

Dummy:
https://github.com/Vauxoo/lodigroup/pull/528
