### PR TITLE
[FIX] account_reconcile_advance: Fix the assert using False instead o…

### DIFF
--- a/account_reconcile_advance/model/account_reconcile_advance.py
+++ b/account_reconcile_advance/model/account_reconcile_advance.py
@@ -6,8 +6,8 @@ from openerp.tools.translate import _
 class AccountMoveLine(osv.Model):
     _inherit = 'account.move.line'
 
-    def _search(self, cr, uid, args, offset=0, limit=None, order=None, context=None, count=False,
-                access_rights_uid=None):
+    def _search(self, cr, uid, args, offset=0, limit=None, order=None,
+                context=None, count=False, access_rights_uid=None):
 
         move_obj = self.pool.get('account.move.line')
         voucher_obj = self.pool.get('account.voucher')
@@ -41,8 +41,16 @@ class AccountMoveLine(osv.Model):
 
         args.append(no_incluir)
 
-        return super(AccountMoveLine, self)._search(cr, uid, args, offset=offset, limit=limit,
-                                                    order=order, context=context, count=count, access_rights_uid=access_rights_uid)
+        return super(AccountMoveLine, self)._search(
+            cr,
+            uid,
+            args,
+            offset=offset,
+            limit=limit,
+            order=order,
+            context=context,
+            count=count,
+            access_rights_uid=access_rights_uid)
 
 
 class AccountReconcileAdvance(osv.Model):
@@ -51,8 +59,10 @@ class AccountReconcileAdvance(osv.Model):
 
     _name = 'account.reconcile.advance'
 
+    # pylint: disable=W0621
     def default_get(self, cr, uid, fields, context=None):
-        ''''''
+        """Returns default values for the fields
+        """
         context = context or {}
 
         res = super(AccountReconcileAdvance, self).default_get(
@@ -62,39 +72,89 @@ class AccountReconcileAdvance(osv.Model):
 
         return res
 
+    # pylint: disable=W8105
     _columns = {
-        'name': fields.char('Name', size=256, help='Name of This Advance Document'),
+        'name': fields.char(
+            'Name',
+            size=256,
+            help='Name of This Advance Document'),
         'date': fields.date('Date', help='Document Date'),
-        'date_post': fields.date('Accounting Date', help='Date to be used in Journal Entries when posted'),
-        'type': fields.selection([('pay', 'Payment'), ('rec', 'Receipt')],
-                                 help='State'),
-        'state': fields.selection([('draft', 'Draft'), ('cancel', 'Cancel'),
-                                   ('done', 'Done')], help='State'),
-        'company_id': fields.many2one('res.company', 'Company', help='Company'),
-        'partner_id': fields.many2one('res.partner', 'Partner', help='Advance Partner'),
-        'period_id': fields.many2one('account.period', 'Accounting Period', help='Period where Journal Entries will be posted'),
-        'journal_id': fields.many2one('account.journal', 'Journal', help='Accounting Journal where Entries will be posted'),
-        'move_id': fields.many2one('account.move', 'Accounting Entry', help='Accounting Entry'),
-        'invoice_ids': fields.many2many('account.invoice', 'ara_invoice_rel', 'ara_id', 'inv_id', 'Invoices', help='Invoices to be used in this Advance'),
-        'voucher_ids': fields.many2many('account.voucher', 'ara_voucher_rel', 'ara_id', 'voucher_id', 'Advances', help='Advances to be used'),
-        'ai_aml_ids': fields.many2many('account.move.line', 'ara_ai_aml_rel', 'ara_id', 'aml_id', 'Invoice Entry Lines', help=''),
-        'av_aml_ids': fields.many2many('account.move.line', 'ara_av_aml_rel', 'ara_id', 'aml_id', 'Advance Entry Lines', help=''),
+        'date_post': fields.date(
+            'Accounting Date',
+            help='Date to be used in Journal Entries when posted'),
+        'type': fields.selection(
+            [('pay', 'Payment'), ('rec', 'Receipt')],
+            help='State'),
+        'state': fields.selection(
+            [('draft', 'Draft'), ('cancel', 'Cancel'), ('done', 'Done')],
+            help='State'),
+        'company_id': fields.many2one(
+            'res.company',
+            'Company',
+            help='Company'),
+        'partner_id': fields.many2one(
+            'res.partner',
+            'Partner',
+            help='Advance Partner'),
+        'period_id': fields.many2one(
+            'account.period',
+            'Accounting Period',
+            help='Period where Journal Entries will be posted'),
+        'journal_id': fields.many2one(
+            'account.journal',
+            'Journal',
+            help='Accounting Journal where Entries will be posted'),
+        'move_id': fields.many2one(
+            'account.move',
+            'Accounting Entry',
+            help='Accounting Entry'),
+        'invoice_ids': fields.many2many(
+            'account.invoice',
+            'ara_invoice_rel',
+            'ara_id',
+            'inv_id',
+            'Invoices',
+            help='Invoices to be used in this Advance'),
+        'voucher_ids': fields.many2many(
+            'account.voucher',
+            'ara_voucher_rel',
+            'ara_id',
+            'voucher_id',
+            'Advances',
+            help='Advances to be used'),
+        'ai_aml_ids': fields.many2many(
+            'account.move.line',
+            'ara_ai_aml_rel',
+            'ara_id',
+            'aml_id',
+            'Invoice Entry Lines',
+            help=''),
+        'av_aml_ids': fields.many2many(
+            'account.move.line',
+            'ara_av_aml_rel',
+            'ara_id',
+            'aml_id',
+            'Advance Entry Lines',
+            help=''),
     }
     _defaults = {
         'state': 'draft',
-        'company_id': lambda s, c, u, cx: s.pool.get('res.users').browse(c, u,
-                                                                         u, cx).company_id.id,
+        'company_id': lambda s, c, u, cx: s.pool.get('res.users').browse(
+            c, u, u, cx).company_id.id,
         'date': fields.date.today
     }
 
     def invoice_credit_lines(self, cr, uid, ids, amount, am_id=None,
-                             account_id=False, partner_id=False, date=None, context=None):
-        """"""
+                             account_id=False, partner_id=False,
+                             date=None, context=None):
+        """Invoice credit lines
+        """
         context = context or {}
         aml_obj = self.pool.get('account.move.line')
         ids = isinstance(ids, (int, long)) and [ids] or ids
         ara_brw = self.browse(cr, uid, ids[0], context=context)
-        account_id = account_id or ara_brw.partner_id.property_account_payable.id
+        account_id = account_id or \
+            ara_brw.partner_id.property_account_payable.id
         partner_id = ara_brw.partner_id.id
         date = date or ara_brw.date_post or fields.date.today()
         period_id = ara_brw.period_id or ara_brw.period_id.id
@@ -113,13 +173,16 @@ class AccountReconcileAdvance(osv.Model):
         return aml_obj.create(cr, uid, vals, context=context)
 
     def invoice_debit_lines(self, cr, uid, ids, amount, am_id=None,
-                            account_id=False, partner_id=False, date=None, context=None):
-        """"""
+                            account_id=False, partner_id=False, date=None,
+                            context=None):
+        """Invoice debit lines
+        """
         context = context or {}
         aml_obj = self.pool.get('account.move.line')
         ids = isinstance(ids, (int, long)) and [ids] or ids
         ara_brw = self.browse(cr, uid, ids[0], context=context)
-        account_id = account_id or ara_brw.partner_id.property_account_payable.id
+        account_id = account_id or \
+            ara_brw.partner_id.property_account_payable.id
         partner_id = ara_brw.partner_id.id
         date = date or ara_brw.date_post or fields.date.today()
         period_id = ara_brw.period_id or ara_brw.period_id.id
@@ -142,10 +205,10 @@ class AccountReconcileAdvance(osv.Model):
         ids = isinstance(ids, (int, long)) and [ids] or ids
         ara_brw = self.browse(cr, uid, ids[0], context=context)
         res = []
-        res.append((ara_brw.invoice_ids or ara_brw.ai_aml_ids)
-                   and True or False)
-        res.append((ara_brw.voucher_ids or ara_brw.av_aml_ids) and True or ara_brw.av_aml_ids and True
-                   or False)
+        res.append((ara_brw.invoice_ids or ara_brw.ai_aml_ids) and
+                   True or False)
+        res.append((ara_brw.voucher_ids or ara_brw.av_aml_ids) and True or
+                   ara_brw.av_aml_ids and True or False)
 
         if all(res):
             return True
@@ -166,9 +229,14 @@ class AccountReconcileAdvance(osv.Model):
         ara_brw = self.browse(cr, uid, ids[0], context=context)
 
         # Se preparan los valores para el account.move que se va a crear
-        am_vals = am_obj.account_move_prepare(cr, uid, ara_brw.journal_id.id,
-                                              date=ara_brw.date_post, ref=ara_brw.name,
-                                              company_id=ara_brw.company_id.id, context=context)
+        am_vals = am_obj.account_move_prepare(
+            cr,
+            uid,
+            ara_brw.journal_id.id,
+            date=ara_brw.date_post,
+            ref=ara_brw.name,
+            company_id=ara_brw.company_id.id,
+            context=context)
 
         # Se crea el acocunt.move
         am_id = am_obj.create(cr, uid, am_vals, context=context)
@@ -187,9 +255,11 @@ class AccountReconcileAdvance(osv.Model):
         # Se obtienen los asientos contables de los anticipos (vouchers,
         # credito)
         for av_brw in ara_brw.voucher_ids:
-            av_aml_ids += [l.id for l in av_brw.move_ids if l.account_id.type
-                           == (ara_brw.type == 'pay' and 'payable' or 'receivable')
-                           and not l.reconcile_id and not l.reconcile_partial_id]
+            av_aml_ids += [l.id for l in av_brw.move_ids if
+                           l.account_id.type == (
+                               ara_brw.type == 'pay' and
+                               'payable' or 'receivable') and not
+                           l.reconcile_id and not l.reconcile_partial_id]
 
         # Se unen los asientos contables de los anticipos con los asientos
         # contables escogidos man.
@@ -210,17 +280,17 @@ class AccountReconcileAdvance(osv.Model):
         lines_2_rec = []
         lines_2_par = []
         aml2_brw = None
-        account_id = False
 
         inv_brw = None
         aml2_brw = None
 
-        while (invoice_ids or ai_aml_ids or inv_sum) and (av_aml_ids or aml_sum):
-            #           Get money to pay debts. Whenever we are cashless or our debts are
-            #           greater than the money we have: Use the ATM. And while there is
-            #           money
+        while (invoice_ids or ai_aml_ids or inv_sum) and \
+                (av_aml_ids or aml_sum):
+            # Get money to pay debts. Whenever we are cashless or our debts are
+            # greater than the money we have: Use the ATM. And while there is
+            # money
 
-            #           Let us pick our debt
+            # Let us pick our debt
             if invoice_ids:
                 if not inv_sum:
                     #               BE AWARE MULTICURRENCY MISSING HERE
@@ -243,7 +313,7 @@ class AccountReconcileAdvance(osv.Model):
                                    'pay' and 'debit' or 'credit']
                 aml_grn_sum += aml_brw[ara_brw.type ==
                                        'pay' and 'debit' or 'credit']  # unused
-#               gruping by account_id should be done here
+#               grouping by account_id should be done here
 
 #           While we have plenty of money to pay our debts and there are debts
 #           to pay. Let us pay them!
@@ -253,27 +323,29 @@ class AccountReconcileAdvance(osv.Model):
                     #               Let us spend our money
                     aml_sum -= inv_sum
 #               BE AWARE MULTICURRENCY MISSING HERE
-                    get_aml = ara_brw.type == 'pay' and self.invoice_debit_lines or \
-                        self.invoice_credit_lines
-                    payid = get_aml(cr, uid, ids, inv_sum, account_id=inv_brw.account_id.id,
+                    get_aml = ara_brw.type == 'pay' and \
+                        self.invoice_debit_lines or self.invoice_credit_lines
+                    payid = get_aml(cr, uid, ids, inv_sum,
+                                    account_id=inv_brw.account_id.id,
                                     am_id=am_id, context=context)
                     inv_sum = 0.0
                     iamls = [line.id for line in inv_brw.move_id.line_id if
-                             line.account_id.type == (ara_brw.type == 'pay' and 'payable' or
+                             line.account_id.type == (ara_brw.type == 'pay' and
+                                                      'payable' or
                                                       'receivable')]
                     pamls = [line.id for line in inv_brw.payment_ids]
                     lines_2_rec.append(iamls + pamls + [payid])
                     inv_brw = None
 
                 elif aml2_brw:
-                    pass
-#               Let us spend our money
+                    # Let us spend our money
                     aml_sum -= inv_sum
 #               BE AWARE MULTICURRENCY MISSING HERE
-                    get_aml = ara_brw.type == 'pay' and self.invoice_debit_lines or \
-                        self.invoice_credit_lines
+                    get_aml = ara_brw.type == 'pay' and \
+                        self.invoice_debit_lines or self.invoice_credit_lines
 #               Creates its own mirror and fully reconciliates them
-                    payid = get_aml(cr, uid, ids, inv_sum, account_id=aml2_brw.account_id.id,
+                    payid = get_aml(cr, uid, ids, inv_sum,
+                                    account_id=aml2_brw.account_id.id,
                                     am_id=am_id, context=context)
                     inv_sum = 0.0
                     lines_2_rec.append([payid, aml2_brw.id])
@@ -282,22 +354,25 @@ class AccountReconcileAdvance(osv.Model):
 #           ATM has run out of cash however we still have cash though we are
 #           not able to fully pay our debts. Let us use the remaining
             if not av_aml_ids and aml_sum and inv_sum > aml_sum:
-                #               Payments are over. Last line to invoice is made with the
-                #               aml_sum
-                get_aml = ara_brw.type == 'pay' and self.invoice_debit_lines or \
-                    self.invoice_credit_lines
+                #   Payments are over. Last line to invoice is made with the
+                #   aml_sum
+                get_aml = ara_brw.type == 'pay' and \
+                    self.invoice_debit_lines or self.invoice_credit_lines
 
                 if inv_brw:
-                    payid = get_aml(cr, uid, ids, aml_sum, account_id=inv_brw.account_id.id,
+                    payid = get_aml(cr, uid, ids, aml_sum,
+                                    account_id=inv_brw.account_id.id,
                                     am_id=am_id, context=context)
                     iamls = [line.id for line in inv_brw.move_id.line_id if
-                             line.account_id.type == (ara_brw.type == 'pay' and 'payable' or
+                             line.account_id.type == (ara_brw.type == 'pay' and
+                                                      'payable' or
                                                       'receivable')]
                     pamls = [line.id for line in inv_brw.payment_ids]
                     lines_2_par.append(iamls + pamls + [payid])
 #               BE AWARE MULTICURRENCY MISSING HERE
                 else:
-                    payid = get_aml(cr, uid, ids, aml_sum, account_id=aml2_brw.account_id.id,
+                    payid = get_aml(cr, uid, ids, aml_sum,
+                                    account_id=aml2_brw.account_id.id,
                                     am_id=am_id, context=context)
                     lines_2_par.append([payid, aml2_brw.id])
 #               BE AWARE MULTICURRENCY MISSING HERE
@@ -314,31 +389,34 @@ class AccountReconcileAdvance(osv.Model):
         adv_2_rec = []
         if used_aml_ids:
 
-            #            when reconciling among used_aml_ids, those ids should be grouped by
-            #            account_id, take care of the last used_aml_ids, because is with this
-            #            that the aml_sum (debit) should be created.
-            #            aml_grn_sum => credit
-            #            aml_sum => debit
+            #   when reconciling among used_aml_ids, those ids should be
+            #   grouped by account_id, take care of the last used_aml_ids,
+            #   because is with that the aml_sum (debit) should be created.
+            #   aml_grn_sum => credit
+            #   aml_sum => debit
             if aml_sum:
-                #               if some remaining money get around it will not be reconciled
+                # if some remaining money get around it will not be reconciled
                 # This should be sent to a method in order to be captured
                 if ara_brw.type == 'pay':
                     acc_id = ara_brw.partner_id.property_account_payable.id
                 else:
                     acc_id = ara_brw.partner_id.property_account_receivable.id
-                get_aml = ara_brw.type == 'pay' and self.invoice_debit_lines or \
-                    self.invoice_credit_lines
+                get_aml = ara_brw.type == 'pay' and \
+                    self.invoice_debit_lines or self.invoice_credit_lines
                 get_aml(cr, uid, ids, aml_sum, account_id=acc_id,
                         am_id=am_id, context=context)
 
             get_aml = ara_brw.type == 'pay' and self.invoice_credit_lines or \
                 self.invoice_debit_lines
-            for aml_brw in aml_obj.browse(cr, uid, used_aml_ids, context=context):
+            for aml_brw in aml_obj.browse(cr, uid, used_aml_ids,
+                                          context=context):
                 adv_2_rec.append([get_aml(cr, uid, ids,
                                           aml_brw[ara_brw.type ==
-                                                  'pay' and 'debit' or 'credit'],
+                                                  'pay' and 'debit' or
+                                                  'credit'],
                                           account_id=aml_brw.account_id.id,
-                                          am_id=am_id, context=context), aml_brw.id])
+                                          am_id=am_id, context=context),
+                                  aml_brw.id])
 
         for line_pair in adv_2_rec + lines_2_rec:
             if not line_pair:
@@ -369,7 +447,8 @@ class AccountVoucher(osv.Model):
         for av_brw in self.browse(cr, uid, ids, context=context):
             if av_brw.state != 'posted':
                 continue
-            i = [l.reconcile_id and True or l.reconcile_partial_id and True or False
+            i = [l.reconcile_id and True or l.reconcile_partial_id and True or
+                 False
                  for l in av_brw.move_ids
                  if l.account_id.type in ('receivable', 'payable')]
             res[av_brw.id] = not all(i) if i else False
@@ -379,24 +458,42 @@ class AccountVoucher(osv.Model):
         context = context or {}
         res = set()
         aml_obj = self.pool.get('account.move.line')
-        for l in aml_obj.browse(cr, uid, ids, context=context):
-            if not l.move_id:
+        for element in aml_obj.browse(cr, uid, ids, context=context):
+            if not element.move_id:
                 continue
-            res.add(l.move_id.id)
+            res.add(element.move_id.id)
         res = list(res)
 
         if not res:
             return []
 
         av_obj = self.pool.get('account.voucher')
-        return av_obj.search(cr, uid, [('move_id', 'in', res)], context=context)
+        return av_obj.search(cr,
+                             uid,
+                             [('move_id', 'in', res)],
+                             context=context)
 
+    # pylint: disable=W8105
     _columns = {
-        'advance': fields.function(_get_advance, method=True, string='Is an Advance?',
+        'advance': fields.function(_get_advance,
+                                   method=True,
+                                   string='Is an Advance?',
                                    store={
-                                       'account.voucher': (lambda s, c, u, ids, cx: ids, ['move_ids', 'move_id', 'state'], 15),
-                                       'account.move.line': (_get_voucher_advance, ['reconcile_id', 'reconcile_partial_id'], 30)
+                                       'account.voucher': (
+                                           lambda s,
+                                           c,
+                                           u,
+                                           ids,
+                                           cx: ids,
+                                           ['move_ids', 'move_id', 'state'],
+                                           15),
+                                       'account.move.line': (
+                                           _get_voucher_advance,
+                                           ['reconcile_id',
+                                            'reconcile_partial_id'],
+                                           30)
                                    },
-                                   help='If the payable or receivable are not fully reconcile then it is advance',
+                                   help='If the payable or receivable are '
+                                   'not fully reconcile then it is advance',
                                    type='boolean')
     }

--- a/account_reconcile_advance/security/security.xml
+++ b/account_reconcile_advance/security/security.xml
@@ -21,3 +21,4 @@
         </record>
     </data>
 </openerp>
+

--- a/account_reconcile_advance/test/advance_equals_than_payment.yml
+++ b/account_reconcile_advance/test/advance_equals_than_payment.yml
@@ -111,16 +111,16 @@
     for move in moves_line :
         if move.debit == 300:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment01 (Debit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment01 (Debit)"
         elif move.credit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment01 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment01 (Credit)"
         elif move.debit == 100:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment02 (Debit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment02 (Debit)"
         elif move.credit == 100:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment02 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment02 (Credit)"
         else:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
             assert False, "Wrong entry. Unrecognized in account move line."
@@ -151,16 +151,16 @@
     for move in moves_line :
         if move.debit == 200:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name== None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice05 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice05 (Debit)"
         elif move.credit == 200:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice05 (Credit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice05 (Credit)"
         elif move.debit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name== None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice06 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice06 (Debit)"
         elif move.credit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice06 (Credit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice06 (Credit)"
         else:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
             assert False, "Wrong entry. Unrecognized in account move line."

--- a/account_reconcile_advance/test/advance_equals_than_payment_customer.yml
+++ b/account_reconcile_advance/test/advance_equals_than_payment_customer.yml
@@ -110,16 +110,16 @@
     for move in moves_line :
         if move.debit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment01 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment01 (Debit)"
         elif move.credit == 300:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment01 (Credit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment01 (Credit)"
         elif move.debit == 100:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment02 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment02 (Debit)"
         elif move.credit == 100:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment02 (Credit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment02 (Credit)"
         else:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
             assert False, "Wrong entry. Unrecognized in account move line."
@@ -150,16 +150,16 @@
     for move in moves_line :
         if move.debit == 200:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice05 (Debit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice05 (Debit)"
         elif move.credit == 200:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice05 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice05 (Credit)"
         elif move.debit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice06 (Debit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice06 (Debit)"
         elif move.credit == 300:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice06 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice06 (Credit)"
         else:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
             assert False, "Wrong entry. Unrecognized in account move line."

--- a/account_reconcile_advance/test/advance_greater_than_payment.yml
+++ b/account_reconcile_advance/test/advance_greater_than_payment.yml
@@ -219,16 +219,16 @@
     for move in moves_line :
         if move.debit == 500:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment01 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment01 (Debit)"
         elif move.credit == 500:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment01 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment01 (Credit)"
         elif move.debit == 1000:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment02 (Debit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment02 (Debit)"
         elif move.credit == 1000:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment02 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment02 (Credit)"
         else:
             assert False, "Wrong entry. Unrecognized in account move line."
 -
@@ -259,21 +259,21 @@
     for move in moves_line :
         if move.debit == 100:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Invoice01 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice01 (Debit)"
         elif move.credit == 100:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice01 (Credit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice01 (Credit)"
         elif move.debit == 200:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name== None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice02 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice02 (Debit)"
         elif move.credit == 200:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice02 (Credit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice02 (Credit)"
         elif move.debit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name== None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice03 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice03 (Debit)"
         elif move.credit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice03 (Credit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice03 (Credit)"
         else:
             assert False, "Wrong entry. Unrecognized in account move line."

--- a/account_reconcile_advance/test/advance_greater_than_payment_customer.yml
+++ b/account_reconcile_advance/test/advance_greater_than_payment_customer.yml
@@ -216,16 +216,16 @@
     for move in moves_line :
         if move.debit == 500:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of receipt01 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of receipt01 (Debit)"
         elif move.credit == 500:
             print move.account_id.name,'\t',move.name ,'\t\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of receipt01 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of receipt01 (Credit)"
         elif move.debit == 1000:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of receipt02 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of receipt02 (Debit)"
         elif move.credit == 1000:
             print move.account_id.name,'\t',move.name ,'\t\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of receipt02 (Credit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of receipt02 (Credit)"
         else:
             assert False, "Wrong entry. Unrecognized in account move line."
 -
@@ -256,21 +256,21 @@
     for move in moves_line :
         if move.debit == 100:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Invoice01 (Debit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice01 (Debit)"
         elif move.credit == 100:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice01 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Inovice01 (Credit)"
         elif move.debit == 200:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice02 (Debit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Inovice02 (Debit)"
         elif move.credit == 200:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None  and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice02 (Credit)"
+            assert move.reconcile_id.name == False  and move.reconcile_partial_id.name == False , "Wrong in account move line of Inovice02 (Credit)"
         elif move.debit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice03 (Debit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Inovice03 (Debit)"
         elif move.credit == 300:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None  and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice03 (Credit)"
+            assert move.reconcile_id.name == False  and move.reconcile_partial_id.name == False , "Wrong in account move line of Inovice03 (Credit)"
         else:
             assert False, "Wrong entry. Unrecognized in account move line."

--- a/account_reconcile_advance/test/advance_less_than_payment.yml
+++ b/account_reconcile_advance/test/advance_less_than_payment.yml
@@ -155,10 +155,10 @@
     for move in moves_line :
         if move.debit == 500:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment03 (Debit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment03 (Debit)"
         elif move.credit == 500:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment03 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment03 (Credit)"
         else:
             assert False, "Wrong entry. Unrecognized in account move line."
 -
@@ -189,21 +189,21 @@
     for move in moves_line :
         if move.debit == 400:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Invoice04 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice04 (Debit)"
         elif move.credit == 400:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice04 (Credit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice04 (Credit)"
         elif move.debit == 200:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name== None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice05 (Debit)"
+            assert move.reconcile_id.name== False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice05 (Debit)"
         elif move.credit == 200:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice05 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice05 (Credit)"
         elif move.debit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name== None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice06 (Debit)"
+            assert move.reconcile_id.name== False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice06 (Debit)"
         elif move.credit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name , "Wrong in account move line of Inovice06 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name , "Wrong in account move line of Invoice06 (Credit)"
         else:
             assert False, "Wrong entry. Unrecognized in account move line."

--- a/account_reconcile_advance/test/advance_less_than_payment_customer.yml
+++ b/account_reconcile_advance/test/advance_less_than_payment_customer.yml
@@ -150,10 +150,10 @@
     for move in moves_line :
         if move.debit == 500:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment03 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment03 (Debit)"
         elif move.credit == 500:
             print move.account_id.name,'\t',move.name ,'\t\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Payment03 (Credit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Payment03 (Credit)"
         else:
             assert False, "Wrong entry. Unrecognized in account move line."
 -
@@ -184,21 +184,21 @@
     for move in moves_line :
         if move.debit == 400:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name and move.reconcile_partial_id.name == None , "Wrong in account move line of Invoice04 (Debit)"
+            assert move.reconcile_id.name and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice04 (Debit)"
         elif move.credit == 400:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice04 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice04 (Credit)"
         elif move.debit == 200:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name== None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice05 (Debit)"
+            assert move.reconcile_id.name== False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice05 (Debit)"
         elif move.credit == 200:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice05 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice05 (Credit)"
         elif move.debit == 300:
             print move.account_id.name,'\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name== None and move.reconcile_partial_id.name  , "Wrong in account move line of Inovice06 (Debit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name  , "Wrong in account move line of Invoice06 (Debit)"
         elif move.credit == 300:
             print move.account_id.name,'\t\t',move.name ,'\t', move.date ,'\t', move.debit,'\t', move.credit,'\t', move.reconcile_id.name , '\t', move.reconcile_partial_id.name
-            assert move.reconcile_id.name == None and move.reconcile_partial_id.name == None , "Wrong in account move line of Inovice06 (Credit)"
+            assert move.reconcile_id.name == False and move.reconcile_partial_id.name == False , "Wrong in account move line of Invoice06 (Credit)"
         else:
             assert False, "Wrong entry. Unrecognized in account move line."


### PR DESCRIPTION
…f None, because None was taken in the comparison as if it were a True value triggering the error.
## [VX#4604](https://www.vauxoo.com/web#id=4604&view_type=form&model=project.task&menu_id=136&action=138)
- [x] Fix the following errors at the [tests log](https://gist.githubusercontent.com/moylop260/4e67df1048a1e089e985/raw/68f8a6944a74d08dca58b0c0fe04929873a21198/account_reconcile_advance.log):

``` bash
2016-01-16 21:04:48,299 13861 [1;34m[1;49mDEBUG[0m openerp_test_account_reconcile_advance openerp.tools.yaml_import: I check account vouchers of payments
Payment01   2016-02-28  Vauxoo  500.0   True
Payment02   2016-02-15  Vauxoo  1000.0  False
2016-01-16 21:04:48,307 13861 [1;34m[1;49mDEBUG[0m openerp_test_account_reconcile_advance openerp.tools.yaml_import: I check account move line of payments
Creditors - (test)      BNK/2016/001    2016-02-28  500.0   0.0     False   False
2016-01-16 21:04:48,324 13861 [1;31m[1;49mERROR[0m openerp_test_account_reconcile_advance openerp.tools.yaml_import: AssertionError in Python code  (line 214): Wrong in account move line of Payment01 (Debit)
2016-01-16 21:04:48,324 13861 [1;34m[1;49mDEBUG[0m openerp_test_account_reconcile_advance openerp.tools.yaml_import: I check account vouchers of invoices
2016-03-11  2016-06-14  Vauxoo  100.0   paid    100.0   0.0
2016-04-26  2016-06-11  Vauxoo  200.0   paid    200.0   0.0
2016-05-08  2016-06-05  Vauxoo  300.0   paid    300.0   0.0
2016-01-16 21:04:48,350 13861 [1;34m[1;49mDEBUG[0m openerp_test_account_reconcile_advance openerp.tools.yaml_import: I check account move line of invoices
Creditors - (test)  Invoice03   2016-05-08  0.0     300.0   A5  False
2016-01-16 21:04:48,375 13861 [1;31m[1;49mERROR[0m openerp_test_account_reconcile_advance openerp.tools.yaml_import: AssertionError in Python code  (line 254): Wrong in account move line of Inovice03 (Credit)
2016-01-16 21:04:48,375 13861 [1;32m[1;49mINFO[0m openerp_test_account_reconcile_advance openerp.modules.loading: loading account_reconcile_advance/test/advance_less_than_payment.yml
```
- [x] I attached the log without errors after the change:
  [account_reconcile_advance_cleandb_i_test_enable20.txt](https://github.com/Vauxoo/addons-vauxoo/files/253276/account_reconcile_advance_cleandb_i_test_enable20.txt)
- [x] Rebase.
