### PR TITLE
[Fix] stock_landed_costs.py

### DIFF
--- a/stock_landed_costs_average/model/stock_landed_costs.py
+++ b/stock_landed_costs_average/model/stock_landed_costs.py
@@ -513,6 +513,13 @@ class StockLandedCost(models.Model):
 
             cost.write(
                 {'state': 'done', 'account_move_id': move_id})
+            
+            # Post the account move if the journal's auto post true
+            move_obj = self.env['account.move'].browse(move_id)
+            if move_obj.journal_id.entry_posted:
+                move_obj.post()
+                move_obj.validate()
+                
         return True
 
     @api.v7


### PR DESCRIPTION
This fix will ensure posting account move of landed cost if the journal have auto post checked.

this is being done by calling 2 methods on move_obj: 1- post() then 2- validate()
