### PR TITLE
[FIX][product_extended_segmentation] Active model for write set on context.

### DIFF
--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -221,6 +221,7 @@ class ProductTemplate(models.Model):
         ctx.update({
             'active_id': product_tmpl_id.id,
             'active_ids': product_tmpl_id.ids,
+            'active_model': product_tmpl_id._name,
         })
         if threshold_reached:
             return self.ensure_change_price_log_messages(cr, uid, vals, ctx)


### PR DESCRIPTION
To fix the error that triggers this warning:

![product variants - odoo](https://cloud.githubusercontent.com/assets/7597456/15733686/de951aaa-284d-11e6-8f03-f71ba60a36cb.png)
