### PR TITLE
[8.0][message_post_model] Modified the way to get the value shown in the message and how this is tested

### DIFF
--- a/message_post_model/model/message_post.py
+++ b/message_post_model/model/message_post.py
@@ -107,15 +107,16 @@ class MessagePostShowAll(models.Model):
                         mes = ' - '.join(dele)
                         message = '%s\n<li><b>%s %s<b>: %s</li>' % \
                             (self.get_encode_value(message),
-                             add, string,
-                             mes)
+                             self.get_encode_value(add),
+                             self.get_encode_value(string),
+                             self.get_encode_value(mes))
                     if not lastv and new:
 
                         dele = [obj.browse(i).name_get()[0][1] for i in new]
                         mes = '-'.join(dele)
                         message = '%s\n<li><b>%s %s<b>: %s</li>' % \
                             (self.get_encode_value(message),
-                             delete,
+                             self.get_encode_value(delete),
                              string,
                              mes)
 

--- a/message_post_model/model/message_post.py
+++ b/message_post_model/model/message_post.py
@@ -85,7 +85,9 @@ class MessagePostShowAll(models.Model):
                 if val[0] == 0:
                     value = val[2]
                     message = '%s\n<li><b>%s<b>: %s</li>' % \
-                        (message, info.get(val[0]), value.get(r_name),)
+                        (self.get_encode_value(message),
+                         self.get_encode_value(info.get(val[0])),
+                         self.get_encode_value(value.get(r_name)))
                 elif val[0] in (2, 3):
                     model_brw = obj.browse(val[1])
                     last_value = model_brw.name_get()
@@ -117,8 +119,8 @@ class MessagePostShowAll(models.Model):
                         message = '%s\n<li><b>%s %s<b>: %s</li>' % \
                             (self.get_encode_value(message),
                              self.get_encode_value(delete),
-                             string,
-                             mes)
+                             self.get_encode_value(string),
+                             self.get_encode_value(mes))
 
                 elif val[0] == 1:
                     vals = val[2]

--- a/message_post_test/tests/test_message_post.py
+++ b/message_post_test/tests/test_message_post.py
@@ -10,29 +10,34 @@ class TestMessagePost(TransactionCase):
         self.test_models = [('message.post.test', 'message.post.test.line'),
                             ('message.post.test.new.api',
                              'message.post.test.line.new.api')]
-        self.user = self.registry('res.users')
-        self.message = self.registry('mail.message')
+        self.user = self.env['res.users']
+        self.message = self.env['mail.message']
+        self.trans = self.env['ir.translation']
 
-    def test_log_git_flow_message_test(self):
-        cr, uid = self.cr, self.uid
+    def test_01_log_git_flow_message_test(self):
+        """Testing the messages in the test model
+        """
         i = 0
         for main_model, line_model in self.test_models:
             i += 1
-            message_test = self.registry(main_model)
-            message_test_line = self.registry(line_model)
-            user_id_field = message_test._fields.get('user_id').string
-            number_field = message_test._fields.get('number').string
-            line_ids_field = message_test._fields.get('line_ids').string
-            user_ids_field = message_test._fields.get('user_ids').string
-            check_field = message_test._fields.get('check').string
-            user_1 = self.user.create(cr, uid,
-                                      {'name': 'Test 1',
-                                       'login': 'test%s' % str(1 + i)})
-            user_2 = self.user.create(cr, uid,
-                                      {'name': 'Test 2',
-                                       'login': 'test%s' % str(8 + i)})
-            message_test_id = message_test.create(cr, uid, {
-                'name': 'Test Message',
+            message_test = self.env[main_model]
+            message_test_line = self.env[line_model]
+            user_id_field = message_test.get_string_by_field(message_test,
+                                                             'user_id')
+            number_field = message_test.get_string_by_field(message_test,
+                                                            'number')
+            line_ids_field = message_test.get_string_by_field(message_test,
+                                                              'line_ids')
+            user_ids_field = message_test.get_string_by_field(message_test,
+                                                              'user_ids')
+            check_field = message_test.get_string_by_field(message_test,
+                                                           'check')
+            user_1 = self.user.create({'name': 'Test 1',
+                                       'login': 'test%s' % str(1 + i)}).id
+            user_2 = self.user.create({'name': 'Test 2 ó%á',
+                                       'login': 'test%s' % str(8 + i)}).id
+            message_test_id = message_test.create({
+                'name': 'Test Message ó%á',
                 'user_id': SUPERUSER_ID,
                 'check': True,
                 'number': 56,
@@ -45,24 +50,32 @@ class TestMessagePost(TransactionCase):
                 ],
             })
             # Added new lines and modifitying simples fields
-            message_test.write(cr, uid, [message_test_id], {
+            message_test_id.write({
                 'check': False,
                 'number': 78,
                 'user_id': user_1,
                 'line_ids': [
-                    (0, 0, {'name': 'Test 5'}),
+                    (0, 0, {'name': 'Test 5 óá%'}),
                     (0, 0, {'name': 'Test 6'}),
                 ]})
 
             message_ids = self.message.search(
-                cr, uid, [
-                    ('res_id', '=', message_test_id),
+                [
+                    ('res_id', '=', message_test_id.id),
+                    ('model', '=', main_model),
+                ])
+            term = self.trans._get_source('', 'code',
+                                          self.env.user.lang,
+                                          source='Created New Line')
+            message_ids = self.message.search(
+                [
+                    ('res_id', '=', message_test_id.id),
                     ('model', '=', main_model),
                     ('body', 'ilike', '%' + check_field + '%'),
                     ('body', 'ilike', '%' + number_field + '%'),
                     ('body', 'ilike', '%' + user_id_field + '%'),
                     ('body', 'ilike', '%' + line_ids_field +
-                     '%Created New Line%'),
+                     '%' + term + '%'),
                     ('body', 'ilike', '%' + 'False' + '%'),
                     ('body', 'ilike', '%' + '78' + '%'),
                     ('body', 'ilike', '%' + 'Test 1' + '%'),
@@ -74,16 +87,16 @@ class TestMessagePost(TransactionCase):
                                     1,
                                     "The last changes were not registred")
             # Updating lines and remove one of them
-            line_ids = message_test_line.search(cr, uid, [])
-            message_test.write(cr, uid, [message_test_id], {
+            line_ids = message_test_line.search([])
+            message_test_id.write({
                 'line_ids': [
-                    (1, line_ids[0], {'name': 'Test Update'}),
-                    (2, line_ids[1]),
+                    (1, line_ids.ids[0], {'name': 'Test Update'}),
+                    (2, line_ids.ids[1]),
                 ]})
 
             message_ids = self.message.search(
-                cr, uid, [
-                    ('res_id', '=', message_test_id),
+                [
+                    ('res_id', '=', message_test_id.id),
                     ('model', '=', main_model),
                     ('body', 'ilike', '%' + line_ids_field + '%'),
                     ('body', 'ilike', '%' + 'Test Update' + '%'),
@@ -95,19 +108,43 @@ class TestMessagePost(TransactionCase):
 
             # Removing an element of a many2many field
 
-            message_test.write(cr, uid, [message_test_id], {
+            message_test_id.write({
                 'user_ids': [
                     (6, 0, [SUPERUSER_ID, user_2]),
                 ]})
 
+            term = self.trans._get_source('', 'code',
+                                          self.env.user.lang,
+                                          source='Deleted')
             message_ids = self.message.search(
-                cr, uid, [
-                    ('res_id', '=', message_test_id),
+                [
+                    ('res_id', '=', message_test_id.id),
                     ('model', '=', main_model),
-                    ('body', 'ilike', '%' + user_ids_field + '%Deleted%'),
+                    ('body', 'ilike', '%' + user_ids_field + '%' + term + '%'),
                     ('body', 'ilike', '%' + 'Test 1' + '%'),
                 ])
 
             self.assertGreaterEqual(len(message_ids),
                                     1,
                                     "The last changes were not registred")
+
+    def test_02_log_git_flow_message_lang_test(self):
+        """Testing the message with another lang configured
+        """
+        lang_obj = self.env['res.lang']
+        modobj = self.env['ir.module.module']
+        lang = 'es_MX'
+        lang_ids = lang_obj.search([('code', '=', 'es_PA')])
+        if not lang_ids:
+            lang_obj.load_lang(lang)
+        lang_ids = lang_obj.search([('code', '=', lang)])
+        mids = modobj.search([('state', '=', 'installed')])
+        context = {'overwrite': True}
+        mids.with_context(context).update_translations(lang)
+        lang_ids.write(
+            {
+                'date_format': '%d/%m/%Y',
+                'time_format': '%H:%M:%S', 'thousands_sep': ',',
+                'decimal_point': '.', 'grouping': '[3,3,3,3,3,3,3,3,-2]'})
+        self.env.user.write({'lang': lang})
+        self.test_01_log_git_flow_message_test()


### PR DESCRIPTION
When the user change his lang the value returned for the translation engine generates an error when the message is created. 

To avoid this we are passing all value returned for the name_get method, for our wrapper to encode the strings.

Modified the test to try the unicode strings and the change of the lang by the user.

Close #986 
Close #978
