### PR TITLE
[FIX] Wrong Conditional Clause at SQL Query 

### DIFF
--- a/account_currency_tools/model/res_company.py
+++ b/account_currency_tools/model/res_company.py
@@ -67,4 +67,9 @@ class ResCompany(osv.Model):
             'account.journal', 'Posting Journal',
             domain=("[('type','=','general')]"),
             required=False),
+        'check_non_multicurrency_account': fields.boolean(
+            'Check Non-Multicurrency Account',
+            help="Check Accounts that were not set as multicurrency, "
+            "i.e., they were not set with a secondary currency, "
+            "but were involved in multicurrency transactions"),
     }

--- a/account_currency_tools/view/view.xml
+++ b/account_currency_tools/view/view.xml
@@ -9,6 +9,7 @@
                 <xpath expr="//group[@name='account_grp']" position="after">
                     <group name="account_act" string="Accounts for Redirection of Exchange Rate Difference">
                         <field name='journal_id'/>
+                        <field name='check_non_multicurrency_account'/>
                         <field name='bank_gain_exchange_account_id'/>
                         <field name='bank_loss_exchange_account_id'/>
                         <field name='rec_gain_exchange_account_id'/>

--- a/account_currency_tools/view/wizard.xml
+++ b/account_currency_tools/view/wizard.xml
@@ -344,6 +344,7 @@
                                         on_change='onchange_company_id(company_id)'
                                         readonly="1"/>
                                     <field name="currency_id"/>
+                                    <field name='check_non_multicurrency_account'/>
                                 </group>
                             </page>
                         </notebook>

--- a/account_currency_tools/wizard/exchange_realization.py
+++ b/account_currency_tools/wizard/exchange_realization.py
@@ -423,7 +423,8 @@ class ForeignExchangeRealization(osv.osv_memory):
                 aml.state <> 'draft' AND
                 am.state IN (%(states)s) AND
                 aml.company_id = %(company_id)d AND
-                aa.id BETWEEN %(parent_left)d AND %(parent_right)d AND
+                aa.parent_left >= %(parent_left)d AND
+                aa.parent_right <= %(parent_right)d AND
                 ap.id IN (%(period_ids)s)
             GROUP BY aml.account_id
         ''' % args

--- a/account_currency_tools/wizard/exchange_realization.py
+++ b/account_currency_tools/wizard/exchange_realization.py
@@ -393,7 +393,8 @@ class ForeignExchangeRealization(osv.osv_memory):
                 am.state IN (%(states)s) AND
                 ap.id IN (%(period_ids)s)
             GROUP BY aml.currency_id
-        ''' % args
+        '''
+        query = cr.mogrify(query, args)
         cr.execute(query)
         res = cr.dictfetchall()
         return res
@@ -415,7 +416,8 @@ class ForeignExchangeRealization(osv.osv_memory):
                 am.state IN (%(states)s) AND
                 ap.id IN (%(period_ids)s)
             GROUP BY aml.account_id, aml.currency_id
-        ''' % args
+        '''
+        query = cr.mogrify(query, args)
         cr.execute(query)
         res = cr.dictfetchall()
         return res
@@ -438,7 +440,8 @@ class ForeignExchangeRealization(osv.osv_memory):
                 aa.parent_right <= %(parent_right)d AND
                 ap.id IN (%(period_ids)s)
             GROUP BY aml.account_id
-        ''' % args
+        '''
+        query = cr.mogrify(query, args)
         cr.execute(query)
         res = cr.fetchall()
         if res:


### PR DESCRIPTION
[FIX] Wrong Conditional Clause at SQL Query 
with parent_left and parent_right columns on 
account_account table which is causing
unintended behaviours when computing 
Foreign Currency Exchange Realization Journal Entries
