### PR TITLE
[IMP] modules version do not follow the OCA guideline

### DIFF
--- a/account_analytic_active_field/__openerp__.py
+++ b/account_analytic_active_field/__openerp__.py
@@ -21,7 +21,7 @@
 ##########################################################################
 {
     "name": "Field Active In Analytic Accounts",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Accouting",
     "website": "http://www.vauxoo.com/",

--- a/account_invoice_show_by_user/__openerp__.py
+++ b/account_invoice_show_by_user/__openerp__.py
@@ -21,7 +21,7 @@
 ##########################################################################
 {
     "name": "Show invoice by user",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Accounting",
     "website": "http://www.vauxoo.com",

--- a/account_move_report/__openerp__.py
+++ b/account_move_report/__openerp__.py
@@ -21,7 +21,7 @@
 ##########################################################################
 {
     "name": "Journal Entries report",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Accouting",
     "website": "http://www.vauxoo.com/",

--- a/account_tax_importation/__openerp__.py
+++ b/account_tax_importation/__openerp__.py
@@ -26,7 +26,7 @@
 
 {
     "name": "Account tax importation",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Localization/Mexico",
     "website": "http://www.vauxoo.com/",

--- a/bank_iva_report/__openerp__.py
+++ b/bank_iva_report/__openerp__.py
@@ -30,7 +30,7 @@
 # retencion_iva, base_vat_ve  ver si se puede eliminar esta dependencia
 {
     "name": "Voucher Paid support report",
-    "version": "0.6",
+    "version": "8.0.0.0.6",
     "author": "Vauxoo",
     "category": "Generic Modules/Accounting",
     "website": "http://vauxoo.com",

--- a/base_vat_principal_view/__openerp__.py
+++ b/base_vat_principal_view/__openerp__.py
@@ -27,7 +27,7 @@
 ###############################################################################
 {
     "name": "Move vat field",
-    "version": "0.6",
+    "version": "8.0.0.0.6",
     "author": "Vauxoo",
     "category": "Customer",
     "website": "http://vauxoo.com",

--- a/bom_inventory_information/__openerp__.py
+++ b/bom_inventory_information/__openerp__.py
@@ -25,7 +25,7 @@
 ##############################################################################
 {
     "name": "BOM Inventory Information",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Generic Modules",
     "website": "http://www.vauxoo.com/",

--- a/crm_cost_issue/__openerp__.py
+++ b/crm_cost_issue/__openerp__.py
@@ -26,7 +26,7 @@
 ###
 {
     "name": "CRM Cost Issue",
-    "version": "0.6",
+    "version": "8.0.0.0.6",
     "author": "Vauxoo",
     "category": "Generic Modules/Accounting",
     "website": "http://vauxoo.com",

--- a/group_button_wkf_send_rfq/__openerp__.py
+++ b/group_button_wkf_send_rfq/__openerp__.py
@@ -25,7 +25,7 @@
 ##############################################################################
 {
     "name": "Purchase / Group for button send email",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Purchase",
     "website": "http://www.vauxoo.com/",

--- a/inactive_account_children/__openerp__.py
+++ b/inactive_account_children/__openerp__.py
@@ -21,7 +21,7 @@
 ##########################################################################
 {
     "name": "Wizard that disables accounts childs ",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Accounting",
     "website": "http://vauxoo.com",

--- a/ir_actions_report_xml_multicompany/__openerp__.py
+++ b/ir_actions_report_xml_multicompany/__openerp__.py
@@ -21,7 +21,7 @@
 ##########################################################################
 {
     "name": "Fields Active, Company And Sequence For Model Ir_actions_report_xml",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Generic",
     "website": "http://www.vauxoo.com/",

--- a/portal_user_story/__openerp__.py
+++ b/portal_user_story/__openerp__.py
@@ -26,7 +26,7 @@
 
 {
     "name": "Portal Access for User Story",
-    "version": "0.6",
+    "version": "8.0.0.0.6",
     "depends": [
         "base",
         "user_story",

--- a/product_category_multicompany/__openerp__.py
+++ b/product_category_multicompany/__openerp__.py
@@ -25,7 +25,7 @@
 ##############################################################################
 {
     "name": "Product Category Multi-Company",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "",
     "website": "http://www.vauxoo.com/",

--- a/product_rfq/__openerp__.py
+++ b/product_rfq/__openerp__.py
@@ -27,7 +27,7 @@
 ###############################################################################
 {
     "name": "Product RFQ",
-    "version": "0.6",
+    "version": "8.0.0.0.6",
     "author": "Vauxoo",
     "category": "Custom",
     "website": "http://vauxoo.com",

--- a/project_followers_rule/__openerp__.py
+++ b/project_followers_rule/__openerp__.py
@@ -25,7 +25,7 @@
 #
 {
     "name": "Followers of Task to Project",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Generic Modules",
     "website": "http://www.vauxoo.com/",

--- a/project_issue_report/__openerp__.py
+++ b/project_issue_report/__openerp__.py
@@ -24,7 +24,7 @@
 ##############################################################################
 {
     "name": "Project Issue Report",
-    "version": "0.6",
+    "version": "8.0.0.0.6",
     "author": "Vauxoo",
     "category": "Generic Modules/Others",
     "website": "http://wiki.openerp.org.ve/",

--- a/project_search_create_uid/__openerp__.py
+++ b/project_search_create_uid/__openerp__.py
@@ -25,7 +25,7 @@
 ##############################################################################
 {
     "name": "Search by Last Modification User, Date Modified, Date Created",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "",
     "website": "http://www.vauxoo.com/",

--- a/purchase_multi_report/__openerp__.py
+++ b/purchase_multi_report/__openerp__.py
@@ -26,7 +26,7 @@
 ##############################################################################
 {
     "name": "Report Order customisation Vnzla",
-    "version": "0.6",
+    "version": "8.0.0.0.6",
     "author": "Vauxoo",
     "category": "Generic Modules/Others",
     "website": "http://wiki.openerp.org.ve/",

--- a/report_move_voucher/__openerp__.py
+++ b/report_move_voucher/__openerp__.py
@@ -25,7 +25,7 @@
 ##############################################################################
 {
     "name": "Report Move Voucher",
-    "version": "0.6",
+    "version": "8.0.0.0.6",
     "author": "Vauxoo",
     "category": "Generic Modules/Others",
     "website": "http://wiki.openerp.org.ve/",

--- a/send_mail_task/__openerp__.py
+++ b/send_mail_task/__openerp__.py
@@ -27,7 +27,7 @@
 ###############################################################################
 {
     "name": "Send mail when create a task",
-    "version": "0.6",
+    "version": "8.0.0.0.6",
     "author": "Vauxoo",
     "category": "Project",
     "website": "http://vauxoo.com",

--- a/stock_location_acml/__openerp__.py
+++ b/stock_location_acml/__openerp__.py
@@ -25,7 +25,7 @@
 ##############################################################################
 {
     "name": "Stock Location ACML",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Generic Modules/Account",
     "website": "http://www.vauxoo.com/",

--- a/stock_picking_show_entries_info/__openerp__.py
+++ b/stock_picking_show_entries_info/__openerp__.py
@@ -25,7 +25,7 @@
 ##############################################################################
 {
     "name": "Show Entries Information in Stock Picking",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Generic Modules/Account",
     "website": "http://www.vauxoo.com/",

--- a/supplier_invoice_number_unique/__openerp__.py
+++ b/supplier_invoice_number_unique/__openerp__.py
@@ -21,7 +21,7 @@
 # #########################################################################
 {
     "name": "supplier_invoice_number_unique",
-    "version": "1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Accouting",
     "website": "http://www.vauxoo.com/",


### PR DESCRIPTION
module: user_story
version: 2.6

This module version number do not match with the OCA guidelines.
The version is  `2.6` but should be `8.0.2.6.0` 

Change here https://github.com/Vauxoo/addons-vauxoo/blob/8.0/user_story/__openerp__.py#L28

Maybe another modules are in the same condition.

NOTE: This [script](https://github.com/Vauxoo/addons-vauxoo/blob/8.0/.version.py) was created to update the version of modules of this repository. Maybe this script can be modificate and use to update this module version and another modules in the same situation.
