### PR TITLE
[IMP][8.0][product_do_merge] Fix issue when delivery module is installed

### DIFF
--- a/product_do_merge/README.rst
+++ b/product_do_merge/README.rst
@@ -16,5 +16,13 @@ We can select which product will be the main product.
 This feature do not change anything if the products to be merged have
 operations in different units of measure.
 
+It is possible to exclude some UoM fields in certain models from the above
+check. For example, the field Weight UoM introduced by module 'Delivery'
+will be often set in a UoM dimension different than that of the product.
+
+In order to exclude a specific field, please go to 'Settings / Technical /
+Database structure / Exclude UoM from Product Merge', then add the field
+related to the product UoM that you want to exclude from the merge criteria.
+
 This feature is in the follow path Warehouse/Tools/Duplicate products
 also is created an action menu in the product view.

--- a/product_do_merge/__openerp__.py
+++ b/product_do_merge/__openerp__.py
@@ -33,8 +33,10 @@
     ],
     "demo": [],
     "data": [
+        "security/ir.model.access.csv",
         "security/res_groups.xml",
-        "wizard/base_product_merge_view.xml"
+        "wizard/base_product_merge_view.xml",
+        "views/product_merge_uom_field_exclude_view.xml"
     ],
     "test": [],
     "js": [],

--- a/product_do_merge/model/__init__.py
+++ b/product_do_merge/model/__init__.py
@@ -1,2 +1,3 @@
 # coding: utf-8
 from . import product
+from . import product_merge_uom_field_exclude

--- a/product_do_merge/model/product_merge_uom_field_exclude.py
+++ b/product_do_merge/model/product_merge_uom_field_exclude.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. (www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields
+
+
+class ProductMergeUoMFieldExclude(models.Model):
+    _description = 'Product Merge Field Exclude'
+    _name = "product.merge.uom.field.exclude"
+
+    field_id = fields.Many2one(comodel_name='ir.model.fields',
+                               string='Field', required=True,
+                               domain=[('relation', '=', 'product.uom')])
+    model_id = fields.Many2one(comodel_name='ir.model',
+                               related='field_id.model_id',
+                               string='Model', readonly=True)
+    name = fields.Char(related='field_id.name')

--- a/product_do_merge/security/ir.model.access.csv
+++ b/product_do_merge/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+"access_product_merge_uom_field_exclude_group_erp_manager","product_merge_uom_field_exclude group_erp_manager","model_product_merge_uom_field_exclude","base.group_erp_manager",1,1,1,1

--- a/product_do_merge/views/product_merge_uom_field_exclude_view.xml
+++ b/product_do_merge/views/product_merge_uom_field_exclude_view.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+
+
+        <!-- Fiscal Year -->
+        <record id="view_product_merge_uom_field_exclude_form" model="ir.ui.view">
+            <field name="name">product.merge.uom.field.exclude.form</field>
+            <field name="model">product.merge.uom.field.exclude</field>
+            <field name="arch" type="xml">
+                <form string="Exclude UoM from Product Merge">
+                    <group>
+                        <field name="field_id"/>
+                        <field name="name"/>
+                        <field name="model_id"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <record id="view_product_merge_uom_field_exclude_tree" model="ir.ui.view">
+            <field name="name">product.merge.uom.field.exclude.tree</field>
+            <field name="model">product.merge.uom.field.exclude</field>
+            <field name="arch" type="xml">
+                <tree string="Exclude UoM from Product Merge">
+                    <field name="field_id"/>
+                    <field name="name"/>
+                    <field name="model_id"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_product_merge_uom_field_exclude_search" model="ir.ui.view">
+            <field name="name">product.merge.uom.field.exclude.search</field>
+            <field name="model">product.merge.uom.field.exclude</field>
+            <field name="arch" type="xml">
+                <search string="Search Exclude UoM from Product Merge">
+                    <field name="field_id"/>
+                </search>
+            </field>
+        </record>
+
+        <record id="action_product_merge_uom_field_exclude" model="ir.actions.act_window">
+            <field name="name">Exclude UoM from Product Merge</field>
+            <field name="res_model">product.merge.uom.field.exclude</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+        <menuitem parent="base.next_id_9"
+                  name="Excluded UoM fields in Product Merge"
+                  id="menu_product_merge_uom_field_exclude"
+                  action="action_product_merge_uom_field_exclude"/>
+
+</data>
+</openerp>

--- a/product_do_merge/wizard/base_product_merge_view.xml
+++ b/product_do_merge/wizard/base_product_merge_view.xml
@@ -57,7 +57,7 @@
                             <p class="oe_grey" attrs="{'invisible': [('state', '!=', ('option'))]}">
                                 Select the list of fields used to search for
                                 duplicated records. If you select several fields,
-                                OpenERP will propose you to merge only those having
+                                Odoo will propose you to merge only those having
                                 all these fields in common. (not one of the fields).
                             </p>
                             <group attrs="{'invisible': ['|', ('state', 'not in', ('selection', 'finished')), ('number_group', '=', 0)]}">
@@ -137,8 +137,9 @@
                             <p class="oe_grey" attrs="{'invisible': [('state', '!=', ('option'))]}">
                                 Select the list of fields used to search for
                                 duplicated records. If you select several fields,
-                                OpenERP will propose you to merge only those having
-                                all these fields in common. (not one of the fields).
+                                Odoo will propose you to merge only those
+                                having all these fields in common. (not one
+                                of the fields).
                             </p>
                             <group attrs="{'invisible': ['|', ('state', 'not in', ('selection', 'finished')), ('number_group', '=', 0)]}">
                                 <field name="state" invisible="1" />


### PR DESCRIPTION
Fixes issue #465 

With this PR..

It is possible to exclude some UoM fields in certain models from the check of conflicting UoM's. 

For example, the field Weight UoM introduced by module 'Delivery' will be often set in a UoM for the field 'Weight Unit of Measure' with a dimension different than that of the product. For example, deliver 1 Unit(s), with weight = 700 Kg.

In normal circumstances the merge process will fail because "Kg" is not in the same dimension as the product's base Uom (Unit).

In order to exclude a specific field, please go to 'Settings / Technical / Database structure / Exclude UoM from Product Merge', then add the field related to the product UoM that you want to exclude from the merge criteria.
