### PR TITLE
New version of default_warehouse_from_sale_team module

### DIFF
--- a/default_warehouse_from_sale_team/README.rst
+++ b/default_warehouse_from_sale_team/README.rst
@@ -1,17 +1,58 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
     :alt: License: AGPL-3
 
-Sales Team Warehouse by default
-===============================
+====================
+Sales Team Warehouse
+====================
+
+Usage
+=====
 
 Add a field `default_warehouse` in sales team.
 
 Create sort kind of api where any object with field called warehouse_id will
-take the default value from the sales team field.
+take the default value from the sales team field
+this taking into account the team defined in `Default Sale Teams` field defined
+in the res.user model.
 
-To use it simple do this:
+To improve, consistency and usability we add the next features:
 
-1. inherit the class that you want to set the field warehouse_id:
+- If you try to add a default sale team where the user do not belongs wil throw
+  you an error message: Can not set default team is do not belongs to sale team
+- Add an automated action/server action to update the user default sales team
+  every time that a sales teams by:
+
+    - add user's default sale team if empty.
+    - remove default sale team from user if not longer in sale team.
+    - dummy write to update m2m in users to make new feature for filtering
+      records.
+
+Currently this default warehouse feature applies for sale.order,
+stock.picking.type and stock.picking.
+
+Also add a new feature for Permissions and Security: Taking advantage of the
+default_warehouse field in the sales team model now we can filter the
+records (picking type and picking model) to only show those records that match
+with the user sale teams default_warehouse. To accomplish this I:
+
+- add new groups to manage the records access by user:
+
+  * Default Warehouse / Limited access to pickings (filtered by sale teams)
+  * Default Warehouse / Limited access to stock pickings (filtered by sale teams)
+  * Default Warehouse / Access to all picking types (filtered by sale teams)
+  * Default Warehouse / Access to all pickings (filtered by sale teams)
+
+- add new m2m field in the res.user model used in the new ir.rules.
+  this onw is showed as a readonly field (only informative) to know
+  the teams were the sale user belongs.
+- add new ir.rule records, one for each default warehouse group. This
+  one will let us to only show the records for the current user sale
+  teams default_warehouse or to do not take into account the sale teams
+  and show all the records to the user.
+
+To add more models use it simple do this:
+
+1. inherit the class that you want to set the field warehouse_id::
 
     class SomeClass(models.Model):
         _name = 'some.class'
@@ -19,9 +60,60 @@ To use it simple do this:
         warehouse_id = fields.Many2one('stock.warehouse', help='Warehouse were'
         'this object will belong to')
 
-2. Don't forget depends of this module adding it to the list into `__openerp__.py`
+2. Create two ir.rule to filter stock.picking and stock.picking.type taking
+into account the current user warehouses. When a user is part of warehouse
+teams will be able to access only the records related to that warehouses::
 
-The default value from this field will be the warehouse setted in the section 
+    <record id="rule_group_model" model="ir.rule">
+        <field name="name">Limited access to model (filtered by sales teams)</field>
+        <field name="model_id" search="[('model','=','model')]" model="ir.model"/>
+        <field name="groups" eval"[(6, 0, [ref('xml_id_group')])]/>
+        <field name="domain_force">[('warehouse_id', 'in', [team.default_warehouse.id for team in user.sale_team_ids if team.default_warehouse])]</field>
+    </record>
+    <record id="rule_group_model_2" model="ir.rule">
+        <field name="name">Access to all model</field>
+        <field name="model_id" search="[('model','=','model')]" model="ir.model"/>
+        <field name="groups" eval"[(6, 0, [ref('xml_id_group')])]/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
+3. Don't forget depends of this module adding it to the list into `__openerp__.py`
+
+The default value from this field will be the warehouse setted in the section
 If the user is not related to a sales team or not warehouse setted on the
 section the default warehouse will be set using the default behavior of the
 system which is assign the main warehouse.
+
+Bug Tracker
+===========
+
+Bugs are tracked on
+`GitHub Issues <https://github.com/Vauxoo/addons-vauxoo/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and
+welcomed feedback
+`here <https://github.com/Vauxoo/addons-vauxoo/issues/new?body=module:%20
+default_warehouse_from_sale_team
+%0Aversion:%20
+8.0.2.0.0
+%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_
+
+Credits
+=======
+
+**Contributors**
+
+* Nhomar Hernandez <nhomar@vauxoo.com> (Planner/Developer)
+* Katherine Zaoral <kathy@vauxoo.com> (Planner/Developer)
+
+Maintainer
+==========
+
+.. image:: https://s3.amazonaws.com/s3.vauxoo.com/description_logo.png
+   :alt: Vauxoo
+   :target: https://www.vauxoo.com
+   :width: 200
+
+This module is maintained by the Vauxoo.
+
+To contribute to this module, please visit https://www.vauxoo.com.

--- a/default_warehouse_from_sale_team/__openerp__.py
+++ b/default_warehouse_from_sale_team/__openerp__.py
@@ -9,16 +9,22 @@
     'website': "http://www.vauxoo.com",
     'license': 'AGPL-3',
     'category': '',
-    'version': '8.0.0.0.2',
+    'version': '8.0.2.0.0',
     'depends': [
         'sale_stock',
         'sales_team',
+        'base_action_rule',
     ],
     'test': [
     ],
     'data': [
         'views/sales_team_view.xml',
+        'views/res_users_view.xml',
         'security/ir.model.access.csv',
+        'security/res_groups.xml',
+        'security/ir_rule.xml',
+        'data/ir_actions_server.xml',
+        'data/base_action_rule.xml',
     ],
     'demo': [
     ],

--- a/default_warehouse_from_sale_team/data/base_action_rule.xml
+++ b/default_warehouse_from_sale_team/data/base_action_rule.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<openerp>
+        <data noupdate="1">
+
+            <record id="automated_action_update_users_sales_teams" model="base.action.rule">
+                <field name="name">Update users after create/update sales teams</field>
+                <field name="model_id" model="ir.model" search="[('model', '=', 'crm.case.section')]"/>
+                <field name="active">1</field>
+                <field name="sequence">5</field>
+                <field name="kind">on_create_or_write</field>
+                <field name="server_action_ids" eval="[(6, 0, [ref('default_warehouse_from_sale_team.server_action_update_users_sales_teams')])]"/>
+            </record>
+
+        </data>
+    </openerp>

--- a/default_warehouse_from_sale_team/data/ir_actions_server.xml
+++ b/default_warehouse_from_sale_team/data/ir_actions_server.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<openerp>
+        <data noupdate="1">
+
+            <record id="server_action_update_users_sales_teams" model="ir.actions.server">
+                <field name="name">Update users after create/update sales teams</field>
+                <field name="model_id" model="ir.model" search="[('model', '=', 'crm.case.section')]"/>
+                <field name="state">code</field>
+                <field name="code">obj.update_users_sales_teams()</field>
+            </record>
+
+        </data>
+</openerp>

--- a/default_warehouse_from_sale_team/i18n/default_warehouse_from_sale_team.pot
+++ b/default_warehouse_from_sale_team/i18n/default_warehouse_from_sale_team.pot
@@ -15,142 +15,142 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
+
 #. module: default_warehouse_from_sale_team
 #: model:res.groups,name:default_warehouse_from_sale_team.group_manager_default_warehouse_spt
 msgid "Access to all picking types"
-msgstr "Acceso a todos los tipos de albarán"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:res.groups,name:default_warehouse_from_sale_team.group_manager_default_warehouse_sp
 msgid "Access to all pickings"
-msgstr "Acceso a todos los albaranes"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: field:default.warehouse,create_uid:0
 msgid "Created by"
-msgstr "Creado por"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: field:default.warehouse,create_date:0
 msgid "Created on"
-msgstr "Creado en"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: field:crm.case.section,default_warehouse:0
 #: model:ir.module.category,name:default_warehouse_from_sale_team.default_warehouse_module
 msgid "Default Warehouse"
-msgstr "Almacén por defecto"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: field:default.warehouse,display_name:0
 msgid "Display Name"
-msgstr "Nombre para mostrar"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: field:default.warehouse,id:0
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: help:crm.case.section,default_warehouse:0
 msgid "In this field can be defined a default warehouse for the related users to the sales team."
-msgstr "En este campo se puede definir el almacén por defecto para los usuarios relacionados al equipo de ventas."
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: field:default.warehouse,__last_update:0
 msgid "Last Modified on"
-msgstr "Ultima Modificación en"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: field:default.warehouse,write_uid:0
 msgid "Last Updated by"
-msgstr "Última actualización por"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: field:default.warehouse,write_date:0
 msgid "Last Updated on"
-msgstr "Última actualización en"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:res.groups,name:default_warehouse_from_sale_team.group_limited_default_warehouse_sp
 msgid "Limited access to pickings (filtered by sale teams)"
-msgstr "Acceso limitado a los albaranes (filtrados por equipo de venta)"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:res.groups,name:default_warehouse_from_sale_team.group_limited_default_warehouse_spt
 msgid "Limited access to pickings types (filtered by sale teams)"
-msgstr "Acceso limitado a los tipos de albarán (filtrados por equipo de venta)"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:res.groups,comment:default_warehouse_from_sale_team.group_manager_default_warehouse_spt
 msgid "Not matter sales team will leave the user to see all the stock picking types"
-msgstr "No importa los equipos de ventas le permitirá al usuario ver todos los tipos de albarán"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:res.groups,comment:default_warehouse_from_sale_team.group_manager_default_warehouse_sp
 msgid "Not matter sales teams will leave the user to see all the stock pickings"
-msgstr "No importa los equipos de ventas le permitirá al usuario ver todos los albaranes"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_stock_picking
 msgid "Picking List"
-msgstr "Albarán"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de venta"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_crm_case_section
 msgid "Sales Teams"
-msgstr "Equipos de ventas"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_stock_picking_type
 msgid "The picking type determines the picking view"
-msgstr "El tipo de albarán determina la vista del albarán"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: help:res.users,sale_team_ids:0
 msgid "This is only an informative field. Go to Sales > Sales > Sales Teams to edit"
-msgstr "Este es un campo solamente informativo. Ve a Ventas > Ventas > Equipos de Ventas para editar"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:ir.actions.server,name:default_warehouse_from_sale_team.server_action_update_users_sales_teams
 msgid "Update users after create/update sales teams"
-msgstr "Actualiza los usuarios luego de crear/actualizar los equipos de ventas"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: field:res.users,sale_team_ids:0
 msgid "User's sales teams"
-msgstr "Equipos de ventas del usuario"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_res_users
 msgid "Users"
-msgstr "Usuarios"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:res.groups,comment:default_warehouse_from_sale_team.group_limited_default_warehouse_spt
 msgid "View only the stock picking types which warehouses match with the user sales teams default warehouses"
-msgstr "Ver solamente los tipos de albarán que corresponden con el almacén por defecto de los equipos de venta del usuario"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: model:res.groups,comment:default_warehouse_from_sale_team.group_limited_default_warehouse_sp
 msgid "View only the stock pickings which warehouses match with the user sales teams default warehouses"
-msgstr "Ver solamente los albaranes que corresponden con el almacén por defecto de los equipos de venta del usuario"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: field:stock.picking,warehouse_id:0
 msgid "Warehouse"
-msgstr "Almacén"
+msgstr ""
 
 #. module: default_warehouse_from_sale_team
 #: code:addons/default_warehouse_from_sale_team/models/res_users.py:30
 #, python-format
 msgid "You can not set %s sale team as default because the user do not belongs to the sale teams.\n"
 "Please go to Sales > Sales > Sales Teams menu if you will like to add this user to the sales team"
-msgstr "No puedes agregar a %s como el equipo de ventas por defecto porque el usuario no pertenece a dicho equipo de ventas.\n"
-"Por favor vaya al menú Ventas > Ventas > Equipos de Ventas si desea agregar el usuario al equipo de ventas"
+msgstr ""
 

--- a/default_warehouse_from_sale_team/models/__init__.py
+++ b/default_warehouse_from_sale_team/models/__init__.py
@@ -1,2 +1,5 @@
 # coding: utf-8
 from . import sales_team
+from . import res_users
+from . import sales
+from . import stock

--- a/default_warehouse_from_sale_team/models/res_users.py
+++ b/default_warehouse_from_sale_team/models/res_users.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+############################################################################
+
+from openerp import api, fields, models, _
+from openerp.exceptions import ValidationError
+
+
+class ResUsers(models.Model):
+
+    _inherit = "res.users"
+
+    sale_team_ids = fields.Many2many(
+        'crm.case.section', 'sale_member_rel', 'member_id', 'section_id',
+        string="User's sales teams",
+        help="This is only an informative field. Go to Sales > Sales >"
+        " Sales Teams to edit")
+
+    @api.constrains('default_section_id')
+    def _check_section_id(self):
+        """ Can only set the Default Sales team if the user is part o
+        """
+        if self.default_section_id and \
+           self.default_section_id not in self.sale_team_ids:
+            raise ValidationError(_(
+                'You can not set %s sale team as default because the user'
+                ' do not belongs to the sale teams.\nPlease go to Sales >'
+                ' Sales > Sales Teams menu if you will like to add this'
+                ' user to the sales team') % (self.default_section_id.name))

--- a/default_warehouse_from_sale_team/models/sales.py
+++ b/default_warehouse_from_sale_team/models/sales.py
@@ -1,0 +1,9 @@
+# coding: utf-8
+
+from openerp import models
+
+
+class SaleOrder(models.Model):
+
+    _name = "sale.order"
+    _inherit = ['sale.order', 'default.warehouse']

--- a/default_warehouse_from_sale_team/models/sales_team.py
+++ b/default_warehouse_from_sale_team/models/sales_team.py
@@ -13,6 +13,44 @@ class InheritedCrmSaseSection(models.Model):
                                         'defined a default warehouse for '
                                         'the related users to the sales team.')
 
+    @api.multi
+    def update_users_sales_teams(self):
+        """ This method will review the users every time a sale team is create
+        / write to:
+
+        - if add a member and this one has not default sale team then set the
+          current team as the new default sale team
+        - if remove a member of the sale team and this one has as default the
+          current sale team then will update the user to set default sale teams
+          to False
+        - if they are just added or remove from the sale team we need to make
+          a dummy write in order to update the user sales_team_wh_ids and this
+          way the filtering rule will works to show the records only related to
+          the real user current sale teams configured warehouses.
+        """
+        for team in self:
+
+            # Add default team to users without default
+            wo_default_team = team.member_ids.filtered(
+                lambda user: not user.default_section_id)
+            for user in wo_default_team:
+                user.write({'default_section_id': team.id})
+
+            # Remove default team for users that are not longer in the current
+            # team
+            default_current_team = self.env['res.users'].search(
+                [('default_section_id', '=', team.id)])
+            remove_default_team = default_current_team - team.member_ids
+            for user in remove_default_team:
+                user.write({'default_section_id': False})
+
+            # Dummy write to update the m2m user.sale_teams in order to be
+            # capable of rendering the ir.rules properly.
+            for member in team.member_ids:
+                member.write({})
+
+        return True
+
 
 class WarehouseDefault(models.Model):
     """If you inherit from this model and add a field called warehouse_id into
@@ -20,7 +58,6 @@ class WarehouseDefault(models.Model):
     setted into the sales team.
     """
 
-    _auto = False
     _name = "default.warehouse"
 
     @api.model
@@ -47,9 +84,3 @@ class WarehouseDefault(models.Model):
                 {name: warehouse_id for name in names_list
                  if defaults.get(name)})
         return defaults
-
-
-class SaleOrder(models.Model):
-
-    _name = "sale.order"
-    _inherit = ['sale.order', 'default.warehouse']

--- a/default_warehouse_from_sale_team/models/stock.py
+++ b/default_warehouse_from_sale_team/models/stock.py
@@ -1,0 +1,17 @@
+# coding: utf-8
+
+from openerp import fields, models
+
+
+class StockPickingType(models.Model):
+
+    _name = "stock.picking.type"
+    _inherit = ['stock.picking.type', 'default.warehouse']
+
+
+class StockPicking(models.Model):
+
+    _name = "stock.picking"
+    _inherit = ['stock.picking', 'default.warehouse']
+
+    warehouse_id = fields.Many2one(related='picking_type_id.warehouse_id')

--- a/default_warehouse_from_sale_team/security/ir_rule.xml
+++ b/default_warehouse_from_sale_team/security/ir_rule.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <openerp>
+        <data noupdate="0">
+
+            <!-- stock.picking.type -->
+            <record id="rule_default_warehouse_stock_picking_type_team" model="ir.rule">
+                <field name="name">Limited access to picking types (filtered by sale teams)</field>
+                <field name="model_id" search="[('model','=','stock.picking.type')]" model="ir.model"/>
+                <field name="domain_force">[('warehouse_id', 'in', [team.default_warehouse.id for team in user.sale_team_ids if team.default_warehouse])]</field>
+                <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_spt')])]"/>
+            </record>
+            <record id="rule_default_warehouse_stock_picking_type_all" model="ir.rule">
+                <field name="name">Access to all picking types</field>
+                <field name="model_id" search="[('model','=','stock.picking.type')]" model="ir.model"/>
+                <field name="domain_force">[(1, '=', 1)]</field>
+                <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_manager_default_warehouse_spt')])]"/>
+            </record>
+
+            <!-- stock.picking -->
+            <record id="rule_default_warehouse_stock_picking_team" model="ir.rule">
+                <field name="name">Limited access to pickings (filtered by sale teams)</field>
+                <field name="model_id" search="[('model','=','stock.picking')]" model="ir.model"/>
+                <field name="domain_force">[('warehouse_id', 'in', [team.default_warehouse.id for team in user.sale_team_ids if team.default_warehouse])]</field>
+                <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_sp')])]"/>
+            </record>
+            <record id="rule_default_warehouse_stock_picking_all" model="ir.rule">
+                <field name="name">Access to all pickings</field>
+                <field name="model_id" search="[('model','=','stock.picking')]" model="ir.model"/>
+                <field name="domain_force">[(1, '=', 1)]</field>
+                <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_manager_default_warehouse_sp')])]"/>
+            </record>
+
+        </data>
+    </openerp>

--- a/default_warehouse_from_sale_team/security/res_groups.xml
+++ b/default_warehouse_from_sale_team/security/res_groups.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <openerp>
+        <data noupdate="0">
+
+            <record id="default_warehouse_module" model="ir.module.category">
+                <field name="name">Default Warehouse</field>
+            </record>
+
+            <!-- stock picking type -->
+            <record id="group_limited_default_warehouse_spt" model="res.groups">
+                <field name="name">Limited access to pickings types (filtered by sale teams)</field>
+                <field name="comment">View only the stock picking types which warehouses match with the user sales teams default warehouses</field>
+                <field name="category_id" ref="default_warehouse_module"/>
+            </record>
+            <record id="group_manager_default_warehouse_spt" model="res.groups">
+                <field name="name">Access to all picking types</field>
+                <field name="comment">Not matter sales team will leave the user to see all the stock picking types</field>
+                <field name="category_id" ref="default_warehouse_module"/>
+            </record>
+
+            <!-- stock.picking -->
+            <record id="group_limited_default_warehouse_sp" model="res.groups">
+                <field name="name">Limited access to pickings (filtered by sale teams)</field>
+                <field name="comment">View only the stock pickings which warehouses match with the user sales teams default warehouses</field>
+                <field name="category_id" ref="default_warehouse_module"/>
+            </record>
+            <record id="group_manager_default_warehouse_sp" model="res.groups">
+                <field name="name">Access to all pickings</field>
+                <field name="comment">Not matter sales teams will leave the user to see all the stock pickings</field>
+                <field name="category_id" ref="default_warehouse_module"/>
+            </record>
+
+        </data>
+    </openerp>

--- a/default_warehouse_from_sale_team/static/description/index.html
+++ b/default_warehouse_from_sale_team/static/description/index.html
@@ -1,60 +1,259 @@
-<head>
+<html>
+ <head>
   <style>
-      .backgrounds{background-color:#fff;color:#a41d35}
+   .backgrounds{background-color:#fff;color:#a41d35}
   </style>
-</head>
-<section class="oe_container">
- <div class="oe_row oe_spaced">
-  <h2 class="oe_slogan">
-   Sale Team Warehouse
-  </h2>
-  <p class="oe_mt32">
-  Adding a field for the default user warehouse and
-  modifing the global default method for asign in any
-  realted field the correct default warehuse.
-
-  This module allows to set a default warehouse on the sales team of the user.
-
-  The default warehouse can be set on the field "Default Warehouse" of the sales team for the related user.
-
-  If the user is not related to a sales team, the default warehouse will be set using the default behavior of the system which is assign the main warehouse.
-  </p>
- </div>
-</section>
-<section class="oe_container">
-    <div class="oe_row oe_spaced">
-        <div class="oe_span6">
-            <h2 class="oe_slogan">Do you need help?</h2>
-            <h3 class="oe_slogan">
-                Let's offer you the best services!
-            </h3>
-            <p class="oe_mt32 text-center">
-                Contact us by our official channels.
-            </p>
-            <div class="oe_spaced">
-                <ul class="text-center list-inline">
-                    <li>
-                        <a href="https://facebook.com/vauxoo" Target="_blank"><i class="fa fa-facebook-square fa-xs backgrounds"></i></a>
-                    </li>
-                    <li>
-                        <a href="https://twitter.com/vauxoo" Target="_blank" ><i class="fa fa-twitter-square fa-xs backgrounds"></i></a>
-                    </li>
-                    <li>
-                        <a href="https://www.linkedin.com/company/vauxoo" Target="_blank"><i class="fa fa-linkedin-square fa-xs backgrounds"></i></a>
-                    </li>
-                    <li>
-                        <a title="Contact us" data-toggle="tooltip" data-placement="left" Target="_blank" href="https://www.vauxoo.com/page/website.contactus"><i class="fa fa-envelope-square fa-xs backgrounds"></i></a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-        <div class="oe_span6">
-            <div class="oe_demo oe_picture oe_screenshot">
-                <a href="https://www.vauxoo.com"  target="_blank"r>
-                    <img src="https://s3.amazonaws.com/s3.vauxoo.com/description_logo.png" width="200" height="auto">
-                </a>
-                <div class="oe_demo_footer oe_centeralign">Meet Us</div>
-            </div>
-        </div>
+ </head>
+ <body>
+  <section class="oe_container" id="description">
+   <object data="https://img.shields.io/badge/licence-AGPL--3-blue.svg" type="image/svg+xml">
+    License: AGPL-3
+   </object>
+   <div class="section oe_span12" id="sales-team-warehouse">
+    <h2 class="oe_slogan">
+     Sales Team Warehouse
+    </h2>
+    <div class="section oe_span12" id="usage">
+     <h2>
+      Usage
+     </h2>
+     <p class="oe_mt32">
+      Add a field
+      <cite>
+       default_warehouse
+      </cite>
+      in sales team.
+     </p>
+     <p class="oe_mt32">
+      Create sort kind of api where any object with field called warehouse_id will
+take the default value from the sales team field
+this taking into account the team defined in
+      <cite>
+       Default Sale Teams
+      </cite>
+      field defined
+in the res.user model.
+     </p>
+     <p class="oe_mt32">
+      To improve, consistency and usability we add the next features:
+     </p>
+     <ul>
+      <li>
+       <p class="oe_mt32">
+        If you try to add a default sale team where the user do not belongs wil throw
+you an error message: Can not set default team is do not belongs to sale team
+       </p>
+      </li>
+      <li>
+       <p class="oe_mt32">
+        Add an automated action/server action to update the user default sales team
+every time that a sales teams by:
+       </p>
+       <blockquote>
+        <ul class="simple">
+         <li>
+          add user's default sale team if empty.
+         </li>
+         <li>
+          remove default sale team from user if not longer in sale team.
+         </li>
+         <li>
+          dummy write to update m2m in users to make new feature for filtering
+records.
+         </li>
+        </ul>
+       </blockquote>
+      </li>
+     </ul>
+     <p class="oe_mt32">
+      Currently this default warehouse feature applies for sale.order,
+stock.picking.type and stock.picking.
+     </p>
+     <p class="oe_mt32">
+      Also add a new feature for Permissions and Security: Taking advantage of the
+default_warehouse field in the sales team model now we can filter the
+records (picking type and picking model) to only show those records that match
+with the user sale teams default_warehouse. To accomplish this I:
+     </p>
+     <ul class="simple">
+      <li>
+       add new groups to manage the records access by user:
+       <ul>
+        <li>
+         Default Warehouse / Limited access to pickings (filtered by sale teams)
+        </li>
+        <li>
+         Default Warehouse / Limited access to stock pickings (filtered by sale teams)
+        </li>
+        <li>
+         Default Warehouse / Access to all picking types (filtered by sale teams)
+        </li>
+        <li>
+         Default Warehouse / Access to all pickings (filtered by sale teams)
+        </li>
+       </ul>
+      </li>
+      <li>
+       add new m2m field in the res.user model used in the new ir.rules.
+this onw is showed as a readonly field (only informative) to know
+the teams were the sale user belongs.
+      </li>
+      <li>
+       add new ir.rule records, one for each default warehouse group. This
+one will let us to only show the records for the current user sale
+teams default_warehouse or to do not take into account the sale teams
+and show all the records to the user.
+      </li>
+     </ul>
+     <p class="oe_mt32">
+      To add more models use it simple do this:
+     </p>
+     <ol class="arabic">
+      <li>
+       <p class="oe_mt32">
+        inherit the class that you want to set the field warehouse_id:
+       </p>
+       <pre class="literal-block">
+class SomeClass(models.Model):
+    _name = 'some.class'
+    _inherit = ['some.class', 'default.warehouse']
+    warehouse_id = fields.Many2one('stock.warehouse', help='Warehouse were'
+    'this object will belong to')
+</pre>
+      </li>
+     </ol>
+     <p class="oe_mt32">
+      2. Create two ir.rule to filter stock.picking and stock.picking.type taking
+into account the current user warehouses. When a user is part of warehouse
+teams will be able to access only the records related to that warehouses:
+     </p>
+     <pre class="literal-block">
+&lt;record id="rule_group_model" model="ir.rule"&gt;
+    &lt;field name="name"&gt;Limited access to model (filtered by sales teams)&lt;/field&gt;
+    &lt;field name="model_id" search="[('model','=','model')]" model="ir.model"/&gt;
+    &lt;field name="groups" eval"[(6, 0, [ref('xml_id_group')])]/&gt;
+    &lt;field name="domain_force"&gt;[('warehouse_id', 'in', [team.default_warehouse.id for team in user.sale_team_ids if team.default_warehouse])]&lt;/field&gt;
+&lt;/record&gt;
+&lt;record id="rule_group_model_2" model="ir.rule"&gt;
+    &lt;field name="name"&gt;Access to all model&lt;/field&gt;
+    &lt;field name="model_id" search="[('model','=','model')]" model="ir.model"/&gt;
+    &lt;field name="groups" eval"[(6, 0, [ref('xml_id_group')])]/&gt;
+    &lt;field name="domain_force"&gt;[(1, '=', 1)]&lt;/field&gt;
+&lt;/record&gt;
+</pre>
+     <ol class="arabic simple" start="3">
+      <li>
+       Don't forget depends of this module adding it to the list into
+       <cite>
+        __openerp__.py
+       </cite>
+      </li>
+     </ol>
+     <p class="oe_mt32">
+      The default value from this field will be the warehouse setted in the section
+If the user is not related to a sales team or not warehouse setted on the
+section the default warehouse will be set using the default behavior of the
+system which is assign the main warehouse.
+     </p>
     </div>
-</section>
+    <div class="section oe_span12" id="bug-tracker">
+     <h2>
+      Bug Tracker
+     </h2>
+     <p class="oe_mt32">
+      Bugs are tracked on
+      <a class="reference external" href="https://github.com/Vauxoo/addons-vauxoo/issues">
+       GitHub Issues
+      </a>
+      .
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and
+welcomed feedback
+      <a class="reference external" href="https://github.com/Vauxoo/addons-vauxoo/issues/new?body=module:%20default_warehouse_from_sale_team%0Aversion:%208.0.2.0.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">
+       here
+      </a>
+     </p>
+    </div>
+    <div class="section oe_span12" id="credits">
+     <h2>
+      Credits
+     </h2>
+     <p class="oe_mt32">
+      <strong>
+       Contributors
+      </strong>
+     </p>
+     <ul class="simple">
+      <li>
+       Nhomar Hernandez &lt;
+       <a class="reference external" href="mailto:nhomar@vauxoo.com">
+        nhomar@vauxoo.com
+       </a>
+       &gt; (Planner/Developer)
+      </li>
+      <li>
+       Katherine Zaoral &lt;
+       <a class="reference external" href="mailto:kathy@vauxoo.com">
+        kathy@vauxoo.com
+       </a>
+       &gt; (Planner/Developer)
+      </li>
+     </ul>
+    </div>
+   </div>
+  </section>
+  <section class="oe_container">
+   <div class="oe_row oe_spaced">
+    <div class="oe_span6">
+     <h2 class="oe_slogan">
+      Do you need help?
+     </h2>
+     <h3 class="oe_slogan">
+      Let's offer you the best services!
+     </h3>
+     <p class="oe_mt32 text-center">
+      Contact us by our official channels.
+     </p>
+     <div class="oe_spaced">
+      <ul class="text-center list-inline">
+       <li>
+        <a href="https://facebook.com/vauxoo" target="_blank">
+         <i class="fa fa-facebook-square fa-xs backgrounds">
+         </i>
+        </a>
+       </li>
+       <li>
+        <a href="https://twitter.com/vauxoo" target="_blank">
+         <i class="fa fa-twitter-square fa-xs backgrounds">
+         </i>
+        </a>
+       </li>
+       <li>
+        <a href="https://www.linkedin.com/company/vauxoo" target="_blank">
+         <i class="fa fa-linkedin-square fa-xs backgrounds">
+         </i>
+        </a>
+       </li>
+       <li>
+        <a data-placement="left" data-toggle="tooltip" href="https://www.vauxoo.com/page/website.contactus" target="_blank" title="Contact us">
+         <i class="fa fa-envelope-square fa-xs backgrounds">
+         </i>
+        </a>
+       </li>
+      </ul>
+     </div>
+    </div>
+    <div class="oe_span6">
+     <div class="oe_demo oe_picture oe_screenshot">
+      <a href="https://www.vauxoo.com" r="" target="_blank">
+       <img height="auto" src="https://s3.amazonaws.com/s3.vauxoo.com/description_logo.png" width="200"/>
+      </a>
+      <div class="oe_demo_footer oe_centeralign">
+       Meet Us
+      </div>
+     </div>
+    </div>
+   </div>
+  </section>
+ </body>
+</html>

--- a/default_warehouse_from_sale_team/views/res_users_view.xml
+++ b/default_warehouse_from_sale_team/views/res_users_view.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<openerp>
+    <data>
+
+       <record id="res_users_sale_teams" model="ir.ui.view">
+            <field name="name">res.users.sale.teams</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="sales_team.res_user_form"/>
+            <field name="arch" type="xml">
+                <field name="default_section_id" position="after">
+                    <field name="sale_team_ids" widget="many2many_tags" readonly="1"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
- [x] currently module is not working, make it work with client's instance
- [x] add new logic to also filter the records related to warehouse taking into account the new sale_team.warehouse field.

This is related to issue Vauxoo/yoytec#1490 
Dummy PR in customer repo Vauxoo/yoytec#1767
