### PR TITLE
[FIX] Only accounting people is allowed to see Stock Accrual Button

### DIFF
--- a/account_anglo_saxon_stock_move_sale/view/sale_view.xml
+++ b/account_anglo_saxon_stock_move_sale/view/sale_view.xml
@@ -14,6 +14,7 @@
                         name="view_accrual"
                         class="oe_stat_button"
                         icon="fa-truck"
+                        groups="account.group_account_user"
                         />
                 </div>
             </xpath>


### PR DESCRIPTION
[FIX] Only accounting people is allowed to see Stock Accrual Button on Sale Order
