### PR TITLE
Missing ACL for Default Picking Type

### DIFF
--- a/default_warehouse_from_sale_team/security/ir.model.access.csv
+++ b/default_warehouse_from_sale_team/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_default_warehouse,default.warehouse,model_default_warehouse,,1,0,0,0
+access_default_picking_type,default.picking.type,model_default_picking_type,,1,0,0,0


### PR DESCRIPTION
module: `default_warehouse_from_sale_team`
version: `8.0`
Close Vauxoo/yoytec#1833

**Steps to reproduce**
1. Create a new odoo instance for a client that depends  `default_warehouse_from_sale_team`

**Current Behavior**

Our client instance that install `default_warehouse_from_sale_team` throw this error

```
WARNING openerp_test openerp.modules.loading: The model default.picking.type has no 
access rules, consider adding one. E.g. 
access_default_picking_type,access_default_picking_type,model_default_picking_type,,1,0,0,0
```

**Expected Behavior**

We need that the odoo instance log has not red or yellows.

> HINT: Only need to add ACL for the new model in order to remove the warning
