### PR TITLE
[IMP] default_warehouse_from_sale_team: propagate SUPERUSER_ID in read

### DIFF
--- a/default_warehouse_from_sale_team/models/sales_team.py
+++ b/default_warehouse_from_sale_team/models/sales_team.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from openerp import api, fields, models
-
+from openerp import SUPERUSER_ID
 
 class InheritedCrmSaseSection(models.Model):
 
@@ -89,7 +89,21 @@ class WarehouseDefault(models.Model):
                  if defaults.get(name)})
         return defaults
 
-    @api.multi
+    @api.v7
+    def read(self, cr, user, ids, fields=None, context=None,
+             load='_classic_read'):
+        """This method is overwrite because we need to propagate SUPERUSER_ID
+        when picking are chained in another warehouse without access to read"""
+        if self.pool.get('ir.model.access').check_groups(
+            cr, user, 'default_warehouse_from_sale_team.'
+                'group_limited_default_warehouse_sp'):
+            return super(WarehouseDefault, self).read(
+                cr, SUPERUSER_ID, ids, fields=fields, context=context,
+                load=load)
+        return super(WarehouseDefault, self).read(
+            cr, user, ids, fields=fields, context=context, load=load)
+
+    @api.v8
     def read(self, fields=None, load='_classic_read'):
         """This method is overwrite because we need to propagate SUPERUSER_ID
         when picking are chained in another warehouse without access to read"""

--- a/default_warehouse_from_sale_team/models/sales_team.py
+++ b/default_warehouse_from_sale_team/models/sales_team.py
@@ -94,12 +94,11 @@ class WarehouseDefault(models.Model):
              load='_classic_read'):
         """This method is overwrite because we need to propagate SUPERUSER_ID
         when picking are chained in another warehouse without access to read"""
-        if self.pool.get('ir.model.access').check_groups(
+        if self.pool.get('res.users').has_group(
             cr, user, 'default_warehouse_from_sale_team.'
                 'group_limited_default_warehouse_sp'):
-            return super(WarehouseDefault, self).read(
-                cr, SUPERUSER_ID, ids, fields=fields, context=context,
-                load=load)
+            # we need to change to SUPERUSER_ID to allow access to read
+            user = SUPERUSER_ID
         return super(WarehouseDefault, self).read(
             cr, user, ids, fields=fields, context=context, load=load)
 
@@ -107,8 +106,8 @@ class WarehouseDefault(models.Model):
     def read(self, fields=None, load='_classic_read'):
         """This method is overwrite because we need to propagate SUPERUSER_ID
         when picking are chained in another warehouse without access to read"""
-        if self.env['ir.model.access'].check_groups(
-            'default_warehouse_from_sale_team.'
-                'group_limited_default_warehouse_sp'):
-            return super(WarehouseDefault, self.sudo()).read(fields, load)
+        if self.env.user.has_group('default_warehouse_from_sale_team.'
+                                   'group_limited_default_warehouse_sp'):
+            # we need to change to SUPERUSER_ID to allow access to read
+            self = self.sudo()
         return super(WarehouseDefault, self).read(fields, load)

--- a/default_warehouse_from_sale_team/models/sales_team.py
+++ b/default_warehouse_from_sale_team/models/sales_team.py
@@ -84,3 +84,13 @@ class WarehouseDefault(models.Model):
                 {name: warehouse_id for name in names_list
                  if defaults.get(name)})
         return defaults
+
+    @api.multi
+    def read(self, fields=None, load='_classic_read'):
+        """This method is overwrite because we need to propagate SUPERUSER_ID
+        when picking are chained in another warehouse without access to read"""
+        if self.env['ir.model.access'].check_groups(
+            'default_warehouse_from_sale_team.'
+                'group_limited_default_warehouse_sp'):
+            return super(WarehouseDefault, self.sudo()).read(fields, load)
+        return super(WarehouseDefault, self).read(fields, load)

--- a/default_warehouse_from_sale_team/models/sales_team.py
+++ b/default_warehouse_from_sale_team/models/sales_team.py
@@ -86,7 +86,7 @@ class WarehouseDefault(models.Model):
         return defaults
 
     @api.multi
-    def read(self, fields=None, load='_classic_read'):
+    def ___read(self, fields=None, load='_classic_read'):
         """This method is overwrite because we need to propagate SUPERUSER_ID
         when picking are chained in another warehouse without access to read"""
         if self.env['ir.model.access'].check_groups(

--- a/default_warehouse_from_sale_team/security/ir_rule.xml
+++ b/default_warehouse_from_sale_team/security/ir_rule.xml
@@ -23,6 +23,13 @@
                 <field name="domain_force">[('warehouse_id', 'in', [team.default_warehouse.id for team in user.sale_team_ids if team.default_warehouse])]</field>
                 <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_sp')])]"/>
             </record>
+            <record id="rule_default_warehouse_stock_picking_team12" model="ir.rule">
+                <field name="name">Limited access to pickings (filtered by not in sale teams)</field>
+                <field name="model_id" search="[('model','=','stock.picking')]" model="ir.model"/>
+                <field name="perm_read" eval="False"/>
+                <field name="domain_force">[('warehouse_id', 'not in', [team.default_warehouse.id for team in user.sale_team_ids if team.default_warehouse])]</field>
+                <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_sp')])]"/>
+            </record>
             <record id="rule_default_warehouse_stock_picking_all" model="ir.rule">
                 <field name="name">Access to all pickings</field>
                 <field name="model_id" search="[('model','=','stock.picking')]" model="ir.model"/>


### PR DESCRIPTION
when user create from sale pickings chained in another warehouse without
access to read

e.g.
Warehouse A
Warehouse B
User A with access to Warehouse A
User B with access to Warehouse B
Route A with resupply Warehouse B → Warehouse A
Create sale order with **Route A** with **User A**

**Sale order created the pickings:**
- Warehouse B → Transito
- Transito → Warehouse A

**User A** must see only the picking **Transito → Warehouse A**
**User B** must see only the picking **Warehouse B → Transito**

When **User B** validated  **Warehouse B → Transito**  the picking **Transito → Warehouse A** must change to **ready to transfer** and if User A cancelled the picking  **Transito → Warehouse A** the picking **Warehouse B → Transito** must change to cancelled as well,
and then, **User A** and **User B** need the **write** and **read** in another warehouse but they can not see the records in web
