### PR TITLE
[FIX] addons-vauxoo: Warnings like boolean False instead of True and modules without po file

### DIFF
--- a/stock_landed_costs_average/demo/account_invoice_demo.xml
+++ b/stock_landed_costs_average/demo/account_invoice_demo.xml
@@ -12,7 +12,7 @@
             <field name="name">Average Product to Valuate with Landed Costs</field>
             <field name="cost_method">average</field>
             <field name="valuation">real_time</field>
-            <field name="landed_cost_ok">0</field>
+            <field name="landed_cost_ok" eval="False"/>
             <field name="type">product</field>
             <field name="weight">1</field>
             <field name="volume">1</field>
@@ -23,7 +23,7 @@
             <field name="name">Real Product to Valuate with Landed Costs</field>
             <field name="cost_method">real</field>
             <field name="valuation">real_time</field>
-            <field name="landed_cost_ok">0</field>
+            <field name="landed_cost_ok" eval="False"/>
             <field name="type">product</field>
             <field name="weight">1</field>
             <field name="volume">1</field>

--- a/stock_landed_costs_segmentation/demo/stock.xml
+++ b/stock_landed_costs_segmentation/demo/stock.xml
@@ -19,7 +19,7 @@
             <field name="name">VX Laptop Battery (std)</field>
             <field name="cost_method">standard</field>
             <field name="valuation">real_time</field>
-            <field name="landed_cost_ok">0</field>
+            <field name="landed_cost_ok" eval="False"/>
             <field name="standard_price">100</field>
             <field name="type">product</field>
             <field name="weight">1</field>
@@ -31,7 +31,7 @@
             <field name="name">VX Wireless Mouse (avg)</field>
             <field name="cost_method">average</field>
             <field name="valuation">real_time</field>
-            <field name="landed_cost_ok">0</field>
+            <field name="landed_cost_ok" eval="False"/>
             <field name="standard_price">100</field>
             <field name="type">product</field>
             <field name="weight">1</field>
@@ -43,7 +43,7 @@
             <field name="name">VX Keyboard (real)</field>
             <field name="cost_method">real</field>
             <field name="valuation">real_time</field>
-            <field name="landed_cost_ok">0</field>
+            <field name="landed_cost_ok" eval="False"/>
             <field name="standard_price">100</field>
             <field name="type">product</field>
             <field name="weight">1</field>

--- a/stock_unfuck/i18n/es.po
+++ b/stock_unfuck/i18n/es.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_unfuck
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-02 05:54+0000\n"
+"PO-Revision-Date: 2016-09-02 05:54+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/stock_unfuck/i18n/es_PA.po
+++ b/stock_unfuck/i18n/es_PA.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_unfuck
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-02 05:54+0000\n"
+"PO-Revision-Date: 2016-09-02 05:54+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/stock_unfuck/i18n/stock_unfuck.pot
+++ b/stock_unfuck/i18n/stock_unfuck.pot
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_unfuck
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-02 05:51+0000\n"
+"PO-Revision-Date: 2016-09-02 05:51+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_unfuck
+#: model:product.template,name:stock_unfuck.product_product_19_product_template
+msgid "Product to try the quants used"
+msgstr ""
+
+#. module: stock_unfuck
+#: model:ir.model,name:stock_unfuck.model_stock_quant
+msgid "Quants"
+msgstr ""
+


### PR DESCRIPTION
## [VX#5888](https://www.vauxoo.com/web#id=5888&view_type=form&model=project.task&action=138)

ToDo:
- [x] Fixes related to the issue  https://github.com/Vauxoo/yoytec/issues/1959
  - [x] Add missing translation in `stock_unfuck` module.
  - [x] Passing unexpected non boolean value 'False' (is string) in boolean field 'attachment_use'. You should use eval='False'.
