### PR TITLE
[ADD] stock_propagation_transfer: New module stock_propagation_transfer

### DIFF
--- a/stock_propagation_transfer/README.rst
+++ b/stock_propagation_transfer/README.rst
@@ -1,0 +1,28 @@
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+    :alt: License: LGPL-3
+
+==========================
+Stock Propagation Transfer
+==========================
+
+This module allows propagate transfer of stock move relateds.
+
+Credits
+=======
+
+**Contributors**
+
+* Julio Serna <julio@vauxoo.com> (Planner/Auditor)
+* Yennifer Santiago <yennifer@vauxoo.com (Developer)
+
+Maintainer
+==========
+
+.. image:: https://s3.amazonaws.com/s3.vauxoo.com/description_logo.png
+    :alt: Vauxoo
+    :target: https://www.vauxoo.com
+    :width: 200
+
+This module is maintained by Vauxoo.
+
+To contribute to this module, please visit https://www.vauxoo.com.

--- a/stock_propagation_transfer/__init__.py
+++ b/stock_propagation_transfer/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/stock_propagation_transfer/__openerp__.py
+++ b/stock_propagation_transfer/__openerp__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Yennifer Santiago <yennifer@vauxoo.com>
+#    planned by: Julio Serna <julio@vauxoo.com>
+############################################################################
+{
+    'name': "Stock Propagation Transfer",
+    'license': "LGPL-3",
+    'author': 'Vauxoo',
+    'website': 'http://www.vauxoo.com/',
+    'category': '',
+    'version': '8.0.0.1.0',
+
+    # any module necessary for this one to work correctly
+    'depends': [
+        'stock',
+    ],
+
+    # always loaded
+    'data': [
+        'views/procurement_rule_view.xml',
+    ],
+    # only loaded in demonstration mode
+    'demo': [
+    ],
+    'installable': True,
+}

--- a/stock_propagation_transfer/models/__init__.py
+++ b/stock_propagation_transfer/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import procurement_rule
+from . import stock

--- a/stock_propagation_transfer/models/procurement_rule.py
+++ b/stock_propagation_transfer/models/procurement_rule.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from openerp import fields, models
+
+
+class ProcurementRule(models.Model):
+
+    _inherit = "procurement.rule"
+
+    propagate_transfer = fields.Boolean(
+        string="Propagate transfer",
+        help="When this field is check, the first stock move which is"
+        " transferred triggers automatically the transfer to the other"
+        " stock move related")

--- a/stock_propagation_transfer/models/stock.py
+++ b/stock_propagation_transfer/models/stock.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from openerp import api, models
+
+
+class StockMove(models.Model):
+
+    _inherit = "stock.move"
+
+    @api.multi
+    def action_done(self):
+        """Inherit action_done to verify if it have to propagate transfer to
+        move_dest_id.
+        """
+        res = super(StockMove, self).action_done()
+        if self.move_dest_id and self.move_dest_id.rule_id.propagate_transfer:
+            picking = self.move_dest_id.picking_id
+            ctx = {
+                'active_id': picking.id,
+                'active_ids': [picking.id],
+                'active_model': 'stock.picking',
+            }
+            wizard_transfer_id = self.env['stock.transfer_details'].\
+                with_context(ctx).create({'picking_id': picking.id})
+            wizard_transfer_id.do_detailed_transfer()
+        return res

--- a/stock_propagation_transfer/views/procurement_rule_view.xml
+++ b/stock_propagation_transfer/views/procurement_rule_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_procurement_rule_stock_propagate_transfer_inherit" model="ir.ui.view">
+            <field name="name">procurement.rule.stock.propagate.transfer.inherit</field>
+            <field name="model">procurement.rule</field>
+            <field name="inherit_id" ref="procurement.view_procurement_rule_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='group_id']" position="after">
+                    <field name="propagate_transfer"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
This module has the following features:
- Adds a boolean field propagate_transfer to model procurement_rule that indicates whether the related stock_move needs to be transferred by propagation.
- Inherit the method action_done of stock_move to verify field propagate_transfer of register move_dest_id and depending on its value also transfer the stock_move referred by that register move_dest_id.

Close [Vauxoo/typ#30](https://github.com/Vauxoo/typ/pull/30)
