### PR TITLE
[FIX] When Creating records values are not yet written in records only on dict

### DIFF
--- a/stock_quant_cost_segmentation/model/stock.py
+++ b/stock_quant_cost_segmentation/model/stock.py
@@ -111,9 +111,9 @@ class StockQuant(models.Model):
 
     @api.model
     def create(self, vals):
-        segmentation_cost = sum([
-            getattr(self, field_name) for field_name in SEGMENTATION_COST])
-        vals.update({'segmentation_cost': segmentation_cost})
+        vals.update(
+            {'segmentation_cost': sum(
+                [vals.get(field_name, 0) for field_name in SEGMENTATION_COST])})
         return super(StockQuant, self).create(vals)
 
     @api.multi


### PR DESCRIPTION
So fetching the segmentation origin values can not be possible at early stages.

<img width="790" alt="current_stock" src="https://cloud.githubusercontent.com/assets/7598010/18295491/e45e75da-746f-11e6-995a-a23ac4e0d655.png">
