### PR TITLE
[FIX] stock_quant_cost_segmentation: Fix sum Null value

### DIFF
--- a/stock_quant_cost_segmentation/model/stock.py
+++ b/stock_quant_cost_segmentation/model/stock.py
@@ -113,7 +113,8 @@ class StockQuant(models.Model):
     def create(self, vals):
         vals.update(
             {'segmentation_cost': sum(
-                [vals.get(field_name, 0) for field_name in SEGMENTATION_COST])})
+                [vals.get(field_name) or 0
+                 for field_name in SEGMENTATION_COST])})
         return super(StockQuant, self).create(vals)
 
     @api.multi


### PR DESCRIPTION
<img width="995" alt="screen shot 2016-09-06 at 9 33 35 pm" src="https://cloud.githubusercontent.com/assets/6644187/18297850/9a3aaa1e-7479-11e6-9954-680bfc32c41f.png">

Executed in last green of runbot with this branch:

<img width="1277" alt="screen shot 2016-09-06 at 9 44 09 pm" src="https://cloud.githubusercontent.com/assets/6644187/18298030/1653ddd6-747b-11e6-9c34-4e0892e612df.png">

Fix https://github.com/Vauxoo/yoytec/issues/1982
