### PR TITLE
[REF] stock_unfuck: weight_uom_id violates not null constraint.

### DIFF
--- a/stock_unfuck/__openerp__.py
+++ b/stock_unfuck/__openerp__.py
@@ -30,6 +30,7 @@
     "license": "",
     "depends": [
         "stock",
+        "delivery",
     ],
     "demo": [
         'demo/product_demo.xml',


### PR DESCRIPTION
This case is similar to the yoytec's commit
7e7d02ef897a3b7e8a90dfcf5193a4a753c3c78d

Following the relations of the models, stock.quant has a
relation with stock.move, then stock.move is related to
stock.picking and then the delivery module inherits
stock.picking and adds the required field: "weight_uom_id".

But odoo#8.0 have don't detect this field using:
self._columns['weight_uom_id'] the only way to detect it
is adding the dependency to delivery directly.

To reproduce the error your can revert this change and start
the server in isolated mode:
odoo.py -d bd -i stock_unfuck
and then:
odoo.py -d bd -u yoytec_mrp --test-enable
In this second time fails with:
ntegrityError: null value in column "weight_uom_id" violates not-null
constraint

**PR dummy:**
- [x] yoytec: https://github.com/Vauxoo/yoytec/pull/1995
