### PR TITLE
[REF] product_available_by_warehouse: remove domain route in show message

### DIFF
--- a/product_available_by_warehouse/models/product.py
+++ b/product_available_by_warehouse/models/product.py
@@ -24,7 +24,7 @@ class ProductProduct(models.Model):
             virtual_available = []
             incoming_qty = []
             outgoing_qty = []
-            for warehouse in self.env['stock.warehouse'].search([]):
+            for warehouse in self.env['stock.warehouse'].sudo().search([]):
                 ctx.update({'warehouse': warehouse.id, 'location': False})
                 product_qty = product.with_context(ctx).\
                     _product_available()[product.id]

--- a/product_available_by_warehouse/models/sale.py
+++ b/product_available_by_warehouse/models/sale.py
@@ -45,9 +45,11 @@ class SaleOrderLine(models.Model):
             product_qty_by_wh = product.\
                 get_product_available_by_warehouse()[product.id][colname]
         for warehouse, product_qty in product_qty_by_wh:
-            if product_qty > 0.0 and \
-                    colname in ['qty_available', 'virtual_available']:
-                route_ids += [warehouse.delivery_route_id.id]
+            # TODO: uncomment until figure out a better way to choice only
+            # the routes with availability
+            # if product_qty > 0.0 and \
+            #         colname in ['qty_available', 'virtual_available']:
+            #     route_ids += [warehouse.delivery_route_id.id]
             warning_msgs += _("- %s . Quantity: %.2f \n" %
                               (warehouse.name, product_qty))
         res = {}
@@ -91,6 +93,6 @@ class SaleOrderLine(models.Model):
             # update domain
             if 'domain' in result:
                 domain = res.get('domain', {})
-                domain['route_id'] = result['domain'].get('route_ids', [])
+                domain['route_id'] = result['domain'].get('route_id', [])
                 res.update({'domain': domain})
         return res

--- a/product_available_by_warehouse/views/sale_view.xml
+++ b/product_available_by_warehouse/views/sale_view.xml
@@ -7,7 +7,7 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale_stock.view_order_form_inherit" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='order_line']/form//field[@name='product_id']" position="before">
+            <xpath expr="//field[@name='order_line']/form//field[@name='product_id']" position="after">
                 <field name="show_message" attrs="{'invisible': [('state','not in',('draft'))]}"
                     on_change="onchange_show_message(show_message, product_id)"/>
             </xpath>


### PR DESCRIPTION
## Summary

When it was used 'show message' field to see product available the domain route should consider only the routes that are available for sale order line.

To solve #1054 
## TODO
- [x] avoid route_ids domain in 'show message' onchange.
- [x] use sudo in warehouse search to show always the same info no matter what permission has the user.
- [x] swap positions between show_message field and product_id field
