### PR TITLE
[REF] sale_order_due_date: Use another demo sale order

### DIFF
--- a/sale_order_due_date/models/sale_order.py
+++ b/sale_order_due_date/models/sale_order.py
@@ -7,8 +7,8 @@
 #    info Vauxoo (info@vauxoo.com)
 #    coded by: Luis Torres <luis_t@vauxoo.com>
 ############################################################################
-from openerp import models, fields, api
 from datetime import date, timedelta
+from openerp import models, fields, api
 
 
 class SaleOrder(models.Model):

--- a/sale_order_due_date/tests/test_sale_due_date.py
+++ b/sale_order_due_date/tests/test_sale_due_date.py
@@ -7,8 +7,8 @@
 #    info Vauxoo (info@vauxoo.com)
 #    coded by: Luis Torres <luis_t@vauxoo.com>
 ############################################################################
-from openerp.tests import common
 from datetime import date, timedelta, datetime
+from openerp.tests import common
 
 
 class TestSaleDueDate(common.TransactionCase):
@@ -34,13 +34,13 @@ class TestSaleDueDate(common.TransactionCase):
         })
 
     def test_update_days(self):
-        'Test update the value in ir.config_parameter, to 5 days'
+        """Test update the value in ir.config_parameter, to 5 days"""
         self.env['sale.config.settings'].create({
             'days_due_date_sale': 5}).execute()
         self.assertEquals(5, int(self.conf.value), 'The value was not updated')
 
     def test_check_due_date_by_default(self):
-        'Test to check that date due is fill by default and is correct'
+        """Test to check that date due is fill by default and is correct"""
         self.test_update_days()
         sale = self.sale.copy()
         self.assertEquals(

--- a/sale_order_due_date/tests/test_sale_due_date.py
+++ b/sale_order_due_date/tests/test_sale_due_date.py
@@ -16,7 +16,22 @@ class TestSaleDueDate(common.TransactionCase):
     def setUp(self):
         super(TestSaleDueDate, self).setUp()
         self.conf = self.env.ref('sale_order_due_date.days_due_date')
-        self.sale = self.env.ref('sale.sale_order_4')
+        self.sale_obj = self.env['sale.order']
+        self.sale = self.sale_obj.create({
+            'partner_id': self.ref('base.res_partner_15'),
+            'partner_invoice_id': self.ref('base.res_partner_address_25'),
+            'partner_shipping_id': self.ref('base.res_partner_address_25'),
+            'user_id': self.ref('base.user_root'),
+            'section_id': self.ref('sales_team.section_sales_department'),
+            'pricelist_id': self.ref('product.list0'),
+            'order_line': [(0, 0, {
+                'product_id': self.ref('product.product_product_consultant'),
+                'product_uom_qty': 16.0,
+                'product_uos_qty': 16.0,
+                'price_unit': 75.0,
+                'product_uom': self.ref('product.product_uom_hour'),
+            })],
+        })
 
     def test_update_days(self):
         'Test update the value in ir.config_parameter, to 5 days'


### PR DESCRIPTION
This is to avoid the following error when this module is
installed in isolated way and then is use
-u sale_order_due_date --test-enable

2016-09-09 03:17:32,999 9358 ERROR openerp_test_sale_order_due_date
openerp.addons.sale_order_due_date.tests.test_sale_due_date: `
ValueError: Wrong value for sale.order.order_policy: u'prepaid'`

**PR dumy:** https://github.com/Vauxoo/yoytec/pull/2004

**Log error:** http://runbot.vauxoo.com/runbot/static/build/17488-1880-34756f/logs/job_20_test_all.txt
