### PR TITLE
[IMP] Print stock_card at logger

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas >= 0.16.2
 cssutils >= 1.0.1
 xlrd == 1.0.0
+tabulate == 0.7.5

--- a/stock_card/__openerp__.py
+++ b/stock_card/__openerp__.py
@@ -17,9 +17,17 @@
         'demo/demo.xml',
     ],
     "data": [
+        'security/ir.model.access.csv',
         'view/view.xml',
         'view/wizard.xml',
     ],
     "installable": True,
     "auto_install": False,
+    'external_dependencies': {
+        'bin': [],
+        'python': [
+            'tabulate',
+            'pandas',
+        ],
+    }
 }

--- a/stock_card/i18n/es.po
+++ b/stock_card/i18n/es.po
@@ -140,7 +140,7 @@ msgstr "Movimientos de Inventario"
 #. module: stock_card
 #: model:product.template,name:stock_card.product01_product_template
 msgid "Targus Laptop 16\" Bag"
-msgstr "Bolso Targus Laptop 16''"
+msgstr "Bolso Targus Laptop 16\""
 
 #. module: stock_card
 #: field:stock.card.move,cost_unit:0

--- a/stock_card/i18n/es_MX.po
+++ b/stock_card/i18n/es_MX.po
@@ -140,7 +140,7 @@ msgstr "Movimientos de Inventario"
 #. module: stock_card
 #: model:product.template,name:stock_card.product01_product_template
 msgid "Targus Laptop 16\" Bag"
-msgstr "Bolso Targus Laptop 16''"
+msgstr "Bolso Targus Laptop 16\""
 
 #. module: stock_card
 #: field:stock.card.move,cost_unit:0

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+from __future__ import division
 from openerp import models, fields, api, _
 import openerp.addons.decimal_precision as dp
 from openerp.exceptions import Warning as UserError

--- a/stock_card/tests/test_stock_card_negative_stock.py
+++ b/stock_card/tests/test_stock_card_negative_stock.py
@@ -27,6 +27,15 @@ from openerp.tests.common import TransactionCase
 
 _logger = logging.getLogger(__name__)
 
+try:
+  import pandas
+except ImportError:
+  _logger.debug('Cannot `import pandas`.')
+
+try:
+  import tabulate
+except ImportError:
+  _logger.debug('Cannot `import tabulate`.')
 
 class TestStockCardNegativeStock(TransactionCase):
 

--- a/stock_card/tests/test_stock_card_negative_stock.py
+++ b/stock_card/tests/test_stock_card_negative_stock.py
@@ -18,24 +18,21 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-import logging
 from datetime import datetime, timedelta
-from tabulate import tabulate
-import pandas as pd
-
+import logging
 from openerp.tests.common import TransactionCase
-
 _logger = logging.getLogger(__name__)
 
 try:
-  import pandas
+    import pandas as pd
 except ImportError:
-  _logger.debug('Cannot `import pandas`.')
+    _logger.debug('Cannot `import pandas`.')
 
 try:
-  import tabulate
+    from tabulate import tabulate
 except ImportError:
-  _logger.debug('Cannot `import tabulate`.')
+    _logger.debug('Cannot `import tabulate`.')
+
 
 class TestStockCardNegativeStock(TransactionCase):
 

--- a/stock_card/tests/test_stock_card_negative_stock.py
+++ b/stock_card/tests/test_stock_card_negative_stock.py
@@ -18,8 +18,14 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
+import logging
+from tabulate import tabulate
+import pandas as pd
+
 from openerp.tests.common import TransactionCase
 from datetime import datetime, timedelta
+
+_logger = logging.getLogger(__name__)
 
 
 class TestStockCardNegativeStock(TransactionCase):
@@ -177,6 +183,15 @@ class TestStockCardNegativeStock(TransactionCase):
                 self.create_sale_order(qty=qty, price=costprice)
 
         card_lines = self.get_stock_valuations()
+
+        df = pd.DataFrame(card_lines)
+        tbl_sc = tabulate(df, headers='keys', tablefmt='psql')
+        _logger.info('Gotten Stock Card \n%s', tbl_sc)
+
+        df = pd.DataFrame(self.inv_ids)
+        tbl_sc = tabulate(df, headers='keys', tablefmt='psql')
+        _logger.info('Expected Stock Card \n%s', tbl_sc)
+
         self.assertEqual(len(self.inv_ids), len(card_lines),
                          "Both lists should have the same length(=12)")
         for expected, succeded in zip(self.inv_ids, card_lines):

--- a/stock_card/tests/test_stock_card_negative_stock.py
+++ b/stock_card/tests/test_stock_card_negative_stock.py
@@ -19,11 +19,11 @@
 #
 ##############################################################################
 import logging
+from datetime import datetime, timedelta
 from tabulate import tabulate
 import pandas as pd
 
 from openerp.tests.common import TransactionCase
-from datetime import datetime, timedelta
 
 _logger = logging.getLogger(__name__)
 

--- a/stock_card/tests/test_stock_card_product_returns.py
+++ b/stock_card/tests/test_stock_card_product_returns.py
@@ -18,9 +18,9 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
+from datetime import datetime, timedelta
 from openerp.tests.common import TransactionCase
 from openerp.tools.float_utils import float_compare
-from datetime import datetime, timedelta
 
 
 class TestStockCardProductReturns(TransactionCase):


### PR DESCRIPTION
[IMP] Print stock_card at logger in order to debug later when failing and find cause of random failures of tests

<img width="1354" alt="2_ _docker_exec_-it_yoytec-8_0_script_-q_-c_term_xterm_tmux_-s_yoytec-8_0_new_-s_yoytec-8_0_term_xterm_tmux_-s_yoytec-8_0_attach_-d_-t_yoytec-8_0__bin_bash__dev_null_ _168x48" src="https://cloud.githubusercontent.com/assets/7598010/18941622/b46d00e4-85e0-11e6-913a-9ecb7f84ec85.png">
