### PR TITLE
[ADD] add missing dependency cython, this is required to properly install pandas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cython >= 0.24.1
 pandas >= 0.16.2
 cssutils >= 1.0.1
 xlrd == 1.0.0


### PR DESCRIPTION
Currently we have an error in travis builds 1 and 2 related to the unit tests of the server. An error when preparing the environment occurs:

``` bash
    ImportError: Building pandas requires cython
```

Detailed last addons-vauxoo travis build [here](https://travis-ci.com/Vauxoo/yoytec/builds/32571565)
