### PR TITLE
[FIX] Segmention on Average Products and Material Cost when Segmentation is filled

### DIFF
--- a/product_extended_segmentation/data/data.xml
+++ b/product_extended_segmentation/data/data.xml
@@ -22,5 +22,26 @@ self.update_material_cost_on_zero_segmentation(cr, uid, [])
             </field>
         </record>
 
+        <record model="ir.actions.server" id="update_product_segmentation_from_stock_card">
+            <field name="name">Update Segmentation on Average Product from Stock Card</field>
+            <field name="model_id" eval="ref('product.model_product_product')"/>
+            <field name="state">code</field>
+            <field name="condition"></field>
+            <field name="sequence">5</field>
+            <field name="code">
+# Available locals:
+#  - time, datetime, dateutil: Python libraries
+#  - env: Odoo Environement
+#  - model: Model of the record on which the action is triggered
+#  - object: Record on which the action is triggered if there is one, otherwise None
+#  - workflow: Workflow engine
+#  - Warning: Warning Exception to use with raise
+# To return an action, assign: action = {...}
+
+scp_obj = env['stock.card.product']
+scp_obj._update_product_segmentation_from_stock_card()
+            </field>
+        </record>
+
     </data>
 </openerp>

--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -395,6 +395,7 @@ class ProductTemplate(models.Model):
             new_price)
         return res
 
+
 class StockCardProduct(models.TransientModel):
     _inherit = 'stock.card.product'
 
@@ -436,7 +437,6 @@ class StockCardProduct(models.TransientModel):
             except OperationalError:
                 # /!\ NOTE: logging the product with the error
                 product_brw._cr.rollback()
-		_logger.info(
+                _logger.info(
                     'Update failed at Product: [%s]', str(product_brw.id))
         return True
-

--- a/product_extended_segmentation/model/template.py
+++ b/product_extended_segmentation/model/template.py
@@ -22,6 +22,7 @@
 from __future__ import division
 
 import logging
+from psycopg2 import OperationalError
 from openerp import api, models
 from openerp.addons.product import _common
 from openerp.tools import float_is_zero
@@ -393,3 +394,49 @@ class ProductTemplate(models.Model):
         res = super(ProductTemplate, self).do_change_standard_price(
             new_price)
         return res
+
+class StockCardProduct(models.TransientModel):
+    _inherit = 'stock.card.product'
+
+    def _update_product_segmentation_from_stock_card(self):
+        _logger.info('Update Segmentation on Average Product from Stock Card')
+        msglog = 'Computing segmentation fields for product: [%s]. %s/%s'
+
+        product_obj = self.env['product.product']
+        count = 0
+
+        product_brws = product_obj.search([('cost_method', '=', 'average')])
+        total = len(product_brws)
+        _logger.info('Cron Job will compute %s products', total)
+
+        for product_brw in product_brws:
+
+            count += 1
+            _logger.info(msglog, str(product_brw.id), str(total), str(count))
+
+            vals = self._stock_card_move_get(product_brw.id)
+            avg_fn = self.get_average(vals)
+            vals.clear()
+
+            if not any(avg_fn):
+                continue
+
+            vals2wrt = {}
+            for key, val in avg_fn.iteritems():
+                if key == 'average':
+                    continue
+                vals2wrt['%s_cost' % key] = val
+            avg_fn.clear()
+
+            product_brw.write(vals2wrt)
+            vals2wrt.clear()
+
+            try:
+                product_brw._cr.commit()
+            except OperationalError:
+                # /!\ NOTE: logging the product with the error
+                product_brw._cr.rollback()
+		_logger.info(
+                    'Update failed at Product: [%s]', str(product_brw.id))
+        return True
+

--- a/stock_quant_cost_segmentation/__init__.py
+++ b/stock_quant_cost_segmentation/__init__.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
 from . import model
-from . import wizard
 from . import report
 from . hooks import post_init_hook

--- a/stock_quant_cost_segmentation/__openerp__.py
+++ b/stock_quant_cost_segmentation/__openerp__.py
@@ -21,6 +21,7 @@
     "data": [
         'view/view.xml',
         'data/data.xml',
+        'security/ir.model.access.csv',
     ],
     "installable": True,
     "auto_install": False,

--- a/stock_quant_cost_segmentation/model/stock.py
+++ b/stock_quant_cost_segmentation/model/stock.py
@@ -1,12 +1,14 @@
 # coding: utf-8
 
+from __future__ import division
+from datetime import datetime
+import logging
+
 from openerp import models, fields, api
 from openerp import SUPERUSER_ID
 from openerp.tools.float_utils import float_compare, float_round, float_is_zero
 from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT
-from datetime import datetime
 import openerp.addons.decimal_precision as dp
-import logging
 
 _logger = logging.getLogger(__name__)
 
@@ -31,7 +33,7 @@ class StockMove(models.Model):
         return res
 
     @api.v8  # pylint: disable=W0404
-    def action_done(self):
+    def action_done(self):  # pylint: disable=E0102
         return StockMove.action_done(self._model, self._cr, self._uid,
                                      self._ids, context=self._context)
 
@@ -108,6 +110,25 @@ class StockMove(models.Model):
 
 class StockQuant(models.Model):
     _inherit = "stock.quant"
+    _sql_query_quants_not_fix = '''
+        SELECT
+        COUNT(sq.id)
+        FROM stock_quant AS sq
+        INNER JOIN product_product AS pp ON sq.product_id = pp.id
+        INNER JOIN product_template AS pt ON pt.id = pp.product_tmpl_id
+        INNER JOIN ir_property AS ip1 ON (
+        ip1.res_id = 'product.template,' || pt.id::text
+        AND ip1.name = 'cost_method')
+        LEFT JOIN ir_property AS ip2 ON (
+        ip2.res_id = 'product.template,' || pt.id::text
+        AND ip2.name = 'standard_price')
+        WHERE
+        sq.material_cost = 0
+        AND sq.landed_cost = 0
+        AND sq.production_cost = 0
+        AND sq.subcontracting_cost = 0
+        -- AND ip1.value_text = 'standard'  -- APPLY ONLY ON STANDARD
+        ;'''
 
     @api.model
     def create(self, vals):
@@ -246,25 +267,7 @@ class StockQuant(models.Model):
             ;''')
         _logger.info('Segmentation Cost has been updated')
 
-        self._cr.execute('''
-            SELECT
-            COUNT(sq.id)
-            FROM stock_quant AS sq
-            INNER JOIN product_product AS pp ON sq.product_id = pp.id
-            INNER JOIN product_template AS pt ON pt.id = pp.product_tmpl_id
-            INNER JOIN ir_property AS ip1 ON (
-            ip1.res_id = 'product.template,' || pt.id::text
-            AND ip1.name = 'cost_method')
-            LEFT JOIN ir_property AS ip2 ON (
-            ip2.res_id = 'product.template,' || pt.id::text
-            AND ip2.name = 'standard_price')
-            WHERE
-            sq.material_cost = 0
-            AND sq.landed_cost = 0
-            AND sq.production_cost = 0
-            AND sq.subcontracting_cost = 0
-            -- AND ip1.value_text = 'standard'  -- APPLY ONLY ON STANDARD
-            ;''')
+        self._cr.execute(self._sql_query_quants_not_fix)
         res = self._cr.fetchone()
         _logger.info('%s quants not fixed', str(int(res[0])))
 

--- a/stock_quant_cost_segmentation/model/stock.py
+++ b/stock_quant_cost_segmentation/model/stock.py
@@ -218,6 +218,20 @@ class StockQuant(models.Model):
             ;''')
         _logger.info('Material Cost equal to Cost on Quant has been set')
 
+        _logger.info('Setting Material Cost = to Cost - Segmentation on Quant')
+        self._cr.execute('''
+            UPDATE stock_quant
+            SET material_cost = cost - (
+                landed_cost + production_cost + subcontracting_cost)
+            WHERE
+                cost != 0
+                AND material_cost = 0
+                AND (landed_cost + production_cost + subcontracting_cost) != 0
+                AND cost > (
+                    landed_cost + production_cost + subcontracting_cost)
+            ;''')
+        _logger.info('Material = Cost - Segmentation on Quant has been set')
+
         _logger.info('Updating Segmentation Cost with sum of Segmentation')
         self._cr.execute('''
             UPDATE stock_quant

--- a/stock_quant_cost_segmentation/tests/test_stock_quant_cost_segmentation.py
+++ b/stock_quant_cost_segmentation/tests/test_stock_quant_cost_segmentation.py
@@ -63,23 +63,7 @@ class TestsStockQuantCostSegmentation(TestStockCommon):
 
     def test_04_quants_segmentation_initialization(self):
         self.quant.initializing_quant_segmentation()
-        self.cr.execute('''
-            SELECT
-            COUNT(sq.id)
-            FROM stock_quant AS sq
-            INNER JOIN product_product AS pp ON sq.product_id = pp.id
-            INNER JOIN product_template AS pt ON pt.id = pp.product_tmpl_id
-            INNER JOIN ir_property AS ip1 ON (
-            ip1.res_id = 'product.template,' || pt.id::text
-            AND ip1.name = 'cost_method')
-            LEFT JOIN ir_property AS ip2 ON (
-            ip2.res_id = 'product.template,' || pt.id::text
-            AND ip2.name = 'standard_price')
-            WHERE
-            sq.material_cost = 0
-            AND sq.landed_cost = 0
-            AND sq.production_cost = 0
-            AND sq.subcontracting_cost = 0;''')
+        self.cr.execute(self.quant._sql_query_quants_not_fix)
         res = self.cr.fetchone()
         quants_qty = int(res[0])
         self.assertEquals(quants_qty, 0, "Quant haven't fixed")

--- a/stock_quant_cost_segmentation/wizard/__init__.py
+++ b/stock_quant_cost_segmentation/wizard/__init__.py
@@ -1,1 +1,0 @@
-# coding: utf-8


### PR DESCRIPTION
- Server action for updating segmentation fields properly in AVG products in order to fetch right values in STD products when updating with Product Extended Segmentation.
- Initialization script for quants when material cost is zero but other segmentation fields sum is not zero and cost in quant isn't zero either, retrieve material cost from those values.
