### PR TITLE
[FIX] Freezing `pandas` version at 0.18.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas >= 0.16.2
+pandas == 0.18.0
 cssutils >= 1.0.1
 xlrd == 1.0.0
 tabulate == 0.7.5


### PR DESCRIPTION
[FIX] Greater versions of `pandas` > 0.18.0 will make code on
commission_payment module to fail with:

```
ValueError: The truth value of a Int64Index is ambiguous. Use
a.empty, a.bool(), a.item(), a.any() or a.all().
```
