### PR TITLE
[ADD] sale_order_shipping_date: added compute field shipping_date

### DIFF
--- a/sale_order_shipping_date/README.rst
+++ b/sale_order_shipping_date/README.rst
@@ -1,0 +1,94 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Shipping Date on Sale Order
+============================
+
+This module add a field into Sale Order that show the Date by which the
+products are sure to be delivered.  In contrast to commitment date, not only is
+taken into account the product lead time, but also the resupply delay, the
+delivery lead time from supplier and the manufacturing delay.
+
+Technically, the shipping date field comes to replace the commitment date.
+
+Usage
+=====
+In order to obtain the best performance for computations of dates, you should:
+- For purchase date computation, you should have configured the supplier information for each product that can be buy
+- For manufacturing date computation, you should have configured the reordering rules for each product that can be manufactured.
+- For resupply date computation, you should have configured the lead time in reordering rules and set delay on the procurement rule in the resupply routes.
+
+Known issues / Roadmap
+======================
+
+* Not tested yet in a multi-company environment
+* In all computed quantities, are used the whole product quantity on line. A
+  good improvement is do computation with split quantities, as `MTS+MTO <https://github.com/OCA/stock-logistics-warehouse/tree/8.0/stock_mts_mto_rule>`_ module approach
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/Vauxoo/addons-vauxoo/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/vauxoo/
+addons-vauxoo/issues/new?body=module:%20
+sale_order_shipping_date%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Technical Sketch
+================
+
+To build the compute shipping date method, is required the followings methods:
+
+* **compute_warehouse_date**: Determine the most early date where a product is sure that could be delivered from a given warehouse. If the forecasted quantity is not enough to complete product qty requested, then is returned False.
+
+    - return **false** there is not enough virtual availability in warehouse, comparing with product qty from order_line
+    - if exist virtual avalability iterate date starting from order_date until date when availability is complete in warehouse, passing the date to product context.
+    - Increase order line delay to resulted date
+
+* **compute_resupply_date**: date when product will come to a given warehouse from others warehouses
+
+    - return **false** there is not enough virtual availability without warehouse filter, comparing with product qty from order_line.
+    - get resupply routes filtering by supplied warehouse
+    - iterate routes, and check virtual availability in supplier warehouse
+    - return **false** there is not enough virtual availability in supplier warehouse
+    - call compute_warehouse_date function using supplier warehouse as parameter,
+    - increase the route's procurement rule delay to resulted date
+
+* **compute_purchase_date**: date when product will come to a given warehouse from a purchase order
+
+    - create a dates list iterating supplierinfo, and sum each supllier delivery lead time to the order_date
+    - return **false** there is not supplierinfo for this product.
+    - if exist supplierinfo return the max date from dates list
+
+* **compute_manufacturing_date**: date when product will come to a given warehouse from a production order
+
+    - get bom, filtering by product template, iterate bom lines, create a dates list to get the product date expected using compute_warehouse_date function
+    - return **false** there is not a BoM for this product.
+    - if exist BoM return the max date from dates list
+    - increase manufacturing lead time to max date expected
+
+
+Contributors
+------------
+
+* Jose Suniaga <josemiguel@vauxoo.com>
+
+Maintainer
+----------
+
+.. image:: https://www.vauxoo.com/logo.png
+   :alt: Vauxoo
+   :target: https://vauxoo.com
+
+This module is maintained by Vauxoo.
+
+a latinamerican company that provides training, coaching,
+development and implementation of enterprise management
+systems and bases its entire operation strategy in the use
+of Open Source Software and its main product is odoo.
+
+To contribute to this module, please visit http://www.vauxoo.com.
+

--- a/sale_order_shipping_date/__init__.py
+++ b/sale_order_shipping_date/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/sale_order_shipping_date/__openerp__.py
+++ b/sale_order_shipping_date/__openerp__.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+###########################################################################
+#    Module Writen to OpenERP, Open Source Management Solution
+#    Copyright (C) Vauxoo (<http://vauxoo.com>).
+#    All Rights Reserved
+# #############Credits#########################################################
+#    Coded by: Jose Suniaga <josemiguel@vauxoo.com>
+###############################################################################
+#    This program is free software: you can redistribute it and/or modify it
+#    under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or (at your
+#    option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###############################################################################
+{
+    "name": "Shipping Date on Sale Order",
+    "version": "8.0.1.7.0",
+    "author": "Vauxoo",
+    "category": "stock",
+    "website": "http://www.vauxoo.com/",
+    "license": "AGPL-3",
+    "depends": [
+        "sale_order_dates",
+        "purchase",
+        "mrp",
+        "workalendar_holidays",
+    ],
+    "demo": [],
+    "data": [
+        "views/sale_view.xml",
+        "views/stock_view.xml",
+    ],
+    "test": [],
+    "js": [],
+    "css": [],
+    "qweb": [],
+    "installable": True,
+    "auto_install": False,
+}

--- a/sale_order_shipping_date/i18n/es.po
+++ b/sale_order_shipping_date/i18n/es.po
@@ -1,0 +1,89 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_shipping_date
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-02 03:32+0000\n"
+"PO-Revision-Date: 2016-11-02 03:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_order_shipping_date
+#: help:sale.order,shipping_date:0
+msgid "Date by which the products are sure to be delivered. In contrast to commitment date, not only is taken into account the product lead time, but also the resupply delay, the delivery lead time from supplier and the manufacturing delay"
+msgstr "Fecha en la que los productos estarán seguros de ser entregados. En contraste con la fecha de compromiso, no sólo se tiene en cuenta el plazo de entrega del producto, sino también el tiempo previsto de reabastecimiento, el plazo de entrega del proveedor y el tiempo previsto de fabricación"
+
+#. module: sale_order_shipping_date
+#: selection:stock.warehouse.orderpoint,lead_type:0
+msgid "Day(s) to get the products"
+msgstr "Día(s) para obtener los productos"
+
+#. module: sale_order_shipping_date
+#: selection:stock.warehouse.orderpoint,lead_type:0
+msgid "Day(s) to purchase"
+msgstr "Día(s) de espera para comprar"
+
+#. module: sale_order_shipping_date
+#: field:stock.warehouse.orderpoint,lead_days:0
+msgid "Lead Time"
+msgstr "Tiempo Previsto"
+
+#. module: sale_order_shipping_date
+#: field:stock.warehouse.orderpoint,lead_type:0
+msgid "Lead Type"
+msgstr "Tipo de Previsión"
+
+#. module: sale_order_shipping_date
+#: model:ir.model,name:sale_order_shipping_date.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr "Regla de inventario mínimo"
+
+#. module: sale_order_shipping_date
+#: help:stock.warehouse.orderpoint,lead_days:0
+msgid "Number of days after the orderpoint is triggered to receive the products or to order to the vendor"
+msgstr "Número de días antes de que el punto de pedido sea generado para recibir los productos o para pedirlos al proveedor"
+
+#. module: sale_order_shipping_date
+#: model:ir.model,name:sale_order_shipping_date.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+
+#. module: sale_order_shipping_date
+#: model:ir.model,name:sale_order_shipping_date.model_product_product
+msgid "Product"
+msgstr "Producto"
+
+#. module: sale_order_shipping_date
+#: model:ir.model,name:sale_order_shipping_date.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: sale_order_shipping_date
+#: model:ir.model,name:sale_order_shipping_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea pedido de venta"
+
+#. module: sale_order_shipping_date
+#: code:addons/sale_order_shipping_date/models/sale.py:73
+#: code:addons/sale_order_shipping_date/tests/test_shipping_date.py:227
+#, python-format
+msgid "The date requested by the customer is sooner than the shipping date. You may be unable to honor the customer's request."
+msgstr "La fecha solicitada por el cliente es mucho antes que la fecha de totalidad. Es posible que no pueda cumplir con la solicitud del cliente."
+
+#. module: sale_order_shipping_date
+#: field:sale.order,shipping_date:0
+msgid "shipping Date"
+msgstr "Fecha de Totalidad"
+
+#. module: sale_order_shipping_date
+#: view:sale.order:sale_order_shipping_date.view_sale_orderfor
+msgid "onchange_requested_date(requested_date, shipping_date)"
+msgstr "onchange_requested_date(requested_date, shipping_date)"
+

--- a/sale_order_shipping_date/i18n/es_PA.po
+++ b/sale_order_shipping_date/i18n/es_PA.po
@@ -1,0 +1,17 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_wholeness_date
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-02 03:32+0000\n"
+"PO-Revision-Date: 2016-11-02 03:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+

--- a/sale_order_shipping_date/models/__init__.py
+++ b/sale_order_shipping_date/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+from . import stock
+from . import procurement
+from . import product
+from . import sale

--- a/sale_order_shipping_date/models/procurement.py
+++ b/sale_order_shipping_date/models/procurement.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Jose Suniaga <josemiguel@vauxoo.com>
+#    planned by: Gabriela Quilarte <gabriela@vauxoo.com>
+############################################################################
+
+from dateutil.relativedelta import relativedelta
+from openerp import api, fields, models
+
+
+class ProcurementOrder(models.Model):
+    _inherit = "procurement.order"
+
+    @api.model
+    def _get_orderpoint_date_planned(self, orderpoint, start_date):
+        """ Approach extracted from Odoo 9.0, using new orderpoint fields:
+            'lead_type' and 'lead_days'
+
+        To considering:
+            In Odoo 8.0 addons this date planned is computed just using the
+            seller delay as dynamic factor, and not include delay by resupply
+            rules. To optimize this date should be checked if the orderpoint
+            would be satisfied by a buy order, manufacturing order or a
+            resupply request, avoiding take the buy order as the only rule,
+            which is how comes from Odoo.
+        """
+        date_planned = fields.Datetime.to_string(start_date)
+        delta_days = relativedelta(days=(orderpoint.lead_days or 0.0))
+        if orderpoint.lead_type == 'supplier':
+            date_planned = super(ProcurementOrder, self).\
+                _get_orderpoint_date_planned(orderpoint, start_date)
+        date_planned = fields.Datetime.to_string(
+            fields.Datetime.from_string(date_planned) + delta_days)
+        return date_planned

--- a/sale_order_shipping_date/models/product.py
+++ b/sale_order_shipping_date/models/product.py
@@ -1,0 +1,29 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Jose Suniaga <josemiguel@vauxoo.com>
+#    planned by: Gabriela Quilarte <gabriela@vauxoo.com>
+############################################################################
+
+from dateutil.relativedelta import relativedelta
+from openerp import api, fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.multi
+    def _get_domain_dates(self):
+        domain = super(ProductProduct, self)._get_domain_dates()
+        context = dict(self._context)
+        from_date_expected = context.get('from_date_expected', False)
+        to_date_expected = context.get('to_date_expected', False)
+        if from_date_expected:
+            domain.append(('date_expected', '>=', from_date_expected))
+        if to_date_expected:
+            domain.append(('date_expected', '<=', to_date_expected))
+        return domain

--- a/sale_order_shipping_date/models/sale.py
+++ b/sale_order_shipping_date/models/sale.py
@@ -1,0 +1,217 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Jose Suniaga <josemiguel@vauxoo.com>
+#    planned by: Gabriela Quilarte <gabriela@vauxoo.com>
+############################################################################
+
+from dateutil.relativedelta import relativedelta
+from openerp import api, fields, models, _
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    shipping_date = fields.Datetime(
+        compute='_compute_shipping_date',
+        string='shipping Date', store=True, compute_sudo=True,
+        help="Date by which the products are sure to be delivered. In contrast"
+        " to commitment date, not only is taken into account the product lead"
+        " time, but also the resupply delay, the delivery lead time from"
+        " supplier and the manufacturing delay")
+
+    @api.depends('date_order', 'order_line.delay',
+                 'order_line.product_id', 'order_line.product_uom_qty')
+    def _compute_shipping_date(self):
+        """Compute the shipping date.
+
+        To analyze shipping date should be check the following dates:
+          - date when product is available in a order warehouse
+          - date when product will come from others warehouses
+          - date when product will come from a purchase order
+          - date when product will come from a manufacturing order
+        """
+
+        for order in self:
+            dates_list = []
+            for line in order.order_line.filtered(
+                    lambda x: x.state != 'cancel'):
+                days = line.delay or 0.0
+                date_expected = line.compute_warehouse_date()
+                resupply_date = line.compute_resupply_date()
+                manufacturing_date = line.compute_manufacturing_date()
+                purchase_date = line.compute_purchase_date()
+                shipping_date = date_expected and [date_expected] or (
+                    (resupply_date and [resupply_date] or []) +
+                    (purchase_date and [purchase_date] or []) +
+                    (manufacturing_date and [manufacturing_date] or []))
+                # when not exists shipping date in at least one order line,
+                # then the result for all order is False because we can't
+                # ensure all order lines can be delivered. To avoid that case,
+                # you should has at least one supplier registered by product,
+                # in this way, we ensure that product shipping date can be
+                # compute by a purchase
+                if not shipping_date:
+                    dates_list = []
+                    break
+                # save on dates_list the best option for this order line
+                dates_list += [min(shipping_date) + relativedelta(days=days)]
+            order.shipping_date = dates_list and \
+                fields.Datetime.to_string(max(dates_list)) or False
+
+    @api.multi
+    def onchange_requested_date(self, requested_date, shipping_date):
+        """Warn if the requested dates is sooner than the shipping date"""
+        res = super(SaleOrder, self).onchange_requested_date(
+            requested_date, shipping_date)
+        if 'warning' in res:
+            res['warning'].update({
+                'message': _("The date requested by the customer is "
+                             "sooner than the shipping date. You may be "
+                             "unable to honor the customer's request.")
+            })
+        return res
+
+    @api.model
+    def _prepare_order_line_procurement(self, order, line, group_id=False):
+        res = super(SaleOrder, self)._prepare_order_line_procurement(
+            order, line, group_id)
+        if order.shipping_date:
+            res['date_planned'] = order.shipping_date
+        return res
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.multi
+    def compute_warehouse_date(self, request_product_qty=None, warehouse=None):
+        """ Determine the most early date where a product is sure that could
+        be delivered from a given warehouse. If the forecasted quantity is
+        not enough to complete product qty requested, then is returned False.
+
+        :param product_qty: product quantity requested
+        :param warehouse: warehouse where the product will be delivered
+        :return: date when product would be delivered
+        :rtype: Datetime or False
+        """
+
+        date_expected = False
+        for line in self.filtered("order_id.warehouse_id"):
+            warehouse_id = warehouse and warehouse.id or \
+                line.order_id.warehouse_id.id
+            date_order = fields.Datetime.from_string(line.order_id.date_order)
+            product_qty = request_product_qty or line.product_uom_qty
+            product = line.product_id.with_context(warehouse=warehouse_id)
+            if product_qty > product.virtual_available:
+                return False
+            days = virtual_available = 0
+            while product_qty > virtual_available:
+                date_expected = date_order + relativedelta(days=days)
+                to_date_expected = fields.Datetime.to_string(date_expected)
+                virtual_available = product.with_context(
+                    to_date_expected=to_date_expected).virtual_available
+                days += 1
+
+        return date_expected
+
+    @api.multi
+    def compute_resupply_date(self, request_product_qty=None, warehouse=None):
+        """ Date when product will come to a given warehouse from
+        others warehouses
+
+        :param product_qty: product quantity requested
+        :param warehouse: warehouse where the product will be delivered
+        :return: date when product is available on warehouse
+        :rtype: Datetime or False
+        """
+
+        resupply_date = False
+        dates_list = []
+        work_time = self.env.user.company_id.logistic_calendar_id
+        for line in self.filtered("order_id.warehouse_id"):
+            product_qty = request_product_qty or line.product_uom_qty
+            if product_qty > line.product_id.virtual_available:
+                return False
+            supplied_wh = warehouse or line.order_id.warehouse_id
+            # delivery_lead = line.order_id.compute_delivery_lead()
+            resupply_routes = self.env['stock.location.route'].search([
+                ('supplied_wh_id', '=', supplied_wh.id)])
+            routes_dates = []
+            for route in resupply_routes:
+                days = sum(route.pull_ids.mapped('delay'))
+                supplier_wh = route.supplier_wh_id
+                date_expected = line.compute_warehouse_date(
+                    warehouse=supplier_wh)
+                if date_expected:
+                    date_expected = work_time and work_time.\
+                        compute_working_days(line.delay or 0.0, date_expected)
+                    # no matter working days when is in transit
+                    routes_dates += [date_expected + relativedelta(days=days)]
+            if routes_dates:
+                dates_list.append(min(routes_dates))
+        # extract the date when could complete all lines
+        if dates_list:
+            resupply_date = max(dates_list)
+        return resupply_date
+
+    @api.multi
+    def compute_purchase_date(self):
+        """ Date when product will come to a given warehouse from a purchase
+        order
+
+        :return: date when product is available on warehouse
+        :rtype: Datetime or False
+        """
+
+        purchase_date = False
+        dates_list = []
+        for line in self.filtered("order_id.warehouse_id"):
+            if not line.order_id.warehouse_id.buy_to_resupply:
+                return False
+            date_order = fields.Datetime.from_string(line.order_id.date_order)
+            if line.product_id.seller_ids:
+                days = line.product_id.seller_delay
+                dates_list += [date_order + relativedelta(days=days)]
+        # extract the date when could complete all lines
+        if dates_list:
+            purchase_date = max(dates_list)
+        return purchase_date
+
+    @api.multi
+    def compute_manufacturing_date(self):
+        """ Date when product will come to a given warehouse from a
+        manufacturing order
+        :return: date when product is available on warehouse
+        :rtype: Datetime or False
+        """
+
+        manufacturing_date = False
+        dates_list = []
+        for line in self.filtered("order_id.warehouse_id"):
+            if not line.order_id.warehouse_id.manufacture_to_resupply:
+                return False
+            date_order = fields.Datetime.from_string(line.order_id.date_order)
+            bom_dates = []
+            for bom in line.product_id.bom_ids:
+                days = line.product_id.produce_delay or 0.0
+                warehouse_id = line.order_id.warehouse_id.id
+                all_lines_available = True
+                for bom_line in bom.bom_line_ids:
+                    product_qty = bom_line.product_qty * line.product_uom_qty
+                    product = bom_line.product_id.with_context(
+                        warehouse=warehouse_id)
+                    if product_qty > product.virtual_available:
+                        all_lines_available = False
+                if all_lines_available:
+                    bom_dates += [date_order + relativedelta(days=days)]
+            if bom_dates:
+                dates_list.append(min(bom_dates))
+        # extract the date when could complete all lines
+        if dates_list:
+            manufacturing_date = max(dates_list)
+        return manufacturing_date

--- a/sale_order_shipping_date/models/stock.py
+++ b/sale_order_shipping_date/models/stock.py
@@ -1,0 +1,27 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Jose Suniaga <josemiguel@vauxoo.com>
+#    planned by: Gabriela Quilarte <gabriela@vauxoo.com>
+############################################################################
+from openerp import fields, models
+
+
+class Orderpoint(models.Model):
+    """ Defines Minimum stock rules. """
+    _inherit = "stock.warehouse.orderpoint"
+
+    # TODO: remove this in 0.0 migration
+    # copied from Odoo 9.0 (commit 43e3663)
+    lead_days = fields.Integer(
+        'Lead Time', default=1,
+        help="Number of days after the orderpoint is triggered to receive the"
+        " products or to order to the vendor")
+    lead_type = fields.Selection([
+        ('net', 'Day(s) to get the products'),
+        ('supplier', 'Day(s) to purchase')],
+        string='Lead Type', required=True, default='supplier')

--- a/sale_order_shipping_date/tests/__init__.py
+++ b/sale_order_shipping_date/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_shipping_date

--- a/sale_order_shipping_date/tests/test_shipping_date.py
+++ b/sale_order_shipping_date/tests/test_shipping_date.py
@@ -1,0 +1,233 @@
+# coding: utf-8
+###########################################################################
+#    Module Writen to OpenERP, Open Source Management Solution
+#    Copyright (C) Vauxoo (<http://vauxoo.com>).
+#    All Rights Reserved
+# #############Credits#########################################################
+#    Coded by: Jose Suniaga <josemiguel@vauxoo.com>
+###############################################################################
+#    This program is free software: you can redistribute it and/or modify it
+#    under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or (at your
+#    option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+
+###############################################################################
+from dateutil.relativedelta import relativedelta
+from openerp.addons.stock.tests.common import TestStockCommon
+from openerp import _, fields
+
+
+class TestSaleOrderShippingDate(TestStockCommon):
+
+    def setUp(self):
+        super(TestSaleOrderShippingDate, self).setUp()
+        # TODO: Replace data demo with TestStockCommon data, for any reason
+        # when try to implement: addons/stock/tests/test_resupply.py#L10-L33
+        # quantity available for ProductA does not increase
+        self.product = self.env.ref('product.product_product_29')
+        self.bigwh = self.env.ref('stock.warehouse0')
+        self.smallwh = self.env.ref('stock.stock_warehouse_shop0')
+        self.smallwh.write({
+            'default_resupply_wh_id': self.bigwh.id,
+            'resupply_wh_ids': [(6, 0, [self.bigwh.id])],
+        })
+
+    def create_sale(self, product=None, warehouse=None, date_order=None):
+        product = product or self.product
+        sale = self.env['sale.order'].create({
+            'order_policy': 'manual',
+            'date_order': date_order or fields.Datetime.now(),
+            'partner_id': self.partner_agrolite_id,
+            'partner_invoice_id': self.partner_agrolite_id,
+            'partner_shipping_id': self.partner_agrolite_id,
+            'order_line': [(0, 0, {
+                'name': product.name,
+                'product_id': product.id,
+                'product_uom_qty': 2,
+                'product_uom': product.uom_id.id,
+                'price_unit': product.list_price,
+                'delay': 1,
+            })],
+            'pricelist_id': self.env.ref('product.list0').id,
+            'warehouse_id': warehouse and warehouse.id or self.bigwh.id,
+        })
+        return sale
+
+    def create_sale_order_line(self, sale, product):
+        sale.write({'order_line': [(0, 0, {
+            'name': product.name,
+            'product_id': product.id,
+            'product_uom_qty': 1,
+            'product_uom': product.uom_id.id,
+            'price_unit': product.list_price,
+            'delay': 1,
+        })]})
+
+    def _create_picking_in(self, warehouse):
+        picking = self.env['stock.picking']
+        picking_values = {
+            'picking_type_id': warehouse.in_type_id.id,
+            'location_id': self.env.ref('stock.stock_location_suppliers').id,
+            'location_dest_id': warehouse.lot_stock_id.id,
+        }
+        return picking.create(picking_values)
+
+    def _create_move(self, product, src_loc, dst_loc, **values):
+        stock_move = self.env['stock.move']
+        # simulate create + onchange
+        move = stock_move.new({
+            'product_id': product.id,
+            'location_id': src_loc,
+            'location_dest_id': dst_loc,
+        })
+        move.onchange_product_id()
+        move_values = move._convert_to_write(move._cache)
+        move_values.update(**values)
+        return stock_move.create(move_values)
+
+    def _create_move_in(self, product=None, warehouse=None, picking=None,
+                        create_picking=False, days_delay=0.0, **values):
+        product = product or self.product
+        warehouse = warehouse or self.bigwh
+        if not values:
+            move_dt = fields.Datetime.from_string(fields.Datetime.now()) + \
+                relativedelta(days=days_delay)
+            values = {
+                'name': product.name,
+                'company_id': self.env.ref('base.main_company').id,
+                'product_uom': product.uom_id.id,
+                'product_uom_qty': 5.0,
+                'picking_type_id': warehouse.in_type_id.id,
+                'warehouse_id': warehouse.id,
+                'date': fields.Datetime.to_string(move_dt),
+                'date_expected': fields.Datetime.to_string(move_dt),
+            }
+        if not picking and create_picking:
+            picking = self._create_picking_in(warehouse)
+        if picking:
+            values['picking_id'] = picking.id
+        src_loc = self.supplier_location
+        dst_loc = warehouse.lot_stock_id.id
+        return self._create_move(product, src_loc, dst_loc, **values)
+
+    def test_compute_warehouse_date(self):
+        product = self.env.ref('product.product_product_35')
+        # create a incoming move for a product
+        move = self._create_move_in(product=product, days_delay=2)
+        move.action_confirm()
+        right_date = fields.Datetime.from_string(move.date_expected)
+        # create a demo Sale Order with a product not on hand but forecasted
+        sale = self.create_sale()
+        # compute date when product is available in warehouse
+        warehouse_date = sale.order_line.compute_warehouse_date()
+        self.assertEqual(warehouse_date, right_date)
+
+    def test_compute_purchase_date(self):
+        product = self.env.ref('product.product_product_35')
+        sale = self.create_sale(product=product)
+        # compute purchase date
+        purchase_date = sale.order_line.compute_purchase_date()
+        right_date = fields.Datetime.from_string(sale.date_order) + \
+            relativedelta(days=product.seller_delay)
+        self.assertEqual(purchase_date, right_date)
+
+    def test_compute_manufacturing_date(self):
+        product = self.env.ref('product.product_product_19')
+        warehouse = self.env.ref('stock.warehouse0')
+        sale = self.create_sale(product=product, warehouse=warehouse)
+        # compute manufacturing date
+        manufacturing_date = sale.order_line.compute_manufacturing_date()
+        right_date = fields.Datetime.from_string(sale.date_order) + \
+            relativedelta(days=product.produce_delay)
+        self.assertEqual(manufacturing_date, right_date)
+
+    def test_compute_resupply_date(self):
+        product = self.env.ref('product.product_product_29')
+        resupply_delay = 4.0
+        resupply_route = self.env['stock.location.route'].search([
+            ('supplied_wh_id', '=', self.smallwh.id)], limit=1)
+        resupply_rule = resupply_route.pull_ids.filtered(
+            lambda x: x.warehouse_id.id == self.smallwh.id)
+        resupply_rule.write({'delay': resupply_delay})
+        sale = self.create_sale(product=product, warehouse=self.smallwh)
+        supplier_wh_date = sale.order_line.compute_warehouse_date(
+            warehouse=self.bigwh)
+        # compute resupply date
+        resupply_date = sale.order_line.compute_resupply_date()
+        right_date = supplier_wh_date + relativedelta(days=resupply_delay)
+        self.assertEqual(resupply_date, right_date)
+
+    def test_compute_shipping_date(self):
+        """ Compute shipping date for order with 3 products
+
+            by definition:
+                shipping date, is the date by which the products are sure to
+                be delivered. All products can be delivered the day when each
+                one is available
+
+            e.g.
+            - products has 1 day delay
+            - sale was created on 2016-10-25 20:57:49
+            -------------------------------
+            product Apple Wireless Keyboard
+            warehouse Chicago Warehouse
+            warehouse_date False
+            resupply_date 2016-10-30 20:57:49 (day when each one is available)
+            manuacturing_date False
+            purchase_date 2016-10-29 20:57:49
+            -------------------------------
+            product Blank CD
+            warehouse Chicago Warehouse
+            warehouse_date False
+            resupply_date False
+            manuacturing_date False
+            purchase_date 2016-10-27 20:57:49
+            -------------------------------
+            product USB Adapter
+            warehouse Chicago Warehouse
+            warehouse_date 2016-10-30 20:57:49
+            resupply_date 2016-10-29 20:57:49
+            manuacturing_date False
+            purchase_date False
+            -------------------------------
+
+            at the end:
+            - Apple Wireless Keyboard is the last product to get at stock
+            - Apple Wireless Keyborad has 4 days PO delay + 1 day product delay
+            - The shipping Date is 2016-10-30 20:57:49 (5 days after sale)
+        """
+        resupply_delay = 5.0
+        product_delay = 1.0
+        product_1 = self.env.ref('product.product_product_9')
+        product_2 = self.env.ref('product.product_product_35')
+        product_3 = self.env.ref('product.product_product_48')
+        resupply_route = self.env['stock.location.route'].search([
+            ('supplied_wh_id', '=', self.smallwh.id)], limit=1)
+        resupply_rule = resupply_route.pull_ids.filtered(
+            lambda x: x.warehouse_id.id == self.smallwh.id)
+        resupply_rule.write({'delay': resupply_delay})
+        sale = self.create_sale(product=product_1, warehouse=self.smallwh)
+        self.create_sale_order_line(sale, product_2)
+        self.create_sale_order_line(sale, product_3)
+        sale._compute_shipping_date()
+        shipping_date = fields.Datetime.from_string(sale.shipping_date)
+        # according to example the shipping date for this case should be
+        # 5 days after date order (product_1 seller delay + product delay)
+        product_1_seller_delay = product_1.seller_ids[0].delay
+        right_date = fields.Datetime.from_string(sale.date_order) + \
+            relativedelta(days=(product_1_seller_delay + product_delay))
+        self.assertEqual(shipping_date, right_date)
+        # check onchange requested date
+        res = sale.onchange_requested_date(
+            sale.date_order, sale.shipping_date)
+        self.assertIn('warning', res)
+        msg = _("The date requested by the customer is "
+                "sooner than the shipping date. You may be "
+                "unable to honor the customer's request.")
+        self.assertEqual(res['warning']['message'], msg)

--- a/sale_order_shipping_date/views/sale_view.xml
+++ b/sale_order_shipping_date/views/sale_view.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_sale_orderfor" model="ir.ui.view">
+            <field name="name">sale.order.form.inherit6</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale_order_dates.view_sale_orderfor"/>
+            <field name="arch" type="xml">
+                <field name="requested_date" position="attributes">
+                    <attribute name="on_change">onchange_requested_date(requested_date, shipping_date)</attribute>
+                </field>
+                <field name="commitment_date" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="commitment_date" position="after">
+                    <field name="shipping_date" />
+                </field>
+            </field>
+        </record>
+
+        <record id="view_order_tree_shipping" model="ir.ui.view">
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale_order_dates.view_order_tree_date"/>
+            <field name="arch" type="xml">
+                <field name="commitment_date" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="commitment_date" position="after">
+                    <field name="shipping_date" />
+                </field>
+            </field>
+        </record>
+
+        <record id="view_quotation_tree_shipping" model="ir.ui.view">
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale_order_dates.view_quotation_tree_date"/>
+            <field name="arch" type="xml">
+                <field name="commitment_date" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="commitment_date" position="after">
+                    <field name="shipping_date" />
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/sale_order_shipping_date/views/stock_view.xml
+++ b/sale_order_shipping_date/views/stock_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_orderpoint_form_inherit" model="ir.ui.view">
+            <field name="name">stock.warehouse.orderpoint.form.inherit</field>
+            <field name="model">stock.warehouse.orderpoint</field>
+            <field name="inherit_id" ref="stock.view_warehouse_orderpoint_form"/>
+            <field name="arch" type="xml">
+                <field name="active" position="after">
+                    <label for="lead_days"/>
+                    <div class="o_row">
+                        <field name="lead_days"/>
+                        <field name="lead_type"/>
+                    </div>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/workalendar_holidays/__openerp__.py
+++ b/workalendar_holidays/__openerp__.py
@@ -28,6 +28,7 @@
     "license": "AGPL-3",
     "depends": [
         "resource",
+        "procurement",
     ],
     "external_dependencies": {
         'python': ['workalendar']
@@ -36,6 +37,7 @@
     "data": [
         "data/res_country_data.xml",
         "wizards/workalendar_holiday_import.xml",
+        "views/res_company_view.xml",
     ],
     "test": [],
     "js": [],

--- a/workalendar_holidays/models/__init__.py
+++ b/workalendar_holidays/models/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import resource
+from . import res_company

--- a/workalendar_holidays/models/res_company.py
+++ b/workalendar_holidays/models/res_company.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Jose Suniaga <josemiguel@vauxoo.com>
+#    planned by: Gabriela Quilarque <gabriela@vauxoo.com>
+#
+############################################################################
+from openerp import fields, models
+
+
+class ResCompany(models.Model):
+
+    _inherit = 'res.company'
+
+    logistic_calendar_id = fields.Many2one(
+        'resource.calendar', string="Logistic Work Time",
+        domain="[('company_id', '=', id)]",
+        help="Company schedule for logistic operations")

--- a/workalendar_holidays/views/res_company_view.xml
+++ b/workalendar_holidays/views/res_company_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="res_company_work_time_inherit" model="ir.ui.view">
+            <field name="name">res.company.work.time.inherit</field>
+            <field name="model">res.company</field>
+            <field name="priority">50</field>
+            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='logistics_grp']" position="inside">
+                    <field name="logistic_calendar_id" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
### [VX#6085 CA#9 HU#805](https://www.vauxoo.com/web#id=805&view_type=form&model=user.story)
## Summary

This module add a field into Sale Order that show the Date by which the are sure to be delivered. In constrast to commitment date, not only is taken into account the product lead time, but also the resupply delay, the also the resupply delay, the delivery lead time from supplier and the manufacturing delay.

Technically, the shipping date field comes to replace the commitment date.
## Test Case

**Sketch**

```
        e.g.
        - products have 1 day delay
        - sale was created on 2016-10-25 20:16:11
        -------------------------------
        product Apple Wireless Keyboard
        warehouse Chicago Warehouse
        date_expected False
        resupply_date 2016-10-28 20:16:11 (day when each one is available)
        manuacturing_date False
        purchase_date 2016-10-29 20:16:11
        -------------------------------
        product Blank CD
        warehouse Chicago Warehouse
        date_expected False
        resupply_date False
        manuacturing_date False
        purchase_date 2016-10-27 20:16:11
        -------------------------------
        product USB Adapter
        warehouse Chicago Warehouse
        date_expected 2016-10-25 20:16:11
        resupply_date 2016-10-28 20:16:11
        manuacturing_date False
        purchase_date False
        -------------------------------

        result:
        - resupply_date 2016-10-28 20:16:11 + 1 day (product delay)
        - shipping_date is 2016-10-29 20:16:11 (4 days after sale)
```

**Configure to compute resupply date**

Check _Default Resupply Warehouse_ in Chicago Warehouse
![pantallazo-2016-10-25 18-44-37](https://cloud.githubusercontent.com/assets/5335402/19708809/f81a75f4-9ae6-11e6-9afa-76414f48247a.png)

Go to Routes, and select _Chicago Warehouse: Supply Product from YourCompany_
![pantallazo-2016-10-25 18-44-38](https://docs.google.com/uc?id=0B5vKhatgX1y8d193anAwTU45TUU)

Select Pull Rule _Chic: Inter Company Transit -> Stock_
![pantallazo-2016-10-25 18-44-39](https://docs.google.com/uc?id=0B5vKhatgX1y8MUpMTFZtSFNfVlk)

Set a delay: the number of days that product will be in transit. 3 days for this example
![pantallazo-2016-10-25 18-44-40](https://docs.google.com/uc?id=0B5vKhatgX1y8Yzl6Nmp2R2VfVE0)

**Configure to compute purchase date**

Select Product _Apple Wireless Keyboard_ and check _Delivery Lead Time_ (4 days)
![pantallazo-2016-10-25 18-44-41](https://docs.google.com/uc?id=0B5vKhatgX1y8bTF4UVZNOUxtTW8)

**Configure to compute manufacturing date**

Ensure that _Customer Lead Time_ and Manufacturing Lead Time are 1 day for products: _Apple Wireless Keyboard_,  _Blank CD_, _USB Adapter_
![pantallazo-2016-10-25 18-44-42](https://docs.google.com/uc?id=0B5vKhatgX1y8S0xwOVBqcmFFWU0)

**Create Order for Test Case**

Create a Order with products: _Apple Wireless Keyboard_,  _Blank CD_, _USB Adapter_ at _Chicago Warehouse_ 
![pantallazo-2016-10-25 18-44-43](https://docs.google.com/uc?id=0B5vKhatgX1y8b0pxcDBqNlNTUW8)

Go to _Other Information_ tab and check the _Wholeness Date_, should be 4 days after _Date Order_ (check date order on previous image)
![pantallazo-2016-10-25 18-44-43](https://docs.google.com/uc?id=0B5vKhatgX1y8aTFCSjdZQlZUYlE)

**Conclusion**
- All products have +1 day delay
- Apple Wireless Keyboard is the last product to be receipt 
- The best choice for Apple Wireless Keyboard is resupply
- Resupply date for Apple Wireless Keyboard is 2016-10-28 20:16:11 (3 days after sale)
- To the resupply date is added +1 for the product delay, in order to compute de shipping date
- **Shipping date is 2016-10-29 20:16:11 (4 days after sale)**
