### PR TITLE
[IMP] stock_card: when set warehouse in wizard we are searching

### DIFF
--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -51,6 +51,8 @@ class StockCardProduct(models.TransientModel):
         :param warehouse: browse record (stock.warehouse)
         """
         loc_obj = self.env["stock.location"]
+        if not warehouse:
+            return False
         locations = loc_obj.search(
             [('parent_left', '<=', warehouse.view_location_id.parent_right),
              ('parent_left', '>=', warehouse.view_location_id.parent_left)]).\


### PR DESCRIPTION
locations in base to parent left/right but when wizard is not set some
locations has not parent left/right and search return locations and try
to create stock card in that locations but we want to create stock card
with all moves when warehouse is not set in wizard

in order to solves:
**Asked Product has not Moves to show**