### PR TITLE
[FIX] requirements.txt: fix missing dependency workalendar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas == 0.18.0
 cssutils >= 1.0.1
 xlrd == 1.0.0
 tabulate == 0.7.5
+workalendar == 0.8.0


### PR DESCRIPTION
To fix:
```
except_orm: ('Error', u'Unable to install module "workalendar_holidays" because an external dependency is not met: No module named workalendar')
```