### PR TITLE
[IMP] workalendar_holidays: added logistic calendar to company model

### DIFF
--- a/workalendar_holidays/__openerp__.py
+++ b/workalendar_holidays/__openerp__.py
@@ -28,6 +28,7 @@
     "license": "AGPL-3",
     "depends": [
         "resource",
+        "procurement",
     ],
     "external_dependencies": {
         'python': ['workalendar']
@@ -36,6 +37,7 @@
     "data": [
         "data/res_country_data.xml",
         "wizards/workalendar_holiday_import.xml",
+        "views/res_company_view.xml",
     ],
     "test": [],
     "js": [],

--- a/workalendar_holidays/models/__init__.py
+++ b/workalendar_holidays/models/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import resource
+from . import res_company

--- a/workalendar_holidays/models/res_company.py
+++ b/workalendar_holidays/models/res_company.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Jose Suniaga <josemiguel@vauxoo.com>
+#    planned by: Gabriela Quilarque <gabriela@vauxoo.com>
+#
+############################################################################
+from openerp import fields, models
+
+
+class ResCompany(models.Model):
+
+    _inherit = 'res.company'
+
+    logistic_calendar_id = fields.Many2one(
+        'resource.calendar', string="Logistic Work Time",
+        domain="[('company_id', '=', id)]",
+        help="Company schedule for logistic operations")

--- a/workalendar_holidays/views/res_company_view.xml
+++ b/workalendar_holidays/views/res_company_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="res_company_work_time_inherit" model="ir.ui.view">
+            <field name="name">res.company.work.time.inherit</field>
+            <field name="model">res.company</field>
+            <field name="priority">50</field>
+            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='logistics_grp']" position="inside">
+                    <field name="logistic_calendar_id" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Summary
-------------

The logistic calendar is used to load the work time, and load company holidays, in order to be able to compute working days in company daily operations.