### PR TITLE
[FIX] Fixing asked model is different from provide model at SQL

### DIFF
--- a/product_extended_variants/model/template.py
+++ b/product_extended_variants/model/template.py
@@ -102,8 +102,9 @@ class ProductTemplate(models.Model):
                     sl.id
                 FROM stock_quant sq
                 INNER JOIN stock_location sl ON sl.id = sq.location_id
+                INNER JOIN product_product pp ON pp.id = sq.product_id
                 WHERE
-                    sq.product_id = %s
+                    pp.product_tmpl_id = %s
                     AND sl.usage = 'internal'
                     AND sl.company_id = %s
                 ;""", (rec_id, user_company_id))


### PR DESCRIPTION
At SQL Query whereabouts model used is product.template, so records are of that model
and not from product.product, hence the _new_ INNER JOIN clause