### PR TITLE
[BUG] default_warehouse_from_sale_team: warehouse_id not set by default_get not found key

### DIFF
--- a/default_warehouse_from_sale_team/models/sales_team.py
+++ b/default_warehouse_from_sale_team/models/sales_team.py
@@ -88,8 +88,7 @@ class WarehouseDefault(models.Model):
                  ('ttype', '=', 'many2one')])
             names_list = list(set([field.name for field in fields_data]))
             defaults.update(
-                {name: warehouse_id for name in names_list
-                 if defaults.get(name)})
+                {name: warehouse_id for name in names_list})
         return defaults
 
     @api.v7


### PR DESCRIPTION
**Impacted versions:**
8.0

Steps to reproduce:

Create a Landed Cost Guide

**Current behavior:**

At the view, the warehouse is not assigned by default, according to user settings in the sales team where is defined a warehouse_id

caused by

```  
 defaults.update({name: warehouse_id for name in names_list 
                                       if defaults.get(name)})
```

This results, if the method Super default_get not find a ``` warehouse_id ```, then there is not updated the value returned by the super, with the warehouse found in sales team, because  not find the one associated with the ``` warehouse_id ``` key in the dictionary

**Expected behavior:**

get by default warehouse_id in view, since version 8 and greater

complete original code [here](https://github.com/Vauxoo/addons-vauxoo/blob/8.0/default_warehouse_from_sale_team/models/sales_team.py#L91)

A viable solution is delete ``` if ``` as follows:

``` diff
 defaults.update({name: warehouse_id for name in names_list 
-                                       if defaults.get(name)})
+                                      })
```