### PR TITLE
[FIX] Passing unexpected non boolean on boolean field

### DIFF
--- a/commission_payment/view/commission_report.xml
+++ b/commission_payment/view/commission_report.xml
@@ -10,7 +10,7 @@
             string="Salespeople Commission Payment"
             report_type="qweb-pdf"
             multi="True"
-            attachment_use="0"
+            attachment_use="False"
             attachment=""
             menu="True"/>
 


### PR DESCRIPTION
[FIX] Passing unexpected non boolean value '0' (is string) 
in boolean field 'attachment_use'. You should use eval='False'.