### PR TITLE
[IMP] account_voucher_tax, account_move_line_base_tax,

### DIFF
--- a/account_move_line_base_tax/account.py
+++ b/account_move_line_base_tax/account.py
@@ -68,8 +68,7 @@ class AccountMoveLine(osv.Model):
                     line.tax_id_secondary.type_tax_use != 'purchase'):
                 continue
             cat_tax = line.tax_id_secondary.tax_category_id
-            if all([cat_tax, cat_tax.name == 'IVA-RET', line.credit <= 0,
-                    not line.not_move_diot]):
+            if cat_tax and cat_tax.name == 'IVA-RET' and line.credit <= 0 and not line.not_move_diot:  # noqa
                 raise ValidationError(_(
                     'The lines with tax of purchase, need have a value '
                     'in the credit. \nTax: %s' % line.tax_id_secondary.name))

--- a/account_voucher_tax/account_statement_bank.py
+++ b/account_voucher_tax/account_statement_bank.py
@@ -21,13 +21,12 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from __future__ import division
 
-import time
 from openerp.tools.translate import _
 from openerp.osv import osv
 from openerp.tools import float_compare
 import openerp
+import time
 
 
 class AccountBankStatementLine(osv.osv):
@@ -213,13 +212,14 @@ class AccountBankStatementLine(osv.osv):
                 line_tax_id = move_line_tax.get('tax_id')
                 # Cuando el impuesto (@tax_id) tiene @amount = 0 es un impuesto
                 # de compra 0% o EXENTO y necesitamos enviar el monto base
-                amount_base_secondary = (
-                    line_tax_id.amount and
-                    move_amount_counterpart[1] / (1 + line_tax_id.amount) or
-                    move_line_tax.get('amount_base_secondary'))
-                account_tax_voucher = move_line_tax.get('account_tax_voucher')
-                account_tax_collected = move_line_tax.get(
-                    'account_tax_collected')
+                amount_base_secondary =\
+                    line_tax_id.amount and\
+                    move_amount_counterpart[1] / (1 + line_tax_id.amount) or\
+                    move_line_tax.get('amount_base_secondary')
+                account_tax_voucher =\
+                    move_line_tax.get('account_tax_voucher')
+                account_tax_collected =\
+                    move_line_tax.get('account_tax_collected')
                 amount_total_tax = move_line_tax.get('amount', 0)
 
                 lines_tax = voucher_obj._preparate_move_line_tax(

--- a/account_voucher_tax/account_statement_bank.py
+++ b/account_voucher_tax/account_statement_bank.py
@@ -21,12 +21,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
+from __future__ import division
 
+import time
 from openerp.tools.translate import _
 from openerp.osv import osv
 from openerp.tools import float_compare
 import openerp
-import time
 
 
 class AccountBankStatementLine(osv.osv):
@@ -212,14 +213,13 @@ class AccountBankStatementLine(osv.osv):
                 line_tax_id = move_line_tax.get('tax_id')
                 # Cuando el impuesto (@tax_id) tiene @amount = 0 es un impuesto
                 # de compra 0% o EXENTO y necesitamos enviar el monto base
-                amount_base_secondary =\
-                    line_tax_id.amount and\
-                    move_amount_counterpart[1] / (1 + line_tax_id.amount) or\
-                    move_line_tax.get('amount_base_secondary')
-                account_tax_voucher =\
-                    move_line_tax.get('account_tax_voucher')
-                account_tax_collected =\
-                    move_line_tax.get('account_tax_collected')
+                amount_base_secondary = (
+                    line_tax_id.amount and
+                    move_amount_counterpart[1] / (1 + line_tax_id.amount) or
+                    move_line_tax.get('amount_base_secondary'))
+                account_tax_voucher = move_line_tax.get('account_tax_voucher')
+                account_tax_collected = move_line_tax.get(
+                    'account_tax_collected')
                 amount_total_tax = move_line_tax.get('amount', 0)
 
                 lines_tax = voucher_obj._preparate_move_line_tax(

--- a/account_voucher_tax/account_voucher.py
+++ b/account_voucher_tax/account_voucher.py
@@ -459,17 +459,16 @@ class AccountVoucher(osv.Model):
 
         return [debit_line_vals, credit_line_vals]
 
-    def _get_base_amount_tax_secondary(
-            self, cr, uid, line_tax, amount_base_tax, reference_amount,
-            context=None):
+    def _get_base_amount_tax_secondary(self, cr, uid, line_tax,
+                                       amount_base_tax, reference_amount,
+                                       context=None):
         amount_base = 0
         tax_secondary = False
-        if all([line_tax, line_tax.tax_category_id,
-               line_tax.tax_category_id.name in (
-                   'IVA', 'IVA-EXENTO', 'IVA-RET', 'IVA-PART')]):
-            amount_base = (line_tax.amount and
-                           reference_amount / line_tax.amount or
-                           amount_base_tax)
+        if line_tax and line_tax.tax_category_id\
+                and line_tax.tax_category_id.name in \
+                ('IVA', 'IVA-EXENTO', 'IVA-RET', 'IVA-PART'):
+            amount_base = line_tax.amount and\
+                reference_amount / line_tax.amount or amount_base_tax
             tax_secondary = line_tax.id
         return [amount_base, tax_secondary]
 


### PR DESCRIPTION
account_voucher_tax_sat: Added that consider amount base in lines to
supplier invoice refund.

When was generated an invoice, this is paid and after is generated an
invoice refund, the movement generated by tax in the payment of that
refund must be amount base to report in DIOT report.

Temporary removed validation that not allow generate movements to DIOT
with amount base in negative

Improve some codes and fixed lint errors