### PR TITLE
[FIX] workalendar_holidays: fixed wrong call to next_day

### DIFF
--- a/workalendar_holidays/models/resource.py
+++ b/workalendar_holidays/models/resource.py
@@ -69,7 +69,7 @@ class ResourceCalendar(models.Model):
         previous_day = isinstance(res, list) and res[0] or res
         for calendar in self:
             previous_day = calendar.is_holiday(previous_day) and \
-                calendar.get_next_day(previous_day) or previous_day
+                calendar.get_previous_day(previous_day) or previous_day
         return previous_day
 
     @api.multi
@@ -82,7 +82,6 @@ class ResourceCalendar(models.Model):
         :param date day_date: current day as a date
         :return date: next day of calendar, or just next day
         """
-
         res = super(ResourceCalendar, self).get_next_day(day_date)
         # TODO: figure out why this function return list instead date
         next_day = isinstance(res, list) and res[0] or res

--- a/workalendar_holidays/tests/__init__.py
+++ b/workalendar_holidays/tests/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Jose Suniaga <josemiguel@vauxoo.com>
+#
+############################################################################
+from . import test_resource
+from . import test_holiday_wizard

--- a/workalendar_holidays/tests/test_holiday_wizard.py
+++ b/workalendar_holidays/tests/test_holiday_wizard.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Jose Suniaga <josemiguel@vauxoo.com>
+#
+############################################################################
+from openerp.addons.resource.tests import common
+
+
+class TestHolidayImport(common.TestResourceCommon):
+
+    def setUp(self):
+        super(TestHolidayImport, self).setUp()
+
+        self.resource_calendar = self.env['resource.calendar']
+        self.holiday_wizard = self.env['wizard.workalendar.holiday.import']
+
+    def test_00_holiday_import(self):
+        """ Testing public holidays importation """
+
+        calendar = self.resource_calendar.browse(self.calendar_id)
+        country_group_id = self.env.ref('workalendar_holidays.america').id
+        year = 2016
+
+        # check that there are no holidays loaded in the calendar
+        self.assertFalse(calendar.get_holidays(year))
+
+        # create wizard to load holidays in the calendar
+        wiz = self.holiday_wizard.create({
+            'start_date': '%d-01-01' % (year),
+            'interval_number': 1,
+            'interval_type': 'years',
+            'calendar_id': self.calendar_id,
+            'country_group_id': country_group_id,
+            'country_id': self.env.ref('base.mx').id,
+        })
+
+        # load holidays in calendar
+        wiz.holiday_import()
+
+        # check that now, the holidays have been loaded in the calendar
+        self.assertTrue(calendar.get_holidays(year))

--- a/workalendar_holidays/tests/test_resource.py
+++ b/workalendar_holidays/tests/test_resource.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2011 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Jose Suniaga <josemiguel@vauxoo.com>
+#
+############################################################################
+from dateutil.relativedelta import relativedelta
+from openerp import fields
+from openerp.addons.resource.tests import common
+
+
+class TestResource(common.TestResourceCommon):
+
+    def setUp(self):
+        super(TestResource, self).setUp()
+
+        self.resource_calendar = self.env['resource.calendar']
+        self.resource_leaves = self.env['resource.calendar.leaves']
+
+        # Some date for demo
+        self.date3 = fields.Datetime.from_string('2016-10-04 10:11:12')
+        self.date4 = fields.Datetime.from_string('2016-10-07 10:11:12')
+
+        # Set as holiday a week after date3
+        self.holiday_start = fields.Datetime.from_string('2016-10-11 00:00:00')
+        self.holiday_end = fields.Datetime.from_string('2016-10-11 23:59:59')
+
+        self.leave4 = self.resource_leaves.create({
+            'name': 'Pre-Columbus Day 2016',
+            'date_from': self.holiday_start,
+            'date_to': self.holiday_end,
+            'calendar_id': self.calendar_id})
+
+    def test_00_next_day(self):
+        """ Testing next day computation """
+
+        calendar = self.resource_calendar.browse(self.calendar_id)
+
+        # next day after date3 is date4
+        date = calendar.get_next_day(day_date=self.date3.date())
+        self.assertEqual(date, self.date4.date(),
+                         'resource_calendar: wrong next day computing')
+
+        # next day after date4 is date4 + 7
+        date = calendar.get_next_day(day_date=self.date4.date())
+        self.assertEqual(date, self.date4.date() + relativedelta(days=7),
+                         'resource_calendar: wrong next day computing')
+
+        # next day after date3 - 1 is date3
+        date = calendar.get_next_day(
+            day_date=self.date3.date() + relativedelta(days=-1))
+        self.assertEqual(date, self.date3.date(),
+                         'resource_calendar: wrong next day computing')
+
+    def test_10_previous_day(self):
+        """ Testing previous day computation """
+
+        calendar = self.resource_calendar.browse(self.calendar_id)
+
+        # previous day before date3 is date4 - 7
+        date = calendar.get_previous_day(day_date=self.date3.date())
+        self.assertEqual(date, self.date4.date() + relativedelta(days=-7),
+                         'resource_calendar: wrong previous day computing')
+
+        # previous day before date4 is date3
+        date = calendar.get_previous_day(day_date=self.date4.date())
+        self.assertEqual(date, self.date3.date(),
+                         'resource_calendar: wrong previous day computing')
+
+        # previous day before date4 + 7 is date 4
+        date = calendar.get_previous_day(
+            day_date=self.date4.date() + relativedelta(days=7))
+        self.assertEqual(date, self.date4.date(),
+                         'resource_calendar: wrong previous day computing')
+
+        # previous day before date3 + 1 is day3
+        date = calendar.get_previous_day(
+            day_date=self.date3.date() + relativedelta(days=1))
+        self.assertEqual(date, self.date3.date(),
+                         'resource_calendar: wrong previous day computing')
+
+    def test_20_working_days(self):
+        """ Testing previous day computation """
+
+        calendar = self.resource_calendar.browse(self.calendar_id)
+
+        # 1 working day after date3 is date4
+        datetime = calendar.compute_working_days(1, self.date3)
+        self.assertEqual(datetime, self.date4,
+                         'resource_calendar: wrong working days computing')
+
+        # 2 working days after date3 is date4 + 7
+        datetime = calendar.compute_working_days(2, self.date3)
+        self.assertEqual(datetime, self.date4 + relativedelta(days=7),
+                         'resource_calendar: wrong working days computing')
+
+        # 2 working days before date3 is date3 - 7
+        datetime = calendar.compute_working_days(-2, self.date3)
+        self.assertEqual(datetime, self.date3 + relativedelta(days=-7),
+                         'resource_calendar: wrong working days computing')
+
+        # 2 working days before date4 is date4 - 7
+        datetime = calendar.compute_working_days(-2, self.date4)
+        self.assertEqual(datetime, self.date4 + relativedelta(days=-7),
+                         'resource_calendar: wrong working days computing')
+
+        # 2 working days before date4 + 7 is date3
+        datetime = calendar.compute_working_days(
+            -2, self.date4 + relativedelta(days=7))
+        self.assertEqual(datetime, self.date3,
+                         'resource_calendar: wrong working days computing')
+
+    def test_30_holidays(self):
+        """ Testing company holidays """
+
+        calendar = self.resource_calendar.browse(self.calendar_id)
+        holidays = calendar.get_holidays(2016)
+
+        # date3 is a working day
+        self.assertFalse(calendar.is_holiday(self.date3.date()))
+
+        # date3 + 1 is not a working day, neither holiday
+        self.assertFalse(calendar.is_holiday(
+            self.date3.date() + relativedelta(days=1)))
+
+        # date3 + 7 is not a working day, because is a holiday
+        self.assertTrue(calendar.is_holiday(
+            self.date3.date() + relativedelta(days=7)))
+
+        self.assertEqual(len(holidays), 1)


### PR DESCRIPTION
### [VX#6085 HU#805](https://www.vauxoo.com/web#id=805&view_type=form&model=user.story)

Summary
-------------
Wrong call to next_day in `previous_day` function, in consecuence `compute_working_days` was not working well

TODO
---------
- [x] Fix wrong call
- [x] Make unittests to ensure that `compute_working_days` work properly
