### PR TITLE
[FIX] Fixing stock_card because it was partially covering Odoo Purchase returns case

### DIFF
--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -138,7 +138,6 @@ class StockCardProduct(models.TransientModel):
         vals['product_qty'] += (vals['direction'] * row['product_qty'])
         sm_obj = self.env['stock.move']
         move_id = sm_obj.browse(row['move_id'])
-        product_id = self.env['product.product'].browse(row['product_id'])
         # Cost is the one record in the stock_move, cost in the
         # quant record includes other segmentation cost: landed_cost,
         # material_cost, production_cost, subcontracting_cost
@@ -148,15 +147,9 @@ class StockCardProduct(models.TransientModel):
         current_quants = set(move_id.quant_ids.ids)
         origin_quants = set(origin_id.quant_ids.ids)
         quants_exists = current_quants.issubset(origin_quants)
-        price = 0
-        if quants_exists:
-            price = move_id.price_unit
-        elif product_id.cost_method == 'average' and not quants_exists:
-            price = vals['average']
-        # / ! \ This is missing when current move's quants are partially
-        # located in origin's quants, so it's taking average cost temporarily
-        else:
-            price = vals['average']
+        price = vals['average']
+        if quants_exists and vals['product_qty'] > 0:
+            price = origin_id.price_unit
         vals['move_valuation'] = sum([price * qnt['qty'] for qnt in qntval])
         return True
 

--- a/stock_card_segmentation/model/stock_card.py
+++ b/stock_card_segmentation/model/stock_card.py
@@ -177,17 +177,20 @@ class StockCardProduct(models.TransientModel):
         current_quants = set(move_id.quant_ids.ids)
         origin_quants = set(origin_id.quant_ids.ids)
         quants_exists = current_quants.issubset(origin_quants)
-        if quants_exists:
+        if quants_exists and vals['product_qty'] > 0:
             vals['move_valuation'] = sum(
                 [qnt['cost'] * qnt['qty'] for qnt in qntval])
+            for sgmnt in SEGMENTATION:
+                vals['%s_valuation' % sgmnt] = sum(
+                    [qnt['%s_cost' % sgmnt] * qnt['qty'] for qnt in qntval])
         # / ! \ This is missing when current move's quants are partially
         # located in origin's quants, so it's taking average cost temporarily
         else:
             vals['move_valuation'] = sum(
                 [vals['average'] * qnt['qty'] for qnt in qntval])
-        for sgmnt in SEGMENTATION:
-            vals['%s_valuation' % sgmnt] = sum(
-                [qnt['%s_cost' % sgmnt] * qnt['qty'] for qnt in qntval])
+            for sgmnt in SEGMENTATION:
+                vals['%s_valuation' % sgmnt] = sum(
+                    [vals[sgmnt] * qnt['qty'] for qnt in qntval])
 
         return True
 


### PR DESCRIPTION
[FIX] Fixing stock_card because it was partially covering
purchase returns when stock_available was equal to zero.

Partially because were replicating exactly the case exposed by Odoo
which was returning a quant which was already sold.
Now we take into account the quant available which lead to a qty=0

Case Exposed by Odoo: https://goo.gl/6vfvgz
https://www.odoo.com/documentation/user/9.0/accounting/others/inventory/avg_price_valuation.html#purchase-return-use-case

Case Exposed by Odoo show with Stock Card:
https://drive.google.com/file/d/0B1w9gokcJL9hUUVmNDNRLWhfMHM/view?usp=sharing

The case when returning Purchase left qty > 0:
https://drive.google.com/file/d/0B1w9gokcJL9hWlJsT0hrOFRqTTQ/view?usp=sharing