### PR TITLE
[IMP] Setting Border Date to Stock Card on Product

### DIFF
--- a/stock_card/model/product.py
+++ b/stock_card/model/product.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from openerp import models, api
+import logging
+from openerp import models, api, fields
+_logger = logging.getLogger(__name__)
 
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'
+
+    date_stock_card_border = fields.Datetime(string='Stock Card Border Date')
 
     @api.multi
     def stock_card_move_get(self):

--- a/stock_card/model/stock_card.py
+++ b/stock_card/model/stock_card.py
@@ -402,6 +402,7 @@ class StockCardProduct(models.TransientModel):
         return action
 
     def _stock_card_move_history_get(self, product_id, locations_ids=None):
+        product_obj = self.env['product.product']
         query = '''
             SELECT distinct
                 sm.id AS move_id, sm.date, sm.product_id, prod.product_tmpl_id,
@@ -437,6 +438,12 @@ class StockCardProduct(models.TransientModel):
             query += self._cr.mogrify('''
                 AND (sl_src.id IN %s or sl_dst.id IN %s)
             ''', (locations_ids, locations_ids))
+
+        date = product_obj.browse(product_id).date_stock_card_border
+        if date:
+            query += self._cr.mogrify('''AND sm.date >= %s
+                                      ''', (date,))
+
         query += '''ORDER BY sm.date'''
         self._cr.execute(query, (product_id,))
         return self._cr.dictfetchall()

--- a/stock_card/view/view.xml
+++ b/stock_card/view/view.xml
@@ -94,6 +94,11 @@
                         <div>Stock Card</div>
                     </button>
                 </xpath>
+                <xpath expr="//group[@name='inventory']" position="after">
+                    <group name='stock_card' groups="stock.group_stock_manager" string="Stock Card Info" attrs="{'invisible':['|', ('type','=','service'), ('cost_method','!=','average')]}">
+                        <field name="date_stock_card_border"/>
+                    </group>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
Chances are that you are migrating data from one system to another or from one version to another, and you could end up in not trusting the Original Stock Card, because, there are returns from previous date than that when setup your Initial Inventory Values that could mess up your stock average.

Then what we intend is to provide you with a Tool where you could set Border Conditions for your stock card, i.e., you said from this moment on my Stock Card is legal, right, true reliable.

To achieve this goal there are some assumptions to be made, it will be considered a Universal True that you will be performing an Initialization of Inventory Values, like sending all the products to Inventory Loss to deplete all the products setting then to zero and then set your right average on your products and then Creating new Stock Move which will create new Inventory Stock on your Warehouse replenishing your Inventories, all this been done at a specific day.

Feature Exposed:
https://drive.google.com/file/d/0B1w9gokcJL9hRElwZEl2a2lRaXc/view