### PR TITLE
[IMP] Take into account the date_stock_account_border to compute average

### DIFF
--- a/stock_account_unfuck/__openerp__.py
+++ b/stock_account_unfuck/__openerp__.py
@@ -21,6 +21,7 @@
     ],
     # always loaded
     'data': [
+        'views/view.xml',
     ],
     # only loaded in demonstration mode
     'demo': [

--- a/stock_account_unfuck/models/__init__.py
+++ b/stock_account_unfuck/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
+from . import product
 from . import stock
 from . import stock_account

--- a/stock_account_unfuck/models/product.py
+++ b/stock_account_unfuck/models/product.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, fields
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    date_stock_account_border = fields.Datetime(
+        string='Stock Account Border Date',
+        help='Used when computing average for products that are returned'
+        'from Customers and whose date are prior to Initialization Inventory',
+    )

--- a/stock_account_unfuck/views/view.xml
+++ b/stock_account_unfuck/views/view.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<openerp>
+    <data>
+        <record id="product_stock_account_form_view" model="ir.ui.view">
+            <field name="name">product.product.stock.account.form</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_normal_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='inventory']" position="after">
+                    <group name='stock_account' groups="stock.group_stock_manager" string="Stock Account Info" attrs="{'invisible':['|', ('type','=','service'), ('cost_method','!=','average')]}">
+                        <field name="date_stock_account_border"/>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Returns from Customers or Transit will be performed at current 
average instead of previous cost on transaction when initialization date
is set on the product

NOTE
====
stock.py: generates/computes the `average` and,
stock_account.py: takes a value (from stock.move or product, it depends) and book a journal entry.

UnitTest
========
- [x] Accounting - Journal Entries are to be make a Cost taking into account Historical Cost and Accounting Border Date.
- [ ] Logistics - Average is to be computed taking into account Historical Cost and Accounting Border Date.
- [ ] Provide a thorough UnitTest (average / journal items)- testing each step in the process of Receiving merchandise from Supplier, Sending it to Customer, Returning Merchandise to Supplier, Returning Merchandise from Customer, Sending/Receiving Merchandise to/from Transit.
- [ ] Provide UnitTest for border date.
- [ ] Review `price_unit` on `action_done` check if *before* or *after*