### PR TITLE
[FIX] Fixed partner credit limit test to adapt to v10

### DIFF
--- a/partner_credit_limit/model/account_invoice.py
+++ b/partner_credit_limit/model/account_invoice.py
@@ -27,3 +27,15 @@ class AccontInvoice(models.Model):
                         '\nCredit'
                         ' Limit : %s') % (invoice.partner_id.credit_limit)
                 raise exceptions.Warning(msg)
+
+    @api.multi
+    def action_invoice_proforma2(self):
+        self.check_limit_credit()
+        res = super(AccontInvoice, self).action_invoice_proforma2()
+        return res
+
+    @api.multi
+    def action_invoice_open(self):
+        self.check_limit_credit()
+        res = super(AccontInvoice, self).action_invoice_open()
+        return res

--- a/partner_credit_limit/tests/test_invoice_credit_limit.py
+++ b/partner_credit_limit/tests/test_invoice_credit_limit.py
@@ -50,8 +50,9 @@ class TestCreditLimits(common.TestCommon):
         # credit limit exceded
         # credit_limit = 500
         # amount_total = 600
+        print invoice_id.state
         with self.assertRaises(exceptions.Warning):
-            invoice_id.signal_workflow('invoice_open')
+            invoice_id.action_invoice_open()
 
     def test_partner_with_late_payments(self):
         """This test validate that the partner has not late payments
@@ -79,7 +80,7 @@ class TestCreditLimits(common.TestCommon):
              'invoice_id': invoice_id.id,
              'name': 'product that cost 100', })
         # Validate the invoice.
-        invoice_id.signal_workflow('invoice_open')
+        invoice_id.action_invoice_open()
 
         # At this moment there are late paymets since the invoice
         # was validate one day before
@@ -101,4 +102,4 @@ class TestCreditLimits(common.TestCommon):
         # Validate the invoice, should fail, couse there are late payments
         # since the invoice 1 was validate with curent day minus 2 days
         with self.assertRaises(exceptions.Warning):
-            invoice_id2.signal_workflow('invoice_open')
+            invoice_id2.action_invoice_open()

--- a/partner_credit_limit/tests/test_sale_credit_limit.py
+++ b/partner_credit_limit/tests/test_sale_credit_limit.py
@@ -76,7 +76,7 @@ class TestSalesCreditLimits(common.TestCommon):
              'invoice_id': invoice_id.id,
              'name': 'product that cost 100', })
         # Validate the invoice.
-        invoice_id.signal_workflow('invoice_open')
+        invoice_id.action_invoice_open()
 
         # At this moment there are late paymets since the invoice
         # was validate one day before


### PR DESCRIPTION
Fixed errors in the tests, removed workflow call from account invoice that no longer exists in v10.

Also corrected operation of the module, since the function that is responsible for checking if it exceeds the credit limits was never being called, so that the credit limit was never validated.

Dummy for test vauxoo/imeqmo#38