### PR TITLE
[FIX] commission_payment: Fixing date conflict

### DIFF
--- a/commission_payment/demo/account_invoice_demo.xml
+++ b/commission_payment/demo/account_invoice_demo.xml
@@ -177,7 +177,7 @@
         <record id="account_move_00" model="account.move">
             <field name="journal_id" ref="account.sales_journal"/>
             <field name="period_id" ref="account.period_1"/>
-            <field name="date" eval="time.strftime('%Y')+'-01-01'"/>
+            <field name="date" eval="time.strftime('%Y')+'-'+str((int(time.strftime('%m'))%12)+1)+'-01'"/>
         </record>
         <record id="aml_rec_debit" model="account.move.line">
             <field name="name">Receivable - Debit</field>
@@ -200,7 +200,7 @@
         <record id="account_move_01" model="account.move">
             <field name="journal_id" ref="account.bank_journal"/>
             <field name="period_id" ref="account.period_1"/>
-            <field name="date" eval="time.strftime('%Y')+'-01-30'"/>
+            <field name="date" eval="time.strftime('%Y')+'-'+str((int(time.strftime('%m'))%12)+1)+'-27'"/>
         </record>
         <record id="aml_bnk_debit" model="account.move.line">
             <field name="name">Bank</field>

--- a/commission_payment/tests/test_commission_payment.py
+++ b/commission_payment/tests/test_commission_payment.py
@@ -27,6 +27,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ###############################################################################
 import time
+from datetime import date
 from openerp.tests.common import TransactionCase
 
 
@@ -132,8 +133,9 @@ class TestCommission(TransactionCase):
         cp_brw = self.cp_model.browse(cur, uid, cp_id)
         cp_brw.action_draft()
 
-        cp_brw.date_start = time.strftime('%Y')+'-01-01'
-        cp_brw.date_stop = time.strftime('%Y')+'-01-31'
+        month = str((date.today().month % 12) + 1)
+        cp_brw.date_start = time.strftime('%Y') + '-' + month + '-01'
+        cp_brw.date_stop = time.strftime('%Y') + '-' + month + '-28'
         cp_brw.unknown_salespeople = True
 
         aml_ids = [self.ref('commission_payment.aml_rec_debit')]


### PR DESCRIPTION
The date of the account.move is modified, for that it does not coincide with that of the invoices. To fix the conflict  in the test, when the month is January.