### PR TITLE
Set installable False the hr_payroll_multicompany and sync_youtube modules

### DIFF
--- a/hr_payroll_multicompany/__openerp__.py
+++ b/hr_payroll_multicompany/__openerp__.py
@@ -24,7 +24,7 @@
 #
 {
     "name": "HR rules multi company",
-    "version": "10.0.0.1.6",
+    "version": "8.0.0.1.6",
     "author": "Vauxoo",
     "category": "Localization/Mexico",
     "website": "http://www.vauxoo.com/",
@@ -42,6 +42,6 @@
     "js": [],
     "css": [],
     "qweb": [],
-    "installable": True,
+    "installable": False,
     "auto_install": False,
 }

--- a/sync_youtube/__openerp__.py
+++ b/sync_youtube/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     "name": "Sign Youtube",
-    "version": "10.0.0.0.6",
+    "version": "8.0.0.0.6",
     "author": "Vauxoo",
     "category": "",
     "website": "http://www.vauxoo.com",
@@ -37,6 +37,6 @@
     "js": [],
     "css": [],
     "qweb": [],
-    "installable": True,
+    "installable": False,
     "auto_install": False,
 }


### PR DESCRIPTION
This two modules were recently set to installable True,
This origin errors in another instances using 10.0 addons vauxoo.

This PR is a revert PR that set both modules to installable False.
These modules need to be re-evaluate to be then updated to new API or to be deleted if they are not needed anymore.