### PR TITLE
[FIX] sale_margin_percentage: migrating to new sale.config.settings view

### DIFF
--- a/sale_margin_percentage/views/sale_config_settings_views.xml
+++ b/sale_margin_percentage/views/sale_config_settings_views.xml
@@ -1,13 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="view_sale_config_settings" model="ir.ui.view">
+    <record id="view_sale_config_settings_inherit" model="ir.ui.view">
         <field name="name">sale.margin.percentage.settings</field>
         <field name="model">sale.config.settings</field>
-        <field name="inherit_id" ref="sale.view_sales_config"/>
+        <field name="inherit_id" ref="sale.sale_config_settings_view_form_inherit_sale"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='module_sale_margin']" position="after">
-                <field name="margin_threshold" attrs="{'invisible': [('module_sale_margin', '=', 0)]}"/>
+            <xpath expr="//div[@class='row mt16 o_settings_container'][2]" position="inside">
+                <div class="col-xs-12 col-md-6 o_setting_box" attrs="{'invisible': [('module_sale_margin' ,'=', False)]}" groups="base.group_no_one">
+                    <div class="o_setting_left_pane"/>
+                    <div class="o_setting_right_pane">
+                        <label string="Margin Threshold"/>
+                        <div class="text-muted">
+                            Minimun margin percentage allowed
+                        </div>
+                        <div class="text-muted">
+                            <field name="margin_threshold"/>
+                        </div>
+                    </div>
+                </div>
             </xpath>
        </field>
     </record>


### PR DESCRIPTION
Summary
-------------

The `sale.config.settings` view was changed completely after v10.0, in this fix we have moved `margin_threshold` field from old sale settings view to the new one.