### PR TITLE
[FIX] stock_account_unfuck: Use price_unit of move_orig_ids field to calculate standard_price of product

### DIFF
--- a/stock_account_unfuck/models/stock.py
+++ b/stock_account_unfuck/models/stock.py
@@ -21,7 +21,8 @@ class StockMove(models.Model):
             qty_available = move.product_id.product_tmpl_id.qty_available
             if (qty_available + move.product_qty * signal) == 0:
                 continue
-            orig = move.origin_returned_move_id or move.move_dest_id
+            orig = (move.origin_returned_move_id or
+                    (move.move_orig_ids and move.move_orig_ids[0]))
             average_valuation_price = sum(
                 [quant.qty * (orig.price_unit if orig else quant.cost)
                  for quant in move.reserved_quant_ids])


### PR DESCRIPTION
Use price_unit of move_orig_ids field insteed of price_unit of move_dest_id field to calculate standard_price of product.

Close [Vauxoo/lodigroup#694](https://github.com/Vauxoo/lodigroup/pull/694)