### PR TITLE
[8.0] fixed bug mrp_subproduction : [["state","not in",["draft"]]]

### DIFF
--- a/mrp_subproduction/mrp_view.xml
+++ b/mrp_subproduction/mrp_view.xml
@@ -14,6 +14,7 @@
                         <field name="name"/>
                         <field name="date_planned"/>
                         <field name="product_id"/>
+                        <field name="state" invisible="1"/>
                         <field name="product_qty"/>
                         <field name="product_uom"/>
                         <field name="product_subproduction_qty_line_real"/>
@@ -29,6 +30,7 @@
                         <tree string="Superproductions">
                             <field name="name"/>
                             <field name="date_planned"/>
+                            <field name="state" invisible="1"/>
                             <field name="product_id"/>
                             <field name="product_qty"/>
                             <field name="product_uom"/>


### PR DESCRIPTION
state not found when add Mrp on superproduction or subproduction it because state not defined on tree view