### PR TITLE
[IMP] account_move_line_base_tax: Removed amount validation to diot

### DIFF
--- a/account_move_line_base_tax/account.py
+++ b/account_move_line_base_tax/account.py
@@ -24,8 +24,6 @@
 #
 ##############################################################################
 from openerp.osv import osv, fields
-from openerp.exceptions import ValidationError
-from openerp.tools.translate import _
 
 
 class AccountMoveLine(osv.Model):
@@ -50,29 +48,6 @@ class AccountMoveLine(osv.Model):
             return {'value': {'tax_id_secondary': tax_acc[0]}}
         else:
             return {'value': {}}
-
-    def write(self, cr, uid, ids, vals, context=None, check=True,
-              update_check=True):
-        if context is None:
-            context = {}
-        if not ids:
-            return True
-        if isinstance(ids, (int, long)):
-            ids = [ids]
-
-        res = super(AccountMoveLine, self).write(
-            cr, uid, ids, vals, context=context, check=check,
-            update_check=update_check)
-        for line in self.browse(cr, uid, ids, context=context):
-            if (not line.tax_id_secondary or
-                    line.tax_id_secondary.type_tax_use != 'purchase'):
-                continue
-            cat_tax = line.tax_id_secondary.tax_category_id
-            if cat_tax and cat_tax.name == 'IVA-RET' and line.credit <= 0 and not line.not_move_diot:  # noqa
-                raise ValidationError(_(
-                    'The lines with tax of purchase, need have a value '
-                    'in the credit. \nTax: %s' % line.tax_id_secondary.name))
-        return res
 
     def onchange_account_id(
             self, cr, uid, ids, account_id=False, partner_id=False,

--- a/account_move_line_base_tax/i18n/es.po
+++ b/account_move_line_base_tax/i18n/es.po
@@ -38,20 +38,6 @@ msgid "Amount base without amount tax"
 msgstr "Monto base sin el monto del impuesto"
 
 #. module: account_move_line_base_tax
-#: code:addons/account_move_line_base_tax/account.py:72
-#, python-format
-msgid "The lines with tax of purchase, need have a value in the credit."
-msgstr ""
-"Las lineas con impuesto de compra, necesitan tener valor en el credito."
-
-#. module: account_move_line_base_tax
-#: code:addons/account_move_line_base_tax/account.py:68
-#, python-format
-msgid "The lines with tax of purchase, need have a value in the amount base."
-msgstr ""
-"Las lineas con impuesto de compra, necesitan tener valor en el monto base."
-
-#. module: account_move_line_base_tax
 #: code:addons/account_move_line_base_tax/account.py:68
 #: code:addons/account_move_line_base_tax/account.py:72
 #, python-format
@@ -80,7 +66,7 @@ msgid ""
 "considered."
 msgstr ""
 "Si este campo esta activo, aunque el movimiento tenga datos del Diot, no "
-"será conciderado."
+"será considerado."
 
 #. module: account_move_line_base_tax
 #: field:account.move.line,tax_id_secondary:0


### PR DESCRIPTION
movements

In this module was added a validation to verify that movements that will
be considered in DIOT report must have amount in the credit. But to invoice
refunds the logic change, and the validation is incorrect.

The DIOT report already have the validation to movements with amount 0,
if this are created manually. By this reason is removed the validation
here.