### PR TITLE
8.0 account_anglo_saxon_stock_move_purchase migration

### DIFF
--- a/account_anglo_saxon_stock_move_purchase/__openerp__.py
+++ b/account_anglo_saxon_stock_move_purchase/__openerp__.py
@@ -23,7 +23,7 @@
 ###############################################################################
 {
     "name": "Account Anglo-Saxon Stock Move Purchase",
-    "version": "8.0.0.1.6",
+    "version": "8.0.0.1.7",
     "author": "Vauxoo",
     "category": "",
     "website": "http://www.vauxoo.com/",

--- a/account_anglo_saxon_stock_move_purchase/migrations/8.0.0.1.7/pre-migration.py
+++ b/account_anglo_saxon_stock_move_purchase/migrations/8.0.0.1.7/pre-migration.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+__name__ = "Setting PurchaseId related field into DB as storable field"
+
+
+def migrate(cr, version):
+    cr.execute("""
+        ALTER TABLE account_move_line
+        ADD COLUMN purchase_id integer;
+    """)
+
+    cr.execute("""
+        ALTER TABLE account_move_line
+        ADD CONSTRAINT account_move_line_purchase_id_fkey
+        FOREIGN KEY (purchase_id)
+        REFERENCES purchase_order(id)
+        ON DELETE SET NULL;
+    """)
+
+    cr.execute("""
+        UPDATE account_move_line aml1
+        SET purchase_id = view.po_id
+        FROM (
+            SELECT aml.id AS aml_id, pol.order_id AS po_id
+            FROM account_move_line aml
+            INNER JOIN stock_move sm ON aml.sm_id = sm.id
+            INNER JOIN purchase_order_line pol ON sm.purchase_line_id = pol.id
+        ) AS view
+        WHERE view.aml_id = aml1.id;;
+    """)


### PR DESCRIPTION
When a functional field moves from store=False to store=True,
`at -u all -d $BD ` it takes too long to perform that task, 
then a migration script prior to perform the update of the module
is execute to avoid the huge amount of time be wasted when updating.
