### PR TITLE
[8.0] Fix subtotal considering taxes with tax included in price

### DIFF
--- a/invoice_discount/model/invoice.py
+++ b/invoice_discount/model/invoice.py
@@ -50,8 +50,12 @@ class AccountInvoiceLine(osv.osv):
         """
         context = context or {}
         res = {}
+        tax_obj = self.pool.get('account.tax')
         for line in self.browse(cr, uid, ids, context=context):
-            res[line.id] = (line.quantity * line.price_unit)
+            taxes = tax_obj.compute_all(
+                cr, uid, line.invoice_line_tax_id, line.price_unit,
+                line.quantity)
+            res[line.id] = taxes['total']
         return res
 
     def _get_discount(self, cr, uid, ids, args, field_name, context=None):


### PR DESCRIPTION
This PR fix an issue in the module invoice_discount that was generated when you generate an invoice with taxes that is configured with tax included in price. When you generate an invoice in odoo-mexico-v2 the subtotal and total were the same.