### PR TITLE
[IMP] This method will avoid that Journal Entries created in an invoice - US#1742

### DIFF
--- a/account_anglo_saxon_stock_move/model/invoice.py
+++ b/account_anglo_saxon_stock_move/model/invoice.py
@@ -45,6 +45,14 @@ OPERATORS = {
 class AccountInvoice(models.Model):
     _inherit = "account.invoice"
 
+    def inv_line_characteristic_hashcode(self, invoice_line):
+        """Including `sm_id` key as part of a hash in the invoice line will
+        prevent lines form same products to be group if they do not share the
+        same ail.move_id foreign_key"""
+        res = super(AccountInvoice, self).inv_line_characteristic_hashcode(
+            invoice_line)
+        return "%s-%s" % (res, invoice_line.get('sm_id', 'False'))
+
     @api.model
     def line_get_convert(self, line, part, date):
         res = super(AccountInvoice, self).line_get_convert(line, part, date)


### PR DESCRIPTION
This method will avoid that Journal Entries created in an invoice 
get group only by Product & Account, there are cases where user can
group in a same invoice Products that were delivered/received in several
Pickings, and Odoo by default will create only one Journal Entry for
each product. Now they will be grouped by Product & Account & StockMove_id
which will make the process of reconciling accrual more accurate, and
will avoid messing several StockMove's into a single Journal Entry

Before:
=======
<img width="899" alt="journal_items_-_odoo2" src="https://user-images.githubusercontent.com/7598010/30995793-59411b0a-a48a-11e7-8b01-e27012d76b8f.png">

After:
======
<img width="839" alt="elementos_diario_-_odoo" src="https://user-images.githubusercontent.com/7598010/30995802-69aca572-a48a-11e7-9762-e7cdb3735197.png">
