### PR TITLE
[FIX] supplier_invoice_number_unique: fixed the trace back triggered by the unique constraint at the invoice validation event task#9288

### DIFF
--- a/supplier_invoice_number_unique/i18n/es.po
+++ b/supplier_invoice_number_unique/i18n/es.po
@@ -42,3 +42,10 @@ msgstr "¡Acción no válida!"
 #: model:ir.model,name:supplier_invoice_number_unique.model_account_invoice
 msgid "Invoice"
 msgstr "Factura"
+
+#. module: supplier_invoice_number_unique
+#: sql_constraint:account.invoice:0
+#: code:addons/supplier_invoice_number_unique/model/account_invoice.py:51
+#, python-format
+msgid "Error you can not validate the invoice with supplier invoice number duplicated."
+msgstr "Error no puedes validar facturas con número de factura de proveedor duplicado"

--- a/supplier_invoice_number_unique/tests/test_supplier_invoice_reference.py
+++ b/supplier_invoice_number_unique/tests/test_supplier_invoice_reference.py
@@ -7,8 +7,10 @@
 #    info Vauxoo (info@vauxoo.com)
 #    Coded by: Luis Torres (luis_t@vauxoo.com)
 # ##########################################################################
-from openerp.tests.common import TransactionCase
+
 from openerp import workflow
+from openerp import exceptions
+from openerp.tests.common import TransactionCase
 
 
 class TestReferenceSupplierInvoiceUnique(TransactionCase):
@@ -42,8 +44,8 @@ class TestReferenceSupplierInvoiceUnique(TransactionCase):
         self.assertEquals(
             invoice.state, 'open', 'This invoice has not state in open')
         with self.assertRaisesRegexp(
-                ValueError,
-                'account_invoice_unique_supplier_invoice_number_strip'):
+                exceptions.Warning, 'Error you can not validate the invoice '
+                'with supplier invoice number duplicated.'):
             invoice2.signal_workflow('invoice_open')
 
     def test_12_validate_invoice_with_ref_unique_hyphen(self):
@@ -58,8 +60,8 @@ class TestReferenceSupplierInvoiceUnique(TransactionCase):
         self.assertEquals(
             invoice.state, 'open', 'This invoice has not state in open')
         with self.assertRaisesRegexp(
-                ValueError,
-                'account_invoice_unique_supplier_invoice_number_strip'):
+                exceptions.Warning, 'Error you can not validate the invoice '
+                'with supplier invoice number duplicated.'):
             invoice2.signal_workflow('invoice_open')
 
     def test_13_validate_invoice_with_ref_unique_space(self):
@@ -74,8 +76,8 @@ class TestReferenceSupplierInvoiceUnique(TransactionCase):
         self.assertEquals(
             invoice.state, 'open', 'This invoice has not state in open')
         with self.assertRaisesRegexp(
-                ValueError,
-                'account_invoice_unique_supplier_invoice_number_strip'):
+                exceptions.Warning, 'Error you can not validate the invoice '
+                'with supplier invoice number duplicated.'):
             invoice2.signal_workflow('invoice_open')
 
     def test_20_validate_invoice_without_reference(self):
@@ -112,8 +114,8 @@ class TestReferenceSupplierInvoiceUnique(TransactionCase):
         self.assertEquals(
             invoice.state, 'open', 'This invoice has not state in open')
         with self.assertRaisesRegexp(
-                ValueError,
-                'account_invoice_unique_supplier_invoice_number_strip'):
+                exceptions.Warning, 'Error you can not validate the invoice '
+                'with supplier invoice number duplicated.'):
             invoice2.signal_workflow('invoice_open')
 
     def test_40_validate_invoice_with_reference_duplicated_in_cancel(self):
@@ -169,6 +171,6 @@ class TestReferenceSupplierInvoiceUnique(TransactionCase):
         self.assertEquals(
             invoice.state, 'open', 'This invoice has not state in open')
         with self.assertRaisesRegexp(
-                ValueError,
-                'account_invoice_unique_supplier_invoice_number_strip'):
+                exceptions.Warning, 'Error you can not validate the invoice '
+                'with supplier invoice number duplicated.'):
             invoice2.signal_workflow('invoice_open')


### PR DESCRIPTION
Fixed by setting a deferred constraint.

Idea taken from the issue https://github.com/odoo/odoo/issues/15395

https://www.postgresql.org/docs/9.1/static/sql-set-constraints.html

DUMMY PR https://github.com/Vauxoo/wohlert/pull/93

TEST INSTANCE
http://dev.lodigroup.com:32855