### PR TITLE
[FIX] product_cost_usd: replace pricelist in unit test

### DIFF
--- a/product_cost_usd/tests/test_standard_price_usd.py
+++ b/product_cost_usd/tests/test_standard_price_usd.py
@@ -28,9 +28,10 @@ class TestStandardPriceUsd(TransactionCase):
                 })]
         })
         self.pricelist_15_mxn = self.pricelist_15_usd.copy({
-            'name': 'Pricelist 15% USD',
+            'name': 'Pricelist 15% MXN',
             'currency_id': self.mxn.id})
-        self.pricelist_id = self.ref('product.list0')
+        self.pricelist = self.env['product.pricelist'].create({
+            'name': 'Pricelist Demo'})
 
     def set_standard_price_usd(self, price):
         self.assertTrue(self.product.seller_ids)
@@ -117,7 +118,7 @@ class TestStandardPriceUsd(TransactionCase):
                 'state': 'draft',
                 'product_id': self.product.id})],
             'partner_id': self.partner.id,
-            'pricelist_id': self.pricelist_id})
+            'pricelist_id': self.pricelist.id})
         # Confirm the sale order.
         sale_order.action_confirm()
         # Verify that margin field gets bind with the value.

--- a/product_cost_usd/tests/test_standard_price_usd.py
+++ b/product_cost_usd/tests/test_standard_price_usd.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from odoo.tests.common import TransactionCase
 from odoo.exceptions import ValidationError
-from odoo.tools import float_round
+from odoo.tools import float_round, float_compare
 from odoo import fields
 
 
@@ -45,7 +45,9 @@ class TestStandardPriceUsd(TransactionCase):
         expected_price = float_round(
             product.standard_price_usd * 1.15,
             precision_rounding=self.usd.rounding)
-        self.assertEqual(product.price, expected_price)
+        self.assertEqual(
+            float_compare(product.price, expected_price, precision_digits=2),
+            0, "Product price should be %s" % product.price)
 
     def test_02(self):
         """ Test a MXN pricelist based on cost in usd. """
@@ -55,7 +57,9 @@ class TestStandardPriceUsd(TransactionCase):
         expected_price = float_round(
             (product.standard_price_usd * 1.15) * mxn_rate,
             precision_rounding=self.mxn.rounding)
-        self.assertEqual(product.price, expected_price)
+        self.assertEqual(
+            float_compare(product.price, expected_price, precision_digits=2),
+            0, "Product price should be %s" % product.price)
 
     def test_03(self):
         """ Test constraint check_cost_and_price. """
@@ -100,8 +104,9 @@ class TestStandardPriceUsd(TransactionCase):
         margin = float_round(
             expected_price - expected_cost,
             precision_rounding=self.mxn.rounding)
-        msg = "Sale order margin should be %s" % margin
-        self.assertEqual(sale_order.margin, margin, msg)
+        self.assertEqual(
+            float_compare(sale_order.margin, margin, precision_digits=2),
+            0, "Sale order margin should be %s" % margin)
 
     def test_sale_margin_normal(self):
         """ Test the sale margin module using a pricelist without cost in


### PR DESCRIPTION
Summary
-------------

The Default Pricelist (`product.list0`) is not a data/demo is a data/data, is not a good practice use it in unit test beacause might be modified by other modules and could cause a fail in unit tests.

**To Fix:**
![captura de pantalla de 2017-10-17 14-55-37](https://user-images.githubusercontent.com/5335402/31686485-dd3394b8-b34b-11e7-8c1a-5fa5caa5a6c6.png)


_Also, now is used `float_compare` to fix:_
![captura de pantalla de 2017-10-17 14-55-40](https://user-images.githubusercontent.com/5335402/31686493-e2e5b4f4-b34b-11e7-8821-d973698aed72.png)

