### PR TITLE
[FIX] Bad convertion of parammeters in sql execution

### DIFF
--- a/user_story/model/timesheet.py
+++ b/user_story/model/timesheet.py
@@ -66,9 +66,7 @@ class AnalyticLine(osv.Model):
                    SELECT array_agg(work.hr_analytic_timesheet_id) as a_id
                    FROM project_task AS task
                    INNER JOIN project_task_work AS work ON work.task_id=task.id
-                   WHERE task.id %(op)s %(tids)s
-                   ''', {'op': (len(ids) == 1) and '=' or 'in',
-                         'tids': (len(ids) == 1) and ids[0] or tuple(ids)})
+                   WHERE task.id in %s''', (tuple(ids),))
         res = cr.dictfetchall()
         if res:
             res = res[0].get('a_id', []) or []


### PR DESCRIPTION
In order to fix 
The operator `=` is bad parsing using the execute method feature of passing params
It's adding an extra quotes `'='`
![image](https://user-images.githubusercontent.com/10233975/32735790-4b40c33a-c85b-11e7-9a33-04daf0068a9b.png)


