### PR TITLE
[REF] aging_due_report: changing the browse line on the wizard becaus… task#16,730

### DIFF
--- a/aging_due_report/wizard/wizard.py
+++ b/aging_due_report/wizard/wizard.py
@@ -269,7 +269,7 @@ class AccountAgingPartnerWizard(models.TransientModel):
 
         for key, val in aml_data_groups.iteritems():
             partner_id, reconcile_id = key
-            aml_lines = aml_obj.browse(val)
+            aml_lines = aml_obj.browse(val.values.tolist())
             if reconcile_id:
                 # TODO: This process can be improve by using the approach reach
                 # in commission_payment


### PR DESCRIPTION
…e with the change of version of pandas previously the indexes on pandas where a normal array and was used for the browse but now pandas stores the indexes on Int64Index object and is needed to convert it to a normal array.

This change fix this error
![image](https://user-images.githubusercontent.com/17324113/34635248-822019e8-f252-11e7-839e-4f823ce03cc1.png)
that was heppening on this report
https://drive.google.com/a/vauxoo.com/file/d/1zQdylVV2DlDG_ZESuo_ls9GqAqe3Xl2f/view?usp=drivesdk
with this configuration
https://drive.google.com/a/vauxoo.com/file/d/1a-Vpl7rDfzjvjZf9gBL7XhQ1ikfBn4Ur/view?usp=drivesdk