### PR TITLE
[ADD] email_show_only_changes: this module shows only the values chan…

### DIFF
--- a/email_show_only_changes/__init__.py
+++ b/email_show_only_changes/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/email_show_only_changes/__manifest__.py
+++ b/email_show_only_changes/__manifest__.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+{
+    "name": "Email Show Only Changes",
+    "version": "11.0.0.0.1",
+    "author": "Vauxoo",
+    "category": "",
+    "website": "http://www.vauxoo.com/",
+    "license": "LGPL-3",
+    "depends": [
+        "mail",
+    ],
+    "demo": [],
+    "data": [],
+    "installable": True,
+}

--- a/email_show_only_changes/models/__init__.py
+++ b/email_show_only_changes/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import mail_thread

--- a/email_show_only_changes/models/mail_thread.py
+++ b/email_show_only_changes/models/mail_thread.py
@@ -1,0 +1,33 @@
+# coding: utf-8
+
+from odoo import models, api
+
+
+class MailThread(models.AbstractModel):
+    _inherit = 'mail.thread'
+
+    @api.multi
+    def _message_track(self, tracked_fields, initial):
+        """ For a given record, fields to check (column name, column info)
+        and initial values, return a structure that is a tuple containing :
+
+        - a set of updated column names
+        - a list of changes (old value, new value, column name, column info)
+        """
+        self.ensure_one()
+        changes = super(MailThread, self)._message_track(
+            tracked_fields, initial)[0]
+        tracking_value_ids = []
+        track_obj = self.env['mail.tracking.value']
+
+        for col_name, col_info in tracked_fields.items():
+            initial_value = initial[col_name]
+            new_value = getattr(self, col_name)
+
+            if new_value != initial_value and (new_value or initial_value):
+                tracking = track_obj.create_tracking_values(
+                    initial_value, new_value, col_name, col_info)
+                if tracking:
+                    tracking_value_ids.append([0, 0, tracking])
+
+        return changes, tracking_value_ids


### PR DESCRIPTION
…ged of an object on email, instead of all tracked values, even if it has track_visibility set as always

Before:
![image](https://user-images.githubusercontent.com/17324113/38059351-60891b5e-32a3-11e8-8002-e65ddf8ea99a.png)

After:
![image](https://user-images.githubusercontent.com/17324113/38059364-64b13162-32a3-11e8-8054-df2dff600140.png)
