### PR TITLE
[11.0] Fixing issues #1274 #1275

### DIFF
--- a/account_analytic_policy/model/account_move_line.py
+++ b/account_analytic_policy/model/account_move_line.py
@@ -32,26 +32,30 @@ class AccountMoveLine(models.Model):
 
     @api.multi
     def _is_analytic_policy_ok(self, vals):
-        account = (self.env['account.account'].browse(vals['account_id'])
-                   if ('account_id' in vals) else self.account_id)
-        analytic = (self.env['account.analytic.account'].browse(
-            vals['analytic_account_id'])
-            if ('analytic_account_id' in vals) else self.analytic_account_id)
-        policy = account.analytic_policy
-        if not policy or policy == 'optional':
-            return True
-        if policy == 'never' and analytic:
-            raise UserError(_(
-                'You cannot use analytic accounts on a move line with Analytic '
-                'Policy "Never" contact the account manager or fix the '
-                'account configuration or pick another account.\n\n') +
-                            '%s' % account.name_get())
-        if policy == 'always' and not analytic:
-            raise UserError(_(
-                'You must use analytic accounts on a move line with Analytic '
-                'Policy "Always" contact the account manager or fix the '
-                'account configuration or pick another account.\n\n') +
-                            '%s' % account.name_get())
+        account = self.env['account.account']
+        analytic = self.env['account.analytic.account']
+        for record in self:
+            account = (account.browse(vals['account_id'])
+                       if ('account_id' in vals) else record.account_id)
+            analytic = (
+                analytic.browse(
+                    vals['analytic_account_id']) if ('analytic_account_id' in vals)
+                else record.analytic_account_id)
+            policy = account.analytic_policy
+            if not policy or policy == 'optional':
+                continue
+            if policy == 'never' and analytic:
+                raise UserError(_(
+                    'You cannot use analytic accounts on a move line with Analytic '
+                    'Policy "Never" contact the account manager or fix the '
+                    'account configuration or pick another account.\n\n') +
+                                '%s' % account.name_get())
+            if policy == 'always' and not analytic:
+                raise UserError(_(
+                    'You must use analytic accounts on a move line with Analytic '
+                    'Policy "Always" contact the account manager or fix the '
+                    'account configuration or pick another account.\n\n') +
+                                '%s' % account.name_get())
         return True
 
     @api.model

--- a/payment_term_type/tests/test_payment_term_type.py
+++ b/payment_term_type/tests/test_payment_term_type.py
@@ -13,7 +13,7 @@ class TestPaymentTermType(TransactionCase):
     def setUp(self):
         super(TestPaymentTermType, self).setUp()
         self.company = self.env.ref('base.main_company')
-        self.config_obj = self.env['account.config.settings']
+        self.config_obj = self.env['ir.config_parameter']
         self.pay_term_obj = self.env['account.payment.term']
 
     def test_payment_term_type_cash(self):
@@ -38,8 +38,11 @@ class TestPaymentTermType(TransactionCase):
         """This test validates that payment type is equal to cash if payment
         terms is based on quantity of payments and exists only one record.
         """
-        payment_type = self.config_obj.get_default_payment_term_type('bqp')
-        self.assertEqual(payment_type['payment_type'],
+        self.config_obj.set_param(
+            'account.payment_term_type', 'bqp')
+        payment_type = self.config_obj.get_param(
+            'account.payment_term_type', default='bqp')
+        self.assertEqual(payment_type,
                          'bqp',
                          'Payment Type should be equal bqp')
         pay_term_id = self.pay_term_obj.create({
@@ -56,8 +59,11 @@ class TestPaymentTermType(TransactionCase):
         """This test validates that payment type is equal to credit if payment
         terms is based on quantity of payments and exists two or more records.
         """
-        payment_type = self.config_obj.get_default_payment_term_type('bqp')
-        self.assertEqual(payment_type['payment_type'],
+        self.config_obj.set_param(
+            'account.payment_term_type', 'bqp')
+        payment_type = self.config_obj.get_param(
+            'account.payment_term_type', default='bqp')
+        self.assertEqual(payment_type,
                          'bqp',
                          'Payment Type should be equal bqp')
         pay_term_id = self.pay_term_obj.create({
@@ -84,13 +90,11 @@ class TestPaymentTermType(TransactionCase):
         """This test validates that payment type is equal to cash if payment
         terms is based on date of payments and days equal to 0
         """
-        config = self.config_obj.create({
-            'company_id': self.company.id,
-            'payment_type': 'bdp',
-        })
-        config.set_default_payment_term_type()
-        payment_type = config.get_default_payment_term_type('bdp')
-        self.assertEqual(payment_type['payment_type'],
+        self.config_obj.set_param(
+            'account.payment_term_type', 'bdp')
+        payment_type = self.config_obj.get_param(
+            'account.payment_term_type', default='bdp')
+        self.assertEqual(payment_type,
                          'bdp',
                          'Payment Type should be equal bdp')
         pay_term_id = self.pay_term_obj.create({
@@ -107,13 +111,11 @@ class TestPaymentTermType(TransactionCase):
         """This test validates that payment type is equal to credit if payment
         terms is based on date of payments and days is greater than 0
         """
-        config = self.config_obj.create({
-            'company_id': self.company.id,
-            'payment_type': 'bdp',
-        })
-        config.set_default_payment_term_type()
-        payment_type = config.get_default_payment_term_type('bdp')
-        self.assertEqual(payment_type['payment_type'],
+        self.config_obj.set_param(
+            'account.payment_term_type', 'bdp')
+        payment_type = self.config_obj.get_param(
+            'account.payment_term_type', default='bdp')
+        self.assertEqual(payment_type,
                          'bdp',
                          'Payment Type should be equal bdp')
         pay_term_id = self.pay_term_obj.create({


### PR DESCRIPTION
#1274 

The writing process calls to _is_analytic_policy_ok method sending more than one recordset in some operations. To avoid getting a singleton error, we are using a loop over "self" object to be sure we are asking for values to a single object. 

 #1275
 Odoo removed the custom configuration models by models in the current version. The rest doesn't need an explanation.

fix #1274 
fix #1275