### PR TITLE
[FIX] account_move_report:  Print time corrected according to time zone in report. vx#25102

### DIFF
--- a/account_move_report/views/account_move_report.xml
+++ b/account_move_report/views/account_move_report.xml
@@ -29,7 +29,7 @@
                             </div>
                         </div>
                         <div class="text-right">
-                            <p>Printing Date: <span t-esc="time.strftime('%Y-%m-%d %H:%M:%S')"/></p>
+                            <p>Printing Date: <span t-esc="context_timestamp(datetime.datetime.now()).strftime('%Y-%m-%d %H:%M')"/></p>
                         </div>
                     </div>
                     <t t-if="o.line_ids">


### PR DESCRIPTION
When you check any book entry or click on the seat

The Print option appears and shows you the option:


* Account Move Report

- When selecting any of the report, the system generates a PDF where the print time shown is not correct

**TODO**
- [x] Modified Account Move Report