### PR TITLE
[REF] product_cost_usd: standard_price_usd as compute field

### DIFF
--- a/product_cost_usd/i18n/es.po
+++ b/product_cost_usd/i18n/es.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0+e\n"
+"Project-Id-Version: Odoo Server 11.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-06 18:52+0000\n"
-"PO-Revision-Date: 2017-02-06 18:52+0000\n"
+"POT-Creation-Date: 2018-07-04 21:18+0000\n"
+"PO-Revision-Date: 2018-07-04 21:18+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,14 +16,16 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_cost_usd
+#: model:ir.model.fields,field_description:product_cost_usd.field_product_product_standard_price_usd
 #: model:ir.model.fields,field_description:product_cost_usd.field_product_template_standard_price_usd
 msgid "Cost in USD"
 msgstr "Costo en Dólares"
 
 #. module: product_cost_usd
+#: model:ir.model.fields,help:product_cost_usd.field_product_product_standard_price_usd
 #: model:ir.model.fields,help:product_cost_usd.field_product_template_standard_price_usd
-msgid "Price cost of the product in USD currency"
-msgstr "Precio coste del producto en moneda USD"
+msgid "Price cost of the product expressed in USD currency. To modify this cost you must go to the Purchasing tab, suppliers section and add/create a line with the cost of the product."
+msgstr "Precio de coste del producto expresado en USD. Para modificar este costo debe ir a la pestaña Compras, sección Proveedores y agregar/crear una línea con el costo del producto."
 
 #. module: product_cost_usd
 #: model:ir.model,name:product_cost_usd.model_product_pricelist
@@ -44,22 +46,4 @@ msgstr "Plantilla de producto"
 #: model:ir.model,name:product_cost_usd.model_sale_order_line
 msgid "Sales Order Line"
 msgstr "Línea de pedido de venta"
-
-#. module: product_cost_usd
-#: code:addons/product_cost_usd/models/product.py:38
-#, python-format
-msgid "You cannot create or modify a product if the cost in USD is less than the supplier list price.\n"
-"\n"
-"- Supplier list price = %s\n"
-"- Cost in USD = %s"
-msgstr "No puede crear o modificar un producto si el costo en USD es menor que el precio del proveedores..\n"
-"\n"
-"- Precio del proveedor = %s\n"
-"- Costo en Dólares = %s"
-
-#. module: product_cost_usd
-#: code:addons/product_cost_usd/models/product.py:33
-#, python-format
-msgid "You must have at least one supplier with price in USD before assign a Cost in USD"
-msgstr "Debe tener al menos un proveedor con precio en Dólares antes de asignar un Costo en Dólares a el producto"
 

--- a/product_cost_usd/tests/test_standard_price_usd.py
+++ b/product_cost_usd/tests/test_standard_price_usd.py
@@ -35,8 +35,9 @@ class TestStandardPriceUsd(TransactionCase):
 
     def set_standard_price_usd(self, price):
         self.assertTrue(self.product.seller_ids)
-        self.product.seller_ids[0].write({'currency_id': self.usd.id})
-        self.product.write({'standard_price_usd': price})
+        self.product.seller_ids[0].write({
+            'currency_id': self.usd.id,
+            'price': price})
 
     def test_01(self):
         """ Test USD pricelist based on cost in usd. """
@@ -60,20 +61,6 @@ class TestStandardPriceUsd(TransactionCase):
         self.assertEqual(
             float_compare(product.price, expected_price, precision_digits=2),
             0, "Product price should be %s" % product.price)
-
-    def test_03(self):
-        """ Test constraint check_cost_and_price. """
-        with self.assertRaisesRegexp(
-                ValidationError,
-                'You must have at least one supplier with price in USD'):
-            self.product.write({'standard_price_usd': 880})
-
-    def test_04(self):
-        """ Test constraint check_cost_and_price. """
-        with self.assertRaisesRegexp(
-                ValidationError,
-                'You cannot create or modify a product if the cost in USD'):
-            self.set_standard_price_usd(1)
 
     def test_sale_margin(self):
         """ Test the sale margin module using a pricelist with cost in usd. """


### PR DESCRIPTION
Summary
--------------

The field Cost in USD, now, is computed getting the price in USD recordered in vendor pricelist. In this way, is not necessary have constraint to ensure that at least a vendor pricelist in USD currency is loaded, if it isn't registered in the vendor pricelist, then, will be 0.0.

Preview
-----------

![d3694770 rear inner cover duplex unit mp2550sp - odoo](https://user-images.githubusercontent.com/5335402/42294330-b22d2906-7fa5-11e8-94c9-9c2fceaa6544.png)

![d3694770 rear inner cover duplex unit mp2550sp - odoo 1](https://user-images.githubusercontent.com/5335402/42294336-b517c07c-7fa5-11e8-9fcb-65cd3258a713.png)
