### PR TITLE
[ADD] invoice_split: Add module to split customer invoices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ cache:
   directories:
     - $HOME/.cache/pip
 
+
 addons:
   postgresql: "9.6"
+  apt:
+    packages:
+      - expect-dev  # provides unbuffer utility
+      - python-lxml  # because pip installation is slow
 
 python:
   - "3.6"

--- a/invoice_split/README.md
+++ b/invoice_split/README.md
@@ -1,0 +1,47 @@
+Split Invoices
+==============
+
+This module allows to split a customer invoice, so the customer may pay a
+percentage of the invoice amount and, optionally,  create a new invoice
+to pay the remaining amount later.
+
+
+Usage
+=====
+
+To use this module, you need to:
+
+1. Go to any invoice in draft mode
+2. Click on the menu Actions → "Split Invoice"
+3. Fill the percent by which the invoice will be split, and check/uncheck if a
+   new invoice will be created for the  remaining amount
+4. Click on the "Split" button. When a new invoice is created, you'll be
+   redirected to a list view where both invoices are displayed
+
+
+Considerations
+==============
+
+When invoices are split, their lines are copied and product quantities are
+divided which may produce non-integer quantities. This process is done without
+taking into account unit of measures. That means, if a line contains, for
+instance, three shirts, and the invoice is split to 50%; then the invoice will
+be for 1.5 shirts after the invoice is split, even though that is not
+possible in practice.
+
+
+Credits
+=======
+
+**Contributors**
+
+* Luis González <lgonzalez@vauxoo.com> (Developer)
+* Yanina Aular <yanina.aular@vauxoo.com> (Planner/Auditor)
+
+
+Maintainer
+==========
+
+.. image:: https://www.vauxoo.com/logo.png
+   :alt: Vauxoo
+   :target: https://vauxoo.com

--- a/invoice_split/__init__.py
+++ b/invoice_split/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2018 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import wizards

--- a/invoice_split/__manifest__.py
+++ b/invoice_split/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2018 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Split Invoices',
+    'summary': 'Split invoices to pay them by percentages of the total amount',
+    'author': 'Vauxoo',
+    'website': 'https://www.vauxoo.com',
+    'license': 'AGPL-3',
+    'category': 'Accounting',
+    'version': '12.0.1.0.0',
+    'depends': [
+        'account',
+    ],
+    'data': [
+        'wizards/invoice_split.xml',
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+}

--- a/invoice_split/i18n/es.po
+++ b/invoice_split/i18n/es.po
@@ -1,0 +1,121 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* invoice_split
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-10-23 23:20+0000\n"
+"PO-Revision-Date: 2018-10-23 23:20+0000\n"
+"Last-Translator: Luis González <lgonzalez@vauxoo.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: invoice_split
+#: model_terms:ir.ui.view,arch_db:invoice_split.split_wizard
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split__create_invoice
+msgid "Create New Invoice"
+msgstr "Crear Factura Nueva"
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split__id
+msgid "ID"
+msgstr ""
+
+#. module: invoice_split
+#: code:addons/invoice_split/wizards/invoice_split.py:38
+#, python-format
+msgid "Invalid percent %s%%.\n"
+"\n"
+"It must be a number greater than 0 and less than 100."
+msgstr "El porcentaje %s%% es incorrecto.\n"
+"\n"
+"Debe ser un número mayor a 0 y menor que 100."
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split__invoice_id
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: invoice_split
+#: model:ir.model,name:invoice_split.model_account_invoice_split
+msgid "Invoice Splitter"
+msgstr "Separador de Facturas"
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split__new_invoice_id
+msgid "New Invoice"
+msgstr "Nueva Factura"
+
+#. module: invoice_split
+#: model:ir.model.fields,help:invoice_split.field_account_invoice_split__percent
+msgid "Percent of the amount that will be paid on the current invoice"
+msgstr "Porcentaje del monto que se pagará en la factura actual"
+
+#. module: invoice_split
+#: model:ir.model.fields,field_description:invoice_split.field_account_invoice_split__percent
+msgid "Percent to Pay"
+msgstr "Porcentaje a Pagar"
+
+#. module: invoice_split
+#: model:ir.model.fields,help:invoice_split.field_account_invoice_split__create_invoice
+msgid "Specifies whether a new invoice will be created in draft mode with the remaining uncovered amount"
+msgstr "Especifica si se creará una nueva factura en borrador con el monto restante por cubrir"
+
+#. module: invoice_split
+#: model_terms:ir.ui.view,arch_db:invoice_split.split_wizard
+msgid "Split"
+msgstr "Dividir"
+
+#. module: invoice_split
+#: code:addons/invoice_split/wizards/invoice_split.py:56
+#: model:ir.actions.act_window,name:invoice_split.split_act_window
+#: model_terms:ir.ui.view,arch_db:invoice_split.split_wizard
+#, python-format
+msgid "Split Invoice"
+msgstr "Separar Factura"
+
+#. module: invoice_split
+#: code:addons/invoice_split/wizards/invoice_split.py:29
+#, python-format
+msgid "You may split invoices only when they are in draft mode."
+msgstr "Solo puede dividir facturas que estén en borrador."
+

--- a/invoice_split/tests/__init__.py
+++ b/invoice_split/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2018 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_account_invoice

--- a/invoice_split/tests/test_account_invoice.py
+++ b/invoice_split/tests/test_account_invoice.py
@@ -1,0 +1,105 @@
+# Copyright 2018 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.account.tests.account_test_classes import AccountingTestCase
+
+
+class TestAccountInvoice(AccountingTestCase):
+
+    def setUp(self):
+        super(TestAccountInvoice, self).setUp()
+        self.invoice_obj = self.env['account.invoice']
+        self.partner = self.env.ref('base.res_partner_3')
+        self.product1 = self.env.ref('product.product_product_3')
+        self.product2 = self.env.ref('product.product_product_5')
+        self.split_wizard_obj = self.env['account.invoice.split']
+
+    def create_invoice(self):
+        invoice = self.invoice_obj.create({
+            'name': 'Test Customer Invoice',
+            'partner_id': self.partner.id,
+        })
+        invoice.invoice_line_ids = [
+            (0, 0, {
+                'product_id': self.product1.id,
+                'name': 'Green Shirt',
+                'quantity': 10.0,
+                'price_unit': 5.0,
+                'account_id': invoice.account_id.id,
+            }),
+            (0, 0, {
+                'product_id': self.product2.id,
+                'name': 'Gray Pants',
+                'quantity': 5,
+                'price_unit': 3.0,
+                'account_id': invoice.account_id.id,
+            }),
+        ]
+        return invoice
+
+    def test_01_split_with_new_invoice(self):
+        """Test case: split an invoice without creating a new one
+
+        This splits an invoice, without creating a new one to cover the
+        remaining amount, and setting the amount to 20%
+        """
+        invoice = self.create_invoice()
+        wizard = self.split_wizard_obj.create({
+            'invoice_id': invoice.id,
+            'percent': 20.0,
+            'create_invoice': False,
+        })
+        result = wizard.action_split_invoice()
+
+        # Validate fields of the invoice
+        self.assertFalse(wizard.new_invoice_id)
+        self.assertListEqual(
+            invoice.invoice_line_ids.mapped('quantity'), [2.0, 1.0])
+        self.assertListEqual(
+            invoice.invoice_line_ids.mapped('price_total'), [10.0, 3.0])
+
+        # Validate fields of the returned action
+        self.assertTrue(result)
+        self.assertEqual(result['view_mode'], 'form')
+        self.assertEqual(
+            result['domain'], [('id', 'in', invoice.ids)])
+
+    def test_02_split_with_new_invoice(self):
+        """Test case: split an invoice creating a new one
+
+        This splits an invoice, creating a new one to cover the remaining
+        amount, and setting the amount to 30%.
+
+        First invoice's total amount should be 30% of the original amount, and
+        the new one should be 70%.
+        """
+        invoice = self.create_invoice()
+        wizard = self.split_wizard_obj.create({
+            'invoice_id': invoice.id,
+            'percent': 30.0,
+            'create_invoice': True,
+        })
+        result = wizard.action_split_invoice()
+
+        # Validate fields of the current invoice
+        self.assertListEqual(
+            invoice.invoice_line_ids.mapped('quantity'), [3.0, 1.5])
+        self.assertListEqual(
+            invoice.invoice_line_ids.mapped('price_total'), [15.0, 4.5])
+
+        # Validate fields of the created invoice
+        new_invoice = wizard.new_invoice_id
+        products = self.product1 + self.product2
+        self.assertEqual(len(new_invoice.invoice_line_ids), 2)
+        self.assertEqual(
+            new_invoice.invoice_line_ids.mapped('product_id'), products)
+        self.assertListEqual(
+            new_invoice.invoice_line_ids.mapped('quantity'), [7.0, 3.5])
+        self.assertListEqual(
+            new_invoice.invoice_line_ids.mapped('price_total'), [35.0, 10.5])
+
+        # Validate fields of the returned action
+        self.assertTrue(result)
+        self.assertEqual(result['view_mode'], 'tree,form')
+        self.assertEqual(
+            result['domain'], [('id', 'in', [invoice.id, new_invoice.id])])

--- a/invoice_split/wizards/__init__.py
+++ b/invoice_split/wizards/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2018 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import invoice_split

--- a/invoice_split/wizards/invoice_split.py
+++ b/invoice_split/wizards/invoice_split.py
@@ -1,0 +1,80 @@
+# Copyright 2018 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class AccountInvoiceSplit(models.TransientModel):
+    _name = "account.invoice.split"
+    _description = "Invoice Splitter"
+
+    invoice_id = fields.Many2one('account.invoice', String="Invoice to Split")
+    new_invoice_id = fields.Many2one('account.invoice')
+    percent = fields.Float(
+        string="Percent to Pay",
+        help="Percent of the amount that will be paid on the current invoice")
+    create_invoice = fields.Boolean(
+        string="Create New Invoice", default=True,
+        help="Specifies whether a new invoice will be created in draft mode "
+        "with the remaining uncovered amount")
+
+    @api.model
+    def default_get(self, fields_list):
+        """Ensure only invoices in draft may be split"""
+        res_ids = self._context.get('active_ids')
+        invoices = self.env['account.invoice'].browse(res_ids)
+        inv_not_draft = invoices.filtered(lambda inv: inv.state != 'draft')
+        if inv_not_draft:
+            raise UserError(_(
+                "You may split invoices only when they are in draft mode."))
+        return super(AccountInvoiceSplit, self).default_get(fields_list)
+
+    @api.multi
+    def action_split_invoice(self):
+        """Actual action called by the wizard once it's fulfilled
+
+        When invoices are split, their lines are copied and product quantities
+        are divided which may produce non-integer quantities. This process is
+        done without taking into account unit of measures. That means, if a
+        line contains, for instance, three shirts, and the invoice is split to
+        50%; then the invoice will be for 1.5 shirts after the invoice is
+        split, even though that is not possible in practice.
+        """
+        valid_percent = 0 < self.percent < 100
+        if not valid_percent:
+            raise UserError(_(
+                "Invalid percent %s%%.\n\n"
+                "It must be a number greater than 0 and less than 100.") % (
+                    self.percent))
+        if self.create_invoice:
+            self.new_invoice_id = self.invoice_id.copy()
+            for line in self.new_invoice_id.invoice_line_ids:
+                line.quantity *= (100-self.percent)/100
+            self.new_invoice_id.compute_taxes()
+        for line in self.invoice_id.invoice_line_ids:
+            line.quantity *= self.percent/100
+        self.invoice_id.compute_taxes()
+        return self.action_open_invoices()
+
+    @api.multi
+    def action_open_invoices(self):
+        """Action to be executed once invoice is split
+
+        There are two possibilities:
+        - If no new invoice was created, current invoice is refreshed
+        - If it was created, a list view is opened, listing both current and
+          new invoices
+        """
+        self.ensure_one()
+        invoices = self.invoice_id + self.new_invoice_id
+        return {
+            'name': _('Split Invoice'),
+            'view_type': 'form',
+            'view_mode': 'tree,form' if self.new_invoice_id else 'form',
+            'res_model': 'account.invoice',
+            'res_id': invoices.ids[0],
+            'domain': [('id', 'in', invoices.ids)],
+            'type': 'ir.actions.act_window',
+            'context': {'type': 'out_invoice'},
+        }

--- a/invoice_split/wizards/invoice_split.xml
+++ b/invoice_split/wizards/invoice_split.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="split_wizard" model="ir.ui.view">
+        <field name="name">split.invoice.wizard</field>
+        <field name="model">account.invoice.split</field>
+        <field name="arch" type="xml">
+            <form string="Split Invoice">
+                <group>
+                    <field name="percent"/>
+                    <field name="create_invoice"/>
+                </group>
+                <footer>
+                    <button
+                        string="Split"
+                        name="action_split_invoice"
+                        type="object"
+                        class="btn-primary"/>
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+   <act_window
+        name="Split Invoice"
+        id="split_act_window"
+        res_model="account.invoice.split"
+        src_model="account.invoice"
+        view_type="form"
+        view_mode="form"
+        target="new"
+        context="{'default_invoice_id': active_id}"
+        groups="account.group_account_invoice"/>
+
+</odoo>


### PR DESCRIPTION
This module allows to split a customer invoice, so the customer may pay
a percentage of the invoice amount and, optionally,  create a new
invoice to pay the remaining amount later.

For more info, see the README file.

Dummy MR: https://git.vauxoo.com/absa/absa/merge_requests/75