### PR TITLE
[REF] .travis.yml: Use Python 3.6 for Odoo 12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ cache:
     - $HOME/.pip-cache/
 
 python:
-  - "3.4"
-
-virtualenv:
-  system_site_packages: true
+  - "3.6"
 
 env:
   global:


### PR DESCRIPTION
Odoo 12.0 should use Python 3.6, instead of Python 3.4