### PR TITLE
[IMP] account_invoice_change_currency: Migration & Improvements

### DIFF
--- a/account_index_based_currency/README.rst
+++ b/account_index_based_currency/README.rst
@@ -1,0 +1,59 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===============================
+Account Invoice Change Currency
+===============================
+
+This replace original odoo wizard for changing currency on an invoice with serveral
+improovements:
+
+* Preview and allow to change the rate thats is going to be used:
+* Log the currency change on the chatter
+* Add this functionality to supplier invoices
+
+Installation
+============
+
+To install this module, you need to:
+
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+
+Usage
+=====
+
+To use this module, you need to:
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/vauxoo/addons-vauxoo/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/vauxoo/addons-vauxoo/issues/new?body=module:%20payment_conekta%0Aversion:%209.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+This module was created by Vauxoo S.A. de C.V.
+
+Contributors
+------------
+* Hugo Adan <hugo@vauxoo.com>
+
+
+Maintainer
+----------
+
+.. image:: http://www.vauxoo.com/logo.png
+   :alt: Vauxoo, S.A. de C.V.
+   :target: http://www.vauxoo.com
+
+This module is maintained by Vauxoo, S.A. de C.V.

--- a/account_index_based_currency/__init__.py
+++ b/account_index_based_currency/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from .hooks import pre_init_hook

--- a/account_index_based_currency/__manifest__.py
+++ b/account_index_based_currency/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# © 2017 Vauxoo, S.A. de C.V.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    'author': 'ADHOC SA,Odoo Community Association (OCA), Vauxoo',
+    'category': 'Accounting & Finance',
+    'demo_xml': [],
+    'depends': ['account'],
+    'installable': True,
+    'name': 'Account Index Based Currency',
+    'test': [],
+    'data': [
+        'views/invoice_view.xml',
+        'views/res_company_view.xml',
+    ],
+    'version': '12.0.0.0.0',
+    'website': 'www.adhoc.com.ar, www.vauxoo.com',
+    'pre_init_hook': 'pre_init_hook',
+    'license': 'AGPL-3'
+}

--- a/account_index_based_currency/hooks.py
+++ b/account_index_based_currency/hooks.py
@@ -1,0 +1,25 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):
+    cr.execute(
+        'ALTER TABLE account_invoice ADD COLUMN currency_rate '
+        ' DECIMAL(12, 6);'
+
+        'ALTER TABLE account_invoice ADD COLUMN index_based_currency_rate '
+        ' DECIMAL(12, 6);'
+
+        'ALTER TABLE account_invoice ADD COLUMN company_currency_rate '
+        ' DECIMAL(12, 6);'
+
+        'ALTER TABLE account_invoice ADD COLUMN agreement_currency_rate '
+        ' DECIMAL(12, 6);'
+    )
+
+    # /!\ NOTE: This second clause can be improved. Instead of using a plain 1
+    cr.execute('UPDATE account_invoice SET currency_rate=1;')
+    cr.execute('UPDATE account_invoice SET index_based_currency_rate=1;')
+    cr.execute('UPDATE account_invoice SET company_currency_rate=1;')
+    cr.execute('UPDATE account_invoice SET agreement_currency_rate=1;')

--- a/account_index_based_currency/i18n/es.po
+++ b/account_index_based_currency/i18n/es.po
@@ -1,0 +1,186 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_index_based_currency
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-11-20 06:07+0000\n"
+"PO-Revision-Date: 2018-11-20 06:07+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_index_based_currency
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_change_currency_form
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_supplier_form
+msgid "Agreement Amount"
+msgstr "Monto Acordado"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_invoice__agreement_currency_id
+msgid "Agreement Currency"
+msgstr "Moneda del Acuerdo"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_invoice__agreement_currency_amount
+msgid "Agreement Currency Amount"
+msgstr "Monto en Moneda del Acuerdo"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_invoice__agreement_currency_rate
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_move_line__agreement_currency_rate
+msgid "Agreement Currency Rate"
+msgstr "Tasa en Moneda del Acuerdo"
+
+#. module: account_index_based_currency
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_change_currency_form
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_supplier_form
+msgid "Agreement Rate"
+msgstr "Tasa del Acuerdo"
+
+#. module: account_index_based_currency
+#: model:ir.model,name:account_index_based_currency.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: account_index_based_currency
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_change_currency_form
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_supplier_form
+msgid "Company Amount"
+msgstr "Monto de la Compañía"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_invoice__company_currency_rate
+msgid "Company Currency Rate"
+msgstr "Tasa en Moneda de la Compañía"
+
+#. module: account_index_based_currency
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_change_currency_form
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_supplier_form
+msgid "Company Rate"
+msgstr "Tasa de la Compañía"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,help:account_index_based_currency.field_account_invoice__company_currency_rate
+msgid "Company currency rate at date of document creation or document approval against Index Based Currency"
+msgstr "Tasa en moneda de la compañía a la fecha de la creación o aprabación del documento contra la Moneda Basada en Índice"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_invoice__currency_rate
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_move_line__currency_rate
+msgid "Currency Rate"
+msgstr "Tasa Monetaria"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,help:account_index_based_currency.field_account_invoice__agreement_currency_id
+msgid "Currency at which the agreement is to be/was settled"
+msgstr "Moneda a la cual el acuerdo se va/será establecido"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,help:account_index_based_currency.field_account_invoice__agreement_currency_rate
+#: model:ir.model.fields,help:account_index_based_currency.field_account_move_line__agreement_currency_rate
+msgid "Currency rate this Document was agreed"
+msgstr "Tasa de la moneda en la que este Documento se acordó"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,help:account_index_based_currency.field_account_invoice__index_based_currency_id
+msgid "Currency used for reporting purposes"
+msgstr "Moneda usada para propósitos de reportes"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,help:account_index_based_currency.field_account_move_line__index_based_currency_id
+#: model:ir.model.fields,help:account_index_based_currency.field_res_company__index_based_currency_id
+msgid "Currency used por reporting purposes"
+msgstr "Moneda usada para propósitos de reportes"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,help:account_index_based_currency.field_account_invoice__currency_rate
+#: model:ir.model.fields,help:account_index_based_currency.field_account_move_line__currency_rate
+msgid "Document currency rate at date of document creation or document approval against Index Based Currency"
+msgstr "Tasa de la moneda del documento a la creación o aprobación del documento contra la Moneda Basada en Índice"
+
+#. module: account_index_based_currency
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_change_currency_form
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_supplier_form
+msgid "Exchange Rates"
+msgstr "Tasas de Cambio"
+
+#. module: account_index_based_currency
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_change_currency_form
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_supplier_form
+msgid "Index Based Amount"
+msgstr "Monto Basado en Índice"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_invoice__index_based_currency_id
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_move_line__index_based_currency_id
+#: model:ir.model.fields,field_description:account_index_based_currency.field_res_company__index_based_currency_id
+msgid "Index Based Currency"
+msgstr "Moneda Basada en Índice"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_invoice__index_based_currency_amount
+msgid "Index Based Currency Amount"
+msgstr "Monto en Moneda Basada en Índice"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,field_description:account_index_based_currency.field_account_invoice__index_based_currency_rate
+msgid "Index Based Currency Rate"
+msgstr "Tasa de Moneda Basada en Índice"
+
+#. module: account_index_based_currency
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_change_currency_form
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_supplier_form
+msgid "Index Based Rate"
+msgstr "Tasa Basada en Índice"
+
+#. module: account_index_based_currency
+#: code:addons/account_index_based_currency/models/account_invoice.py:39
+#, python-format
+msgid "Invalid currency rate value"
+msgstr "Valor inválido de la tasa de la moneda"
+
+#. module: account_index_based_currency
+#: model:ir.model,name:account_index_based_currency.model_account_invoice
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: account_index_based_currency
+#: model:ir.model,name:account_index_based_currency.model_account_move_line
+msgid "Journal Item"
+msgstr "Apunte Contable"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,help:account_index_based_currency.field_account_invoice__index_based_currency_rate
+msgid "Technical field for Index based currency rate"
+msgstr "Campo técnico para la tasa de la moneda basada en índice"
+
+#. module: account_index_based_currency
+#: model:ir.model.fields,help:account_index_based_currency.field_account_invoice__agreement_currency_amount
+#: model:ir.model.fields,help:account_index_based_currency.field_account_invoice__index_based_currency_amount
+msgid "Total amount in the currency of the company, negative for credit notes."
+msgstr "Importe total en la moneda de la compañía, negativo para notas de crédito."
+
+#. module: account_index_based_currency
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_change_currency_form
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_supplier_form
+msgid "Transaction Amount"
+msgstr "Monto de la Transacción"
+
+#. module: account_index_based_currency
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_change_currency_form
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_supplier_form
+msgid "Transaction Currency"
+msgstr "Moneda de la Transacción"
+
+#. module: account_index_based_currency
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_change_currency_form
+#: model_terms:ir.ui.view,arch_db:account_index_based_currency.invoice_supplier_form
+msgid "Transaction Rate"
+msgstr "Tasa de la Transacción"
+

--- a/account_index_based_currency/models/__init__.py
+++ b/account_index_based_currency/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_company
+from . import account_invoice

--- a/account_index_based_currency/models/account_invoice.py
+++ b/account_index_based_currency/models/account_invoice.py
@@ -1,0 +1,144 @@
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.one
+    @api.depends('date_invoice', 'index_based_currency_id',
+                 'company_currency_id', 'currency_id')
+    def _compute_currency_rate(self):
+        self.index_based_currency_rate = 1
+        self.currency_rate = (
+            self.currency_id._convert(
+                1, self.index_based_currency_id, self.company_id,
+                self.date_invoice or fields.Date.today(), round=False))
+        self.company_currency_rate = (
+            self.company_currency_id._convert(
+                1, self.index_based_currency_id, self.company_id,
+                self.date_invoice or fields.Date.today(), round=False))
+
+    @api.one
+    @api.depends('amount_total_signed', 'agreement_currency_rate',
+                 'date_invoice')
+    def _compute_currency_amount(self):
+        index_based_currency_amount = self.amount_total_signed
+        if self.index_based_currency_id != self.currency_id:
+            index_based_currency_amount = self.currency_id._convert(
+                self.amount_total_signed, self.index_based_currency_id,
+                self.company_id, self.date_invoice or fields.Date.today())
+        self.index_based_currency_amount = index_based_currency_amount
+        self.agreement_currency_amount = (
+            self.index_based_currency_amount / self.agreement_currency_rate)
+
+    @api.multi
+    @api.onchange('agreement_currency_rate')
+    def onchange_agreement_currency_rate(self):
+        if self.agreement_currency_rate <= 0:
+            raise UserError(_('Invalid currency rate value'))
+
+    @api.multi
+    @api.onchange('agreement_currency_id')
+    def onchange_agreement_currency_id(self):
+        self.agreement_currency_rate = self.agreement_currency_id._convert(
+            1, self.index_based_currency_id,
+            self.company_id,
+            self.date_invoice or fields.Date.today(), round=False)
+        self.agreement_currency_amount = self.index_based_currency_id._convert(
+            self.index_based_currency_amount, self.agreement_currency_id,
+            self.company_id,
+            self.date_invoice or fields.Date.today(), round=False)
+
+    @api.model
+    def default_get(self, default_fields):
+        res = super(AccountInvoice, self).default_get(default_fields)
+        default_rate = (
+            self.env.user.company_id.currency_id._convert(
+                1, self.env.user.company_id.index_based_currency_id,
+                self.env.user.company_id,
+                self.date_invoice or fields.Date.today(), round=False))
+        res['agreement_currency_id'] = self.env.user.company_id.currency_id.id
+        res['agreement_currency_rate'] = default_rate
+        return res
+
+    # old_currency_id = fields.Many2one(
+    #     'res.currency', help="The previous currency used")
+    agreement_currency_id = fields.Many2one(
+        'res.currency',
+        copy=True,
+        help="Currency at which the agreement is to be/was settled",
+        readonly=True, states={'draft': [('readonly', False)]},
+    )
+    index_based_currency_id = fields.Many2one(
+        'res.currency',
+        related='company_id.index_based_currency_id',
+        help="Currency used for reporting purposes",
+        copy=False,
+        readonly=True)
+    index_based_currency_amount = fields.Monetary(
+        currency_field='index_based_currency_id',
+        store=True, readonly=True, compute='_compute_currency_amount',
+        copy=False,
+        help="Total amount in the currency of the company, negative for "
+        "credit notes.")
+    agreement_currency_amount = fields.Monetary(
+        currency_field='agreement_currency_id',
+        store=True, readonly=True, compute='_compute_currency_amount',
+        copy=False,
+        help="Total amount in the currency of the company, negative for "
+        "credit notes.")
+    index_based_currency_rate = fields.Float(
+        default=1,
+        store=True, readonly=True, compute='_compute_currency_rate',
+        help='Technical field for Index based currency rate',
+        copy=False, digits=(12, 6))
+    currency_rate = fields.Float(
+        help="Document currency rate at date of document creation or "
+        "document approval against Index Based Currency",
+        store=True, readonly=True, compute='_compute_currency_rate',
+        copy=False, digits=(12, 6))
+    company_currency_rate = fields.Float(
+        help="Company currency rate at date of document creation or "
+        "document approval against Index Based Currency",
+        store=True, readonly=True, compute='_compute_currency_rate',
+        copy=False, digits=(12, 6))
+    agreement_currency_rate = fields.Float(
+        help="Currency rate this Document was agreed",
+        readonly=True, states={'draft': [('readonly', False)]},
+        copy=True, digits=(12, 6))
+
+    # custom_rate = fields.Float(
+    #     default=_default_custom_currency_rate,
+    #     required=True,
+    #     help="Set new currency rate to apply on the invoice\n."
+    #     "This rate will be taken in order to convert amounts between the "
+    #     "currency on the invoice and MX currency",
+    #     copy=True)
+
+    @api.multi
+    def finalize_invoice_move_lines(self, move_lines):
+        res = super(AccountInvoice, self).finalize_invoice_move_lines(
+            move_lines)
+        for line in res:
+            line[2]['currency_rate'] = self.currency_rate
+            line[2]['agreement_currency_rate'] = self.agreement_currency_rate
+        return res
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    currency_rate = fields.Float(
+        help="Document currency rate at date of document creation or "
+        "document approval against Index Based Currency",
+        readonly=True, copy=False, digits=(12, 6))
+    agreement_currency_rate = fields.Float(
+        help="Currency rate this Document was agreed",
+        readonly=True, copy=True, digits=(12, 6))
+    index_based_currency_id = fields.Many2one(
+        'res.currency',
+        related='company_id.index_based_currency_id',
+        help="Currency used por reporting purposes",
+        store=True,
+        readonly=True)

--- a/account_index_based_currency/models/res_company.py
+++ b/account_index_based_currency/models/res_company.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class Company(models.Model):
+    _inherit = "res.company"
+
+    index_based_currency_id = fields.Many2one(
+        'res.currency', required=False,
+        help="Currency used por reporting purposes",
+        default=lambda self: self.env.ref('base.USD'))

--- a/account_index_based_currency/views/invoice_view.xml
+++ b/account_index_based_currency/views/invoice_view.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="ir.ui.view" id="invoice_change_currency_form">
+        <field name="name">account.invoice_customer.change.view</field>
+        <field name="inherit_id" ref="account.invoice_form"/>
+        <field name="model">account.invoice</field>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='other_info']" position="after">
+                <page string="Exchange Rates" name="exchange_rate">
+                    <group col='6' colspan="6">
+                        <group colspan="2">
+                            <field name="index_based_currency_id"/>
+                            <field name="currency_id" string="Transaction Currency"/>
+                            <field name="company_currency_id"/>
+                            <field name="agreement_currency_id"/>
+                        </group>
+                        <group colspan="2">
+                            <field name="index_based_currency_amount" string="Index Based Amount"/>
+                            <field name="amount_total_signed" string="Transaction Amount"/>
+                            <field name="amount_total_company_signed" string="Company Amount"/>
+                            <field name="agreement_currency_amount" string="Agreement Amount"/>
+                        </group>
+                        <group colspan="2">
+                            <field name="index_based_currency_rate" string="Index Based Rate"/>
+                            <field name="currency_rate" string="Transaction Rate"/>
+                            <field name="company_currency_rate" string="Company Rate"/>
+                            <field name="agreement_currency_rate" string="Agreement Rate"/>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="invoice_supplier_form">
+        <field name="name">account.invoice_supplier.change.view</field>
+        <field name="inherit_id" ref="account.invoice_supplier_form"/>
+        <field name="model">account.invoice</field>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='other_info']" position="after">
+                <page string="Exchange Rates" name="exchange_rate">
+                    <group col='6' colspan="6">
+                        <group colspan="2">
+                            <field name="index_based_currency_id"/>
+                            <field name="currency_id" string="Transaction Currency"/>
+                            <field name="company_currency_id"/>
+                            <field name="agreement_currency_id"/>
+                        </group>
+                        <group colspan="2">
+                            <field name="index_based_currency_amount" string="Index Based Amount"/>
+                            <field name="amount_total_signed" string="Transaction Amount"/>
+                            <field name="amount_total_company_signed" string="Company Amount"/>
+                            <field name="agreement_currency_amount" string="Agreement Amount"/>
+                        </group>
+                        <group colspan="2">
+                            <field name="index_based_currency_rate" string="Index Based Rate"/>
+                            <field name="currency_rate" string="Transaction Rate"/>
+                            <field name="company_currency_rate" string="Company Rate"/>
+                            <field name="agreement_currency_rate" string="Agreement Rate"/>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/account_index_based_currency/views/res_company_view.xml
+++ b/account_index_based_currency/views/res_company_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="res_company_form_view_inherit_index_based_currency" model="ir.ui.view">
+            <field name="name">res.company.form.index.based.currency</field>
+            <field name="model">res.company</field>
+            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='currency_id']" position="after">
+                    <field name="index_based_currency_id"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
- custom_rate: has been refactored, no longer a computed field. Now includes a default which seeks the rates between company currency and index based currency.
- index_based_currency_id: a new field in the company, and related to invoices. For reporting purposes.

On aml's
- index_based_currency_rate: was added and is recorded from invoice at date of invoice, for reporting purposes.
- custom_rate: was added and is recorded with custom_rate in the invoice
