### PR TITLE
[REF] purchase_third_validation: Remove "Third approval" state from b…

### DIFF
--- a/purchase_third_validation/views/purchase_third_validation.xml
+++ b/purchase_third_validation/views/purchase_third_validation.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data noupdate="0">
+<odoo>
     	<record id="res_config_settings_view_form_purchase_inherit" model="ir.ui.view">
             <field name="name">purchase settings inherit</field>
             <field name="model">res.config.settings</field>
@@ -23,5 +22,4 @@
                 </xpath>
             </field>
         </record>
-    </data>
-</openerp>
+</odoo>

--- a/purchase_third_validation/views/purchase_view.xml
+++ b/purchase_third_validation/views/purchase_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data noupdate="0">
+<odoo>
     	<record id="view_purchase_third_level_inherit" model="ir.ui.view">
             <field name="name">purchase.third.level.inherit</field>
             <field name="model">purchase.order</field>
@@ -9,10 +8,6 @@
                 <xpath expr="//button[@name='button_approve']" position="after">
                     <button name="button_approve" type="object" states='third approve' string="Approve Order" class="oe_highlight" groups="purchase_third_validation.general_purchase_manager"/>
                 </xpath>
-                <xpath expr="//field[@name='state']" position="attributes">
-                    <attribute name="statusbar_visible" add="third approve" separator=","></attribute>
-                </xpath>
             </field>
         </record>
-    </data>
-</openerp>
+</odoo>


### PR DESCRIPTION
…eing always visible on the widget, to only be visible if the purchase order is on that state. This because it was confusing. And this way it behaves like the state "To approve", that is the second validation state.

Without change:
![image](https://user-images.githubusercontent.com/17324113/47672085-affcbc00-db76-11e8-9c87-ca792d0c5f2f.png)

With change:
![image](https://user-images.githubusercontent.com/17324113/47671985-7330c500-db76-11e8-9f6a-7902389dcb31.png)
![image](https://user-images.githubusercontent.com/17324113/47671989-762bb580-db76-11e8-8f82-116c94432f0a.png)
