### PR TITLE
[FIX] sale_margin_percentage: The subtotal price is set to zero

### DIFF
--- a/sale_margin_percentage/models/sale_order.py
+++ b/sale_margin_percentage/models/sale_order.py
@@ -50,7 +50,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             currency = line.order_id.pricelist_id.currency_id
 
-            if not line.product_uom_qty:
+            if not line.product_uom_qty or line.price_subtotal == 0.0:
                 line.margin_percentage = 0.0
                 continue
 


### PR DESCRIPTION
This occurs when placing a 100% discount on the sales order line, calculating the subtotal price at zero. This generates a division error by zero

**TODO**

- [x] Modified margin percentange 