### PR TITLE
[REF] product_extended_segmentation: Modified cron job to be split in… task#29961

### DIFF
--- a/product_extended_segmentation/data/ir_cron.xml
+++ b/product_extended_segmentation/data/ir_cron.xml
@@ -6,16 +6,15 @@
             <field name="model_id" ref="product.model_product_product"/>
             <field name="state">code</field>
             <field name="code">
-product_ids = model.search([('bom_ids', '!=', False)])
-product_ids.compute_segmetation_price(cron=True)
-model.clear_caches()
+model.execute_cron_splited(number=500)
             </field>
             <field eval="True" name="active"/>
             <field name="user_id" ref="base.user_root"/>
             <field name="interval_number">1</field>
-            <field name="interval_type">days</field>
+            <field name="interval_type">weeks</field>
             <field name="numbercall">-1</field>
-             <field name="nextcall" eval="(DateTime.now() + timedelta(days=1)).strftime('%Y-%m-%d 22:00:00')" />
+            <field name="nextcall" eval="(DateTime.now() + timedelta(days=7)).strftime('%Y-%m-%d 22:00:00')" />
             <field eval="False" name="doall"/>
         </record>
+
 </odoo>


### PR DESCRIPTION
… multiple crons, this is done because when having a lot of records is common to have time out errors.

The cron is splited depending the number of records wanted per cron. All crons are linked to the next one to be executed. And when all crons are executed they are deactivated and waiting to be erased by the next execution of the original cron.