### PR TITLE
[FIX] stock_cost_segmentation: Fix case of recursivity error when get…

### DIFF
--- a/stock_cost_segmentation/models/stock_move.py
+++ b/stock_cost_segmentation/models/stock_move.py
@@ -454,7 +454,8 @@ class StockMove(models.Model):
             ('picking_ids', 'in', self.mapped(
                 'move_orig_logistic_ids.origin_move_id.picking_id.id')),
             ('l10n_mx_edi_customs_number', '!=', False)])
-        origin_moves = self.mapped('move_orig_ids')
+        origin_moves = self.mapped('move_orig_ids').filtered(
+            lambda move: move.id not in self.mapped('returned_move_ids').ids)
         if origin_moves and not landed:
             landed = origin_moves._get_landed_information()
         return landed


### PR DESCRIPTION
…ting the custom numbers of landing costs when there are moves with returns on returns. When returning a return move causes both to be origin and destiny for eachother. With the changes applied, the search of landed wont search on an origin move that is the return move of itself.