### PR TITLE
[REF] account_refund_early_payment: Change widget of create refunds t… task#29987

### DIFF
--- a/account_refund_early_payment/view/refund_early_payment.xml
+++ b/account_refund_early_payment/view/refund_early_payment.xml
@@ -20,6 +20,9 @@
                          invoice.
                      </div>
                 </xpath>
+                <xpath expr="//field[@name='filter_refund']" position="attributes">
+                    <attribute name="attrs">{'invisible': False}</attribute>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
…o not hide the filter of refund type when the invoice is partially paid, because without it it's not possible to create more than one refund of early payment.