### PR TITLE
[FIX] stock_by_warehouse: Use normal fields without formating the amounts in order to allow js made correct comparations t31436

### DIFF
--- a/stock_by_warehouse/static/src/js/widget.js
+++ b/stock_by_warehouse/static/src/js/widget.js
@@ -19,12 +19,12 @@ var ShowPaymentLineWidget = form_common.extend({
         if (info !== false) {
             _.each(info.content, function (k, v) {
                 k.index = v;
-                k.available_not_res = formats.format["float"](k.available_not_res, "", {digits: k.digits});
-                k.available = formats.format["float"](k.available, "", {digits: k.digits});
-                k.incoming = formats.format["float"](k.incoming, "", {digits: k.digits});
-                k.outgoing = formats.format["float"](k.outgoing, "", {digits: k.digits});
-                k.virtual = formats.format["float"](k.virtual, "", {digits: k.digits});
-                k.saleable = formats.format["float"](k.saleable, "", {digits: k.digits});
+                k.available_not_res_formated = formats.format["float"](k.available_not_res, "", {digits: k.digits});
+                k.available_formated  = formats.format["float"](k.available, "", {digits: k.digits});
+                k.incoming_formated  = formats.format["float"](k.incoming, "", {digits: k.digits});
+                k.outgoing_formated  = formats.format["float"](k.outgoing, "", {digits: k.digits});
+                k.virtual_formated  = formats.format["float"](k.virtual, "", {digits: k.digits});
+                k.saleable_formated  = formats.format["float"](k.saleable, "", {digits: k.digits});
             });
         }
         var popover = QWeb.render('ProductWarehousePopOver', {

--- a/stock_by_warehouse/static/src/xml/template.xml
+++ b/stock_by_warehouse/static/src/xml/template.xml
@@ -18,12 +18,12 @@
                             <t t-raw="warehouse.warehouse_short"> | </t>
                         </b>
                         <div class="pull-right text-right">
-                            <span title="This is real(on hand) quantity  minus reserved quantity" class="text-muted"><t t-raw="warehouse.available_not_res"/></span><br/>
-                            <span title="Available Now but not necessarily what I can sale"><t t-raw="warehouse.available"/></span><br/>
-                            - <span title="Outgoing" class="text-danger"><t t-raw="warehouse.outgoing"/></span><br/>
-                            = <span title="I can sale this quantity now and deliver it immediately" class="text-muted"><t t-raw="warehouse.saleable"/></span><br/>
-                            + <span title="Is coming in" class="text-success"><t t-raw="warehouse.incoming"/></span><br/>
-                            = <span title="This will be available next" class="text-muted"><t t-raw="warehouse.virtual"/></span>
+                            <span title="This is real(on hand) quantity  minus reserved quantity" class="text-muted"><t t-raw="warehouse.available_not_res_formated"/></span><br/>
+                            <span title="Available Now but not necessarily what I can sale"><t t-raw="warehouse.available_formated"/></span><br/>
+                            - <span title="Outgoing" class="text-danger"><t t-raw="warehouse.outgoing_formated"/></span><br/>
+                            = <span title="I can sale this quantity now and deliver it immediately" class="text-muted"><t t-raw="warehouse.saleable_formated"/></span><br/>
+                            + <span title="Is coming in" class="text-success"><t t-raw="warehouse.incoming_formated"/></span><br/>
+                            = <span title="This will be available next" class="text-muted"><t t-raw="warehouse.virtual_formated"/></span>
                         </div>
                     </div>
                 </t>


### PR DESCRIPTION
Before:
"1,896.00" > 0 === false
"896.00" >0 === true

After:
1896.00 > 0 === true
896.00 >0 === true

https://youtu.be/Im-cGVj3110