### PR TITLE
[FIX] default_warehouse_from_sale_team: When deleting a user from a

### DIFF
--- a/default_warehouse_from_sale_team/models/res_users.py
+++ b/default_warehouse_from_sale_team/models/res_users.py
@@ -19,7 +19,8 @@ class ResUsers(models.Model):
         """ Can only set the Default Sales team if the user is part o
         """
         for user in self.filtered(
-                lambda dat: dat.sale_team_id not in dat.sale_team_ids):
+                lambda dat: dat.sale_team_id and dat.sale_team_id
+                not in dat.sale_team_ids):
             raise ValidationError(_(
                 'You can not set %s sale team as default because the user'
                 ' do not belongs to the sale teams.\nPlease go to Sales >'


### PR DESCRIPTION
sales team, their sales_team id got empty, making the user failing on
the constraint since it's empty then is not on the list of ids