### PR TITLE
[FIX] Consumable and service type products are excluded in qty2produce

### DIFF
--- a/mrp_partial_production/models/mrp.py
+++ b/mrp_partial_production/models/mrp.py
@@ -49,10 +49,10 @@ class MrpProduction(models.Model):
                                           res.quantity_done)
 
         for line, line_data in lines:
+            if line.product_id.type in ('service','consu'):
+                continue
             lines_dict[line.product_id.id] += line_data['qty'] / quantity
-
-        qty = [(result[key] / val) for key, val in lines_dict.items()
-               if val]
+        qty = [(result[key] / val) for key, val in lines_dict.items() if val]
         return (float_round(
             min(qty) * self.bom_id.product_qty, 0, rounding_method='DOWN') if
             qty and min(qty) >= 0.0 else 0.0)


### PR DESCRIPTION
Consumable and service type products are removed from the bill of materials when are analyzed in the get_qty_availble_to_produce method.

This bug was discovered in the task#31810 of the ticket#5182.

The client tries to produce a product with bills of material that include service, so the function doesn't consider the service because this doesn't appear in the order, and the function always returns 0.
