### PR TITLE
[IMP] account_move_report: Improves in the module

### DIFF
--- a/account_move_report/views/account_move_report.xml
+++ b/account_move_report/views/account_move_report.xml
@@ -42,7 +42,9 @@
                                         <th class="text-right">Debit</th>
                                         <th class="text-right">Credit</th>
                                         <th>Analytic account</th>
-                                        <th class="text-right">Amount Currency</th>
+                                        <t t-if="o.line_ids.filtered('amount_currency')">
+                                            <th class="text-right">Amount Currency</th>
+                                        </t>
                                         <th>Currency</th>
                                         <th>Tax Account</th>
                                         <th class="text-right">Tax Amount</th>
@@ -63,10 +65,12 @@
                                             <span t-field="l.credit"/>
                                         </td>
                                         <td><span t-field="l.analytic_account_id"/></td>
-                                        <td class="text-right">
-                                            <span t-field="l.amount_currency"/>
-                                        </td>
-                                        <td><span t-field="l.currency_id.name"/></td>
+                                        <t t-if="l.amount_currency">
+                                            <td class="text-right">
+                                                <span t-field="l.amount_currency"/>
+                                            </td>
+                                        </t>
+                                        <td><span t-field="(l.currency_id or l.company_id.currency_id).name"/></td>
                                         <td><span t-field="l.tax_line_id.account_id.name"/></td>
                                         <td class="text-right">
                                             <span t-field="l.tax_line_id.amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/></td>


### PR DESCRIPTION
1. If the move currency is the same that the company, the field
   amount_currency is empty, then not must be showed the column.
2. If the move currency is the same that the company, the currency is
   empty, then the column not must be added because is empty the value.

