### PR TITLE
[FIX] account_move_report: Show amount currency when it's 0

### DIFF
--- a/account_move_report/views/account_move_report.xml
+++ b/account_move_report/views/account_move_report.xml
@@ -42,7 +42,7 @@
                                         <th class="text-right">Debit</th>
                                         <th class="text-right">Credit</th>
                                         <th>Analytic account</th>
-                                        <t t-if="o.line_ids.filtered('amount_currency')">
+                                        <t t-if="o.line_ids.mapped('currency_id')">
                                             <th class="text-right">Amount Currency</th>
                                         </t>
                                         <th>Currency</th>
@@ -65,7 +65,7 @@
                                             <span t-field="l.credit"/>
                                         </td>
                                         <td><span t-field="l.analytic_account_id"/></td>
-                                        <t t-if="l.amount_currency">
+                                        <t t-if="l.currency_id">
                                             <td class="text-right">
                                                 <span t-field="l.amount_currency"/>
                                             </td>


### PR DESCRIPTION
In some cases, the amount of a journal entry could be in a different
currency from the company, but still be zero, like in exchange diference
entries. Currently, in such cases, the column is hidden.

To solve the above, the column is shown when the currency is set for the
journal entry.