### PR TITLE
[IMP] stock_by_warehouse_sale: Fix big performance overhead

### DIFF
--- a/stock_by_warehouse/views/product_view.xml
+++ b/stock_by_warehouse/views/product_view.xml
@@ -12,7 +12,8 @@
         <field name="arch" type="xml">
             <data>
                 <field name="default_code" position="before">
-                    <field name="warehouses_stock" widget="warehouse" groups="stock.group_stock_multi_warehouses"/>
+                    <field name="warehouses_stock" widget="warehouse" colspan="1" groups="stock.group_stock_multi_warehouses"/>
+                    <field name="warehouses_stock_recompute" nolabel="1" colspan="1" widget="toggle_button" groups="stock.group_stock_multi_warehouses"/>
                 </field>
             </data>
         </field>
@@ -24,7 +25,8 @@
         <field name="arch" type="xml">
             <data>
                 <field name="default_code" position="before">
-                    <field name="warehouses_stock" widget="warehouse" groups="stock.group_stock_multi_warehouses"/>
+                    <field name="warehouses_stock" colspan="1" widget="warehouse" groups="stock.group_stock_multi_warehouses"/>
+                    <field name="warehouses_stock_recompute" nolabel="1" colspan="1" widget="toggle_button" groups="stock.group_stock_multi_warehouses"/>
                 </field>
             </data>
         </field>

--- a/stock_by_warehouse_purchase/views/purchase_view.xml
+++ b/stock_by_warehouse_purchase/views/purchase_view.xml
@@ -9,7 +9,10 @@
                 <xpath expr="//field[@name='order_line']//group" position="before">
                     <div class="text-center alert alert-info">
                         <p>The stock in: <field name="warehouse_id"/> that is immediately available is:
-                            <field name="warehouses_stock" widget="warehouse" groups="stock.group_stock_multi_warehouses" options="{'placement': 'bottom'}"/></p>
+                            <field name="warehouses_stock" widget="warehouse" groups="stock.group_stock_multi_warehouses" options="{'placement': 'bottom'}"/>
+                            &amp;nbsp;&amp;nbsp;
+                            <field name="warehouses_stock_recompute" nolabel="1" colspan="1" widget="toggle_button" groups="stock.group_stock_multi_warehouses"/>
+                        </p>
                     </div>
                 </xpath>
             </data>

--- a/stock_by_warehouse_sale/models/sale.py
+++ b/stock_by_warehouse_sale/models/sale.py
@@ -7,17 +7,18 @@ class SaleOrderLine(models.Model):
 
     _inherit = "sale.order.line"
 
-    warehouses_stock = fields.Text(compute="_compute_get_warehouses_stock")
+    warehouses_stock = fields.Text(store=False, readonly=True)
     warehouse_id = fields.Many2one(string="Warehouse",
                                    related='order_id.warehouse_id',
                                    readonly=True)
+    warehouses_stock_recompute = fields.Boolean(store=False, readonly=False)
 
     @api.multi
-    @api.depends('product_id', 'order_id.warehouse_id')
     def _compute_get_warehouses_stock(self):
         for line in self:
             line.warehouses_stock = line.product_id.with_context(
-                warehouse_id=line.warehouse_id).warehouses_stock
+                warehouse_id=line.warehouse_id
+            )._compute_get_quantity_warehouses_json()
 
     @api.multi
     @api.onchange('product_id')
@@ -33,3 +34,11 @@ class SaleOrderLine(models.Model):
             # is when we need to set the new fields.
             self.warehouse_id = self.order_id.warehouse_id
             self._compute_get_warehouses_stock()
+
+    @api.onchange('warehouses_stock_recompute')
+    def _warehouses_stock_recompute_onchange(self):
+        if not self.warehouses_stock_recompute:
+            self.warehouses_stock_recompute = True
+            return
+        self._compute_get_warehouses_stock()
+        self.warehouses_stock_recompute = True

--- a/stock_by_warehouse_sale/views/sale_view.xml
+++ b/stock_by_warehouse_sale/views/sale_view.xml
@@ -9,7 +9,10 @@
                 <xpath expr="//field[@name='order_line']//group" position="before">
                     <div class="text-center alert alert-info">
                         <p>The saleable stock in: <field name="warehouse_id"/> that can be delivered immediately is:
-                            <field name="warehouses_stock" widget="warehouse" groups="stock.group_stock_multi_warehouses" options="{'placement': 'bottom'}"/></p>
+                            <field name="warehouses_stock" widget="warehouse" groups="stock.group_stock_multi_warehouses" options="{'placement': 'bottom'}"/>
+                            &amp;nbsp;&amp;nbsp;
+                            <field name="warehouses_stock_recompute" nolabel="1" colspan="1" widget="toggle_button" groups="stock.group_stock_multi_warehouses"/>
+                        </p>
                     </div>
                 </xpath>
             </data>


### PR DESCRIPTION
[![Try me on Runbot](https://img.shields.io/badge/runbot-Try%20me-875A7B.png)](https://runbot.vauxoo.com/runbot/85/671)

# Current behavior before PR:

We need avoid using compute fields as possible because of the following issue:
 - https://github.com/odoo/odoo/issues/30578
warehouses_stock is a computed field used just one time but re-computed too many times:
 - Opening sale order (one time by each line)
 - Saving sale order
 - Choosing a product_id
And it computation is more and more slow when the database grows.
It is making a big overhead saving sale.order.

Before of this commit editing just one product:
 - <img width="445" alt="Screen Shot 2019-07-21 at 10 09 00 PM" src="https://user-images.githubusercontent.com/6644187/61606152-8147d980-ac0e-11e9-9db4-83fda45c1605.png">

production pyflame profiling the black rectangles are of `stock_by_warehouse...` modules:
 - ![Screen Shot 2019-07-21 at 11 45 23 PM](https://user-images.githubusercontent.com/6644187/61606983-670ffa80-ac12-11e9-8c9a-23b1dc28fe8a.png)


# Desired behavior after PR is merged:

With this change we have the same behaviour using it just for onchange
product_id or forcing from a seudo-button (field boolean)
A real button is not used since that it requires save the record to work

Using the technical of fields with store=False and onchange methods
Dummy PR:
 - https://git.vauxoo.com/vauxoo/typ/merge_requests/671

Check the following video testing it:
 - [![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/3rmx0B2GQrQ/0.jpg)](https://www.youtube.com/watch?v=3rmx0B2GQrQ)

# Considerations:
We have changed the computed to field computed on-demand or product_id onchange then we have a little change of functionality.
1) For sale and purchase form view the widget data is filled from onchange but If you open an exists sale.order.line and you like to fill the widget data (without onchange) then you need use `EDIT` button and press the `new button` to fill the widget data.
 - ![Screen Shot 2019-07-21 at 11 27 52 PM](https://user-images.githubusercontent.com/6644187/61606486-3333d580-ac10-11e9-8d6f-975d16bd4318.png)
2) For product form view the widget is not auto-computed, then you will need use the `new button` to fill widget data.
  - ![Screen Shot 2019-07-21 at 11 26 53 PM](https://user-images.githubusercontent.com/6644187/61606536-7130f980-ac10-11e9-80bb-ef2a3ebfefad.png)
