### PR TITLE
WIP [ADD] New feature sale price usd

### DIFF
--- a/product_sale_usd/README.rst
+++ b/product_sale_usd/README.rst
@@ -1,0 +1,36 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+Product Sale Price in USD:
+==========================
+
+This module adds a field to handle sale price in USD on products.
+The approach is to have another currency like base currency and the sale price in USD,
+so that the sale prices in company currency can be calculate in base to the sale price in USD.
+
+Features:
+---------
+
+- New 'Sale Price in USD' field on the product's form.
+- The Sale Price of Odoo is calculated in base to Sale Price in USD daily with the last rate of dollar.
+- Allow computation in pricelist based on Sale Price in USD.
+- The sales price is calculated daily with the new rate
+  The sales price is re-calculated if Sales Price in USD field is changed o setted.
+- When the value of Sales Price USD is changed in the product, then, the Sale Price will be calculate too.
+- The USD currency will be activated
+- The Pricelist with formula will be activated
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/vauxoo/addons-vauxoo/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Yanina Aular <yanina.aular@vauxoo.com>

--- a/product_sale_usd/__init__.py
+++ b/product_sale_usd/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Vauxoo
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import models

--- a/product_sale_usd/__manifest__.py
+++ b/product_sale_usd/__manifest__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Vauxoo
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "Product Sale Price in USD",
+    "summary": '''
+This module adds the field Sale Price in USD to the Product form.
+    ''',
+    "version": "10.0.0.0.1",
+    "author": "Vauxoo",
+    "category": "Sales",
+    "website": "http://vauxoo.com",
+    "license": "LGPL-3",
+    "depends": [
+        'product',
+        'sale',
+    ],
+    "data": [
+        "views/product_view.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/product_sale_usd/models/__init__.py
+++ b/product_sale_usd/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Vauxoo
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import product
+from . import pricelist
+from . import sale_order

--- a/product_sale_usd/models/pricelist.py
+++ b/product_sale_usd/models/pricelist.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Vauxoo
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+from odoo import models, fields, api
+
+
+class Pricelist(models.Model):
+
+    _inherit = "product.pricelist"
+
+    @api.multi
+    def _compute_price_rule(
+            self, products_qty_partner, date=False, uom_id=False):
+        """ Inherited to modify price computation when a pricelist item is
+        based on cost in USD.
+
+        Why this inheritance?
+
+        This method always compute the product price, from product currency
+        (mostly the same company currency) into pricelist currency. When the
+        pricelist item is based on cost in USD is necessary that currency
+        conversion is made from USD currency. By this reason we must go back
+        the conversion made in super and then made a conversion from USD
+        currency to the pricelist currency to get the expected price when the
+        pricelist item is based on cost in USD.
+
+        Returns: dict{product_id: (price, suitable_rule) for given pricelist}
+
+        If date in context: Date of the pricelist (%Y-%m-%d)
+
+        :param products_qty_partner: list of typles products, quantity, partner
+        :param datetime date: validity date
+        :param ID uom_id: intermediate unit of measure
+        """
+        results = super(Pricelist, self)._compute_price_rule(
+            products_qty_partner, date=date, uom_id=uom_id)
+        usd_currency = self.env.ref('base.USD')
+        for product_id in results:
+            # get current price and pricelist item for product_id
+            price, item_id = results[product_id]
+            suitable_rule = self.item_ids.filtered(lambda x: x.id == item_id)
+            # look that pricelist item is based on cost in usd
+            if not suitable_rule or suitable_rule.base != 'sale_price_usd':
+                continue
+            product = self.env['product.product'].browse(product_id)
+            # go back conversion made in super, moving the price into
+            # product currency for items based on cost in USD
+            price = self.currency_id.compute(
+                price, product.currency_id, round=False)
+            # now convert from USD into pricelist currency
+            if self.currency_id != usd_currency:
+                price = usd_currency.compute(
+                    price, self.currency_id, round=False)
+            results[product_id] = (
+                price, suitable_rule and suitable_rule.id or False)
+        return results
+
+
+class PricelistItem(models.Model):
+
+    _inherit = "product.pricelist.item"
+
+    base = fields.Selection(
+        selection_add=[('sale_price_usd', 'Sale Price in USD')])

--- a/product_sale_usd/models/product.py
+++ b/product_sale_usd/models/product.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Vauxoo
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.addons import decimal_precision as dp
+from odoo import models, fields, api, _
+
+
+class ProductTemplate(models.Model):
+
+    _inherit = "product.template"
+
+    @api.depends('sale_price_usd')
+    def _compute_sale_price(self):
+        usd_currency = self.env.ref('base.USD')
+        company = self.env.user.company_id
+        local_currency = company.currency_id
+        for product in self:
+            local_currency_value = local_currency._convert(
+                product.sale_price_usd, usd_currency, company,
+                fields.Date.today())
+            product.list_price = local_currency_value
+
+    def _inverse_sale_price(self):
+        usd_currency = self.env.ref('base.USD')
+        company = self.env.user.company_id
+        currency = company.currency_id
+        for product in self:
+            usd_currency_value = usd_currency._convert(
+                product.list_price, currency, company,
+                fields.Date.today())
+            product.sale_price_usd = usd_currency_value
+
+    list_price = fields.Float(
+        compute="_compute_sale_price",
+        inverse="_inverse_sale_price",
+    )
+
+    sale_price_usd = fields.Float(
+        'Sale Price in USD',
+        digits=dp.get_precision('Product Price'),
+        help="Sale price of the product in USD currency")

--- a/product_sale_usd/models/sale_order.py
+++ b/product_sale_usd/models/sale_order.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Vauxoo
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    @api.model
+    def _get_purchase_price(self, pricelist, product, product_uom, date):
+        """ Inherited to recalculate purchase price when pricelist item is
+        based on cost in usd.
+        """
+        res = super(SaleOrderLine, self)._get_purchase_price(
+            pricelist, product, product_uom, date)
+        price_rule = pricelist._compute_price_rule([(product, 1, False)])
+        price, rule = price_rule[product.id]
+        suitable_rule = pricelist.item_ids.filtered(lambda x: x.id == rule)
+        if not suitable_rule or suitable_rule.base != 'sale_price_usd':
+            return res
+        frm_cur = self.env.ref('base.USD')
+        to_cur = pricelist.currency_id
+        purchase_price = product.sale_price_usd
+        if product_uom != product.uom_id:
+            purchase_price = product.uom_id._compute_price(
+                purchase_price, product_uom)
+        price = frm_cur.with_context(date=date).compute(
+            purchase_price, to_cur, round=False)
+        return {'purchase_price': price}
+
+    @api.model
+    def _compute_margin(self, order_id, product_id, product_uom_id):
+        """ Inherited to recalculate purchase price when pricelist item is
+        based on cost in usd.
+
+        Why this inheritance?
+
+        In spite of the name this method is only used to get the purchase
+        price, calling the method get_purchase_price we reuse that logic to
+        calculate the purchase price when pricelist item is based on cost
+        in usd.
+        """
+        price = super(SaleOrderLine, self)._compute_margin(
+            order_id, product_id, product_uom_id)
+        date = order_id.date_order
+        prices = self._get_purchase_price(
+            order_id.pricelist_id, product_id, product_uom_id, date)
+        return prices.get('purchase_price', price)

--- a/product_sale_usd/tests/__init__.py
+++ b/product_sale_usd/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Vauxoo
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import test_standard_price_usd

--- a/product_sale_usd/tests/test_standard_price_usd.py
+++ b/product_sale_usd/tests/test_standard_price_usd.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+
+from __future__ import division
+
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import ValidationError
+from odoo.tools import float_round, float_compare
+from odoo import fields
+
+
+class TestStandardPriceUsd(TransactionCase):
+
+    def setUp(self):
+        super(TestStandardPriceUsd, self).setUp()
+        self.mxn = self.env.ref('base.MXN')
+        self.usd = self.env.ref('base.USD')
+        self.sale_order = self.env['sale.order']
+        self.partner = self.env.ref('base.res_partner_4')
+        self.product_uom = self.env.ref('product.product_uom_unit')
+        self.product = self.env.ref('product.product_product_24')
+        self.pricelist_15_usd = self.env['product.pricelist'].create({
+            'name': 'Pricelist 15% USD',
+            'currency_id': self.usd.id,
+            'item_ids': [(0, 0, {
+                    'compute_price': 'formula',
+                    'base': 'standard_price_usd',  # based on cost in usd
+                    'price_discount': -15,
+                })]
+        })
+        self.pricelist_15_mxn = self.pricelist_15_usd.copy({
+            'name': 'Pricelist 15% MXN',
+            'currency_id': self.mxn.id})
+        self.pricelist = self.env['product.pricelist'].create({
+            'name': 'Pricelist Demo'})
+
+    def set_standard_price_usd(self, price):
+        self.assertTrue(self.product.seller_ids)
+        self.product.seller_ids[0].write({'currency_id': self.usd.id})
+        self.product.write({'standard_price_usd': price})
+
+    def test_01(self):
+        """ Test USD pricelist based on cost in usd. """
+        self.set_standard_price_usd(880)
+        product = self.product.with_context(pricelist=self.pricelist_15_usd.id)
+        expected_price = float_round(
+            product.standard_price_usd * 1.15,
+            precision_rounding=self.usd.rounding)
+        self.assertEqual(
+            float_compare(product.price, expected_price, precision_digits=2),
+            0, "Product price should be %s" % product.price)
+
+    def test_02(self):
+        """ Test a MXN pricelist based on cost in usd. """
+        self.set_standard_price_usd(880)
+        product = self.product.with_context(pricelist=self.pricelist_15_mxn.id)
+        mxn_rate = (self.mxn.rate / self.usd.rate)
+        expected_price = float_round(
+            (product.standard_price_usd * 1.15) * mxn_rate,
+            precision_rounding=self.mxn.rounding)
+        self.assertEqual(
+            float_compare(product.price, expected_price, precision_digits=2),
+            0, "Product price should be %s" % product.price)
+
+    def test_03(self):
+        """ Test constraint check_cost_and_price. """
+        with self.assertRaisesRegexp(
+                ValidationError,
+                'You must have at least one supplier with price in USD'):
+            self.product.write({'standard_price_usd': 880})
+
+    def test_04(self):
+        """ Test constraint check_cost_and_price. """
+        with self.assertRaisesRegexp(
+                ValidationError,
+                'You cannot create or modify a product if the cost in USD'):
+            self.set_standard_price_usd(1)
+
+    def test_sale_margin(self):
+        """ Test the sale margin module using a pricelist with cost in usd. """
+        self.set_standard_price_usd(880)
+        product = self.product.with_context(pricelist=self.pricelist_15_mxn.id)
+        # Create a sale order for product Graphics Card.
+        sale_order = self.sale_order.create({
+            'date_order': fields.Datetime.now(),
+            'name': 'Test',
+            'order_line': [(0, 0, {
+                'name': '[CARD] Graphics Card',
+                'product_uom': self.product_uom.id,
+                'product_uom_qty': 1,
+                'state': 'draft',
+                'product_id': product.id})],
+            'partner_id': self.partner.id,
+            'pricelist_id': self.pricelist_15_mxn.id})
+        # Confirm the sale order.
+        sale_order.action_confirm()
+        # Verify that margin field gets bind with the value.
+        mxn_rate = (self.mxn.rate / self.usd.rate)
+        expected_price = float_round(
+            (product.standard_price_usd * 1.15) * mxn_rate,
+            precision_rounding=self.mxn.rounding)
+        expected_cost = float_round(
+            product.standard_price_usd * mxn_rate,
+            precision_rounding=self.mxn.rounding)
+        margin = float_round(
+            expected_price - expected_cost,
+            precision_rounding=self.mxn.rounding)
+        self.assertEqual(
+            float_compare(sale_order.margin, margin, precision_digits=2),
+            0, "Sale order margin should be %s" % margin)
+
+    def test_sale_margin_normal(self):
+        """ Test the sale margin module using a pricelist without cost in
+        usd.
+        """
+        # Create a sale order for product Graphics Card.
+        sale_order = self.sale_order.create({
+            'date_order': fields.Datetime.now(),
+            'name': 'Test',
+            'order_line': [(0, 0, {
+                'name': '[CARD] Graphics Card',
+                'product_uom': self.product_uom.id,
+                'product_uom_qty': 1,
+                'state': 'draft',
+                'product_id': self.product.id})],
+            'partner_id': self.partner.id,
+            'pricelist_id': self.pricelist.id})
+        # Confirm the sale order.
+        sale_order.action_confirm()
+        # Verify that margin field gets bind with the value.
+        msg = "Sale order margin should be 9.0"
+        self.assertEqual(sale_order.margin, 9.0, msg)

--- a/product_sale_usd/views/product_view.xml
+++ b/product_sale_usd/views/product_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.inherit</field>
+        <field name="model">product.template</field>
+        <field name="type">form</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <field name="list_price" position="after">
+                <field name="sale_price_usd" widget="monetary"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>
+


### PR DESCRIPTION
New 'Sale Price in USD' field on the product's form.
The Sale Price of Odoo is calculated in base to Sale Price in USD daily with the last rate of dollar.
Allow computation in pricelist based on Sale Price in USD.
The sales price is calculated daily with the new rate
The sales price is re-calculated if Sales Price in USD field is changed or setted.
The Sales Price in USD is re-calculated if sales price is changed or setted.