### PR TITLE
Improve the advance_payment with Default Account and Domain

### DIFF
--- a/account_advance_payment/model/account_voucher.py
+++ b/account_advance_payment/model/account_voucher.py
@@ -32,7 +32,7 @@ class account_voucher(osv.Model):
     _columns = {
         'advance_account_id': fields.many2one('account.account', 'Advance Account', required=False, readonly=True, states={'draft': [('readonly', False)]}),
     }
-
+    
     def writeoff_move_line_get(self, cr, uid, voucher_id, line_total, move_id, name, company_currency, current_currency, context=None):
         move_line = super(account_voucher, self).writeoff_move_line_get(cr, uid, voucher_id, line_total, move_id, name, company_currency, current_currency, context=context)
         voucher = self.pool.get('account.voucher').browse(cr, uid, voucher_id, context)
@@ -56,9 +56,12 @@ class account_voucher(osv.Model):
         partner = partner_pool.browse(cr, uid, partner_id, context=context)
         advance_account_id = False
         if ttype in ('sale', 'receipt'):
-            advance_account_id = partner.property_account_customer_advance and partner.property_account_customer_advance.id or False
+            advance_account_id = partner.property_account_customer_advance and partner.property_account_customer_advance.id \
+                or partner.property_account_receivable and partner.property_account_receivable.id or False
         else:
-            advance_account_id = partner.property_account_supplier_advance and partner.property_account_supplier_advance.id or False
+            advance_account_id = partner.property_account_supplier_advance and partner.property_account_supplier_advance.id \
+                or partner.property_account_payable and partner.property_account_payable.id or False
+                
         res['value']['advance_account_id'] = advance_account_id
 
         return res

--- a/account_advance_payment/view/account_voucher_advance_payment_view.xml
+++ b/account_advance_payment/view/account_voucher_advance_payment_view.xml
@@ -7,7 +7,7 @@
                 <field name="inherit_id" ref="account_voucher.view_vendor_receipt_form"/>
                 <field name="arch" type="xml">
                     <xpath expr="//field[@name='journal_id']" position="after">
-                        <field name="advance_account_id"/>
+                        <field name="advance_account_id" domain="[('journal_id', '=', journal_id)]"/>
                     </xpath>
                 </field>
         </record>
@@ -17,7 +17,7 @@
                 <field name="inherit_id" ref="account_voucher.view_vendor_payment_form"/>
                 <field name="arch" type="xml">
                     <xpath expr="//field[@name='journal_id']" position="after">
-                        <field name="advance_account_id"/>
+                        <field name="advance_account_id" domain="[('journal_id', '=', journal_id)]"/>
                     </xpath>
                 </field>
         </record>


### PR DESCRIPTION

1. The Default of Advance Account is improved by referring the default payable and
receivable account when Advance Account is not setup.
2. Add the domain filter in the field of advance_account_id so that we could limit
the account thru account_journal.