### PR TITLE
[IMP] partner_credit_limit: Improve the module for multicompany

### DIFF
--- a/partner_credit_limit/__manifest__.py
+++ b/partner_credit_limit/__manifest__.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     "name": "Partner Credit Limit",
-    "version": "11.0.0.0.1",
+    "version": "11.0.0.0.2",
     "author": "Vauxoo",
     "category": "",
     "website": "http://www.vauxoo.com/",

--- a/partner_credit_limit/i18n/es.po
+++ b/partner_credit_limit/i18n/es.po
@@ -16,12 +16,13 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: partner_credit_limit
-#: field:res.partner,allowed_sale:0
+#: model:ir.model.fields,field_description:partner_credit_limit.field_res_partner_allowed_sale
+#: model:ir.model.fields,field_description:partner_credit_limit.field_res_users_allowed_sale
 msgid "Allowed Sales"
 msgstr "Venta a crédito permitida"
 
 #. module: partner_credit_limit
-#: code:addons/partner_credit_limit/model/sale.py:30
+#: code:addons/partner_credit_limit/model/sale.py:28
 #, python-format
 msgid "Can not confirm the Sale Order because Partner has late payments or has exceeded the credit limit.\n"
 "Please cover the late payment or check credit limit\n"
@@ -31,7 +32,7 @@ msgstr "No se puede confirmar la orden de venta por que el cliente tiene pagos a
 "Límite de Crédito : %s"
 
 #. module: partner_credit_limit
-#: code:addons/partner_credit_limit/model/accout_invoice.py:31
+#: code:addons/partner_credit_limit/model/account_invoice.py:30
 #, python-format
 msgid "Can not validate the Invoice because Partner has late payments or has exceeded the credit limit.\n"
 "Please cover the late payment or check credit limit\n"
@@ -41,28 +42,39 @@ msgstr "No se puede validar la Factura porque el cliente tiene pagos atrasados o
 "Límite de Crédito : %s"
 
 #. module: partner_credit_limit
-#: field:res.partner,credit_overloaded:0
+#: model:ir.model,name:partner_credit_limit.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: partner_credit_limit
+#: model:ir.model.fields,field_description:partner_credit_limit.field_res_partner_credit_overloaded
+#: model:ir.model.fields,field_description:partner_credit_limit.field_res_users_credit_overloaded
 msgid "Credit Overloaded"
 msgstr "Crédito Excedido"
 
 #. module: partner_credit_limit
-#: field:res.partner,grace_payment_days:0
-#: help:res.partner,grace_payment_days:0
+#: model:ir.model.fields,field_description:partner_credit_limit.field_res_partner_grace_payment_days
+#: model:ir.model.fields,field_description:partner_credit_limit.field_res_users_grace_payment_days
+#: model:ir.model.fields,help:partner_credit_limit.field_res_partner_grace_payment_days
+#: model:ir.model.fields,help:partner_credit_limit.field_res_users_grace_payment_days
 msgid "Days grace payment"
 msgstr "Días de gracia para pago"
 
 #. module: partner_credit_limit
-#: help:res.partner,allowed_sale:0
+#: model:ir.model.fields,help:partner_credit_limit.field_res_partner_allowed_sale
+#: model:ir.model.fields,help:partner_credit_limit.field_res_users_allowed_sale
 msgid "If the Partner has credit overloaded or late payments, he can't validate invoices and sale orders."
 msgstr "Si el Cliente tiene crédito excedido o pagos atrasados, no puede validar facturas y ordenes de venta."
 
 #. module: partner_credit_limit
-#: help:res.partner,credit_overloaded:0
+#: model:ir.model.fields,help:partner_credit_limit.field_res_partner_credit_overloaded
+#: model:ir.model.fields,help:partner_credit_limit.field_res_users_credit_overloaded
 msgid "Indicates when the customer has credit overloaded"
 msgstr "Indica cuando el cliente tiene crédito excedido"
 
 #. module: partner_credit_limit
-#: help:res.partner,overdue_credit:0
+#: model:ir.model.fields,help:partner_credit_limit.field_res_partner_overdue_credit
+#: model:ir.model.fields,help:partner_credit_limit.field_res_users_overdue_credit
 msgid "Indicates when the customer has late payments"
 msgstr "Indica cuando el cliente tiene pagos atrasados"
 
@@ -73,18 +85,12 @@ msgstr "Factura"
 
 #. module: partner_credit_limit
 #: model:ir.actions.act_window,name:partner_credit_limit.action_account_moves_late_payments
-#: view:res.partner:partner_credit_limit.view_category_property_form
-#: field:res.partner,overdue_credit:0
+#: model:ir.model.fields,field_description:partner_credit_limit.field_res_partner_overdue_credit
+#: model:ir.model.fields,field_description:partner_credit_limit.field_res_users_overdue_credit
 msgid "Late Payments"
 msgstr "Pagos Atrasados"
 
 #. module: partner_credit_limit
-#: model:ir.model,name:partner_credit_limit.model_res_partner
-msgid "Partner"
-msgstr "Empresa"
-
-#. module: partner_credit_limit
 #: model:ir.model,name:partner_credit_limit.model_sale_order
-msgid "Sales Order"
-msgstr "Pedido de venta"
-
+msgid "Quotation"
+msgstr "Presupuesto"

--- a/partner_credit_limit/migrations/11.0.0.0.2/post-migration.py
+++ b/partner_credit_limit/migrations/11.0.0.0.2/post-migration.py
@@ -1,0 +1,33 @@
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    set_credit_limit_values_to_partner(cr)
+
+
+def set_credit_limit_values_to_partner(cr):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env.cr.execute(
+        """
+        SELECT id, credit_limit, grace_payment_days FROM res_partner
+        WHERE credit_limit != 0 OR grace_payment_days != 0""")
+    data = env.cr.fetchall()
+    for company in env['res.company'].search([]):
+        for partner_id, credit_limit, grace_payment_days in data:
+            env['res.partner'].browse(partner_id).with_context(
+                force_company=company.id).write({
+                    'credit_limit': credit_limit,
+                    'grace_payment_days': grace_payment_days})
+    env['ir.logging'].create({
+        'name': 'partner_credit_limit migration',
+        'level': 'info',
+        'type': 'server',
+        'dbname': env.cr.dbname,
+        'message': data,
+        'path': 'migration script',
+        'line': 'migration script',
+        'func': 'migration script'
+    })
+    env.cr.execute("""ALTER TABLE res_partner DROP COLUMN credit_limit""")
+    env.cr.execute("""ALTER TABLE res_partner
+                   DROP COLUMN grace_payment_days""")

--- a/partner_credit_limit/model/partner.py
+++ b/partner_credit_limit/model/partner.py
@@ -8,9 +8,10 @@ from odoo import models, fields, api
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
+    credit_limit = fields.Float(company_dependent=True)
     grace_payment_days = fields.Float(
         'Days grace payment',
-        help='Days grace payment')
+        help='Days grace payment', company_dependent=True)
 
     credit_overloaded = fields.Boolean(
         compute='_get_credit_overloaded',
@@ -40,7 +41,10 @@ class ResPartner(models.Model):
 
     @api.model
     def movelines_domain(self, partner):
+        """Return the domain for search the
+        account.move.line for the user's company."""
         domain = [('partner_id', '=', partner.id),
+                  ('company_id', '=', self.env.user.company_id.id),
                   ('account_id.internal_type', '=', 'receivable'),
                   ('move_id.state', '!=', 'draft'),
                   ('reconciled', '=', False)]


### PR DESCRIPTION
- For instances of multiple companies, the credit limit value or days of grace
does not differentiate between company, so if the customer has a credit limit
`100` with `company A`, that same value will be in the `company B`.

- In some cases these values changes according to the company.

- With this change the `account.move.line` are searched according to the
company and additionally the credit limit fields and grace days now
depend on the company.

- Migration script to set the old values for the `credit_limit` and
`grace_payment_days` fields.

Videos in the comments: 

- https://youtu.be/d9p8Hs4JkiQ
- https://youtu.be/7Qyi-SSNMt8 
- https://youtu.be/z6quTSznYpA
- https://youtu.be/LeavM1fmDJ8