### PR TITLE
[FIX] partner_credit_limit: fix module version

### DIFF
--- a/partner_credit_limit/__manifest__.py
+++ b/partner_credit_limit/__manifest__.py
@@ -1,9 +1,8 @@
-# coding: utf-8
 # Copyright 2016 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     "name": "Partner Credit Limit",
-    "version": "10.0.0.1.0",
+    "version": "11.0.0.0.1",
     "author": "Vauxoo",
     "category": "",
     "website": "http://www.vauxoo.com/",


### PR DESCRIPTION
This change is necessary:
1. Maintain the consistency of the module.
2. When executing a migration `11. * `it is not executed since when installing the module with the current version, it is saved in bd as `11.0.10.0.0.1.0.` To execute it, you must place the manifest as `11.0.10.0.0.1.1` which is incorrect.

![Screen Shot 2019-10-22 at 4 36 52 PM](https://user-images.githubusercontent.com/11479473/67336055-52c9eb00-f4ea-11e9-8e67-40c6be1d8b6d.png)
