### PR TITLE
[FIX] mrp_workcenter_account_move: Avoid traceback when creating a valuation adjustment line in account.move

### DIFF
--- a/mrp_workcenter_account_move/model/mrp.py
+++ b/mrp_workcenter_account_move/model/mrp.py
@@ -215,7 +215,7 @@ class MrpProduction(models.Model):
         accounts = self.product_id.product_tmpl_id.get_product_accounts()
         # NOTE: make different between (REAL, AVG) and STD products
         # STD diff shall be booked onto a deviation account
-        valuation_account_id = accounts['stock_valuation']
+        valuation_account_id = accounts['stock_valuation'].id
 
         if self.product_id.cost_method == 'standard':
             company_brw = self.env.user.company_id


### PR DESCRIPTION
If, when closing a manufacturing order, a valuation adjustment line is created, taking the `stock_valuation` account, the following traceback is obtained

![image](https://user-images.githubusercontent.com/11479473/68338099-67d87980-00a7-11ea-8f41-6ad0cb4bfc46.png)



![image](https://user-images.githubusercontent.com/11479473/68337952-2647ce80-00a7-11ea-8a44-584c0acc6d02.png)

This happens because it try to create the line with the object `account.account` and not with the account id.

![image](https://user-images.githubusercontent.com/11479473/68338427-04028080-00a8-11ea-874d-e8232ade5aa4.png)


This PR fix that case. 

![image](https://user-images.githubusercontent.com/11479473/68338138-79ba1c80-00a7-11ea-9fc3-c1ec1cadbd1e.png)


![image](https://user-images.githubusercontent.com/11479473/68338158-850d4800-00a7-11ea-9356-de76f4638467.png)


