### PR TITLE
[FIX] account_refund_early_payment: Fix account dependency

### DIFF
--- a/account_refund_early_payment/__manifest__.py
+++ b/account_refund_early_payment/__manifest__.py
@@ -9,7 +9,7 @@
     'license': 'LGPL-3',
     'category': '',
     'depends': [
-        'account_accountant',
+        'account',
     ],
     'data': [
         'data/data.xml',


### PR DESCRIPTION
Travis is failing because the `account_refund_early_payment` module
    depends on `account_accountant` instead of `account`. The module
    `account_accounting`, from the v12 is available on enterprise.