### PR TITLE
[FIX] account_analytic_policy: When create an account move line, the validation of the account and analytic account fails because self does not exist

### DIFF
--- a/account_analytic_policy/model/account_move_line.py
+++ b/account_analytic_policy/model/account_move_line.py
@@ -39,31 +39,33 @@ class AccountMoveLine(models.Model):
                        if ('account_id' in vals) else record.account_id)
             analytic = (
                 analytic.browse(
-                    vals['analytic_account_id']) if ('analytic_account_id' in vals)
+                    vals['analytic_account_id']) if (
+                        'analytic_account_id' in vals)
                 else record.analytic_account_id)
             policy = account.analytic_policy
             if not policy or policy == 'optional':
                 continue
             if policy == 'never' and analytic:
                 raise UserError(_(
-                    'You cannot use analytic accounts on a move line with Analytic '
-                    'Policy "Never" contact the account manager or fix the '
-                    'account configuration or pick another account.\n\n') +
-                                '%s' % account.name_get())
+                    'You cannot use analytic accounts on a move line with '
+                    'Analytic Policy "Never" contact the account manager or '
+                    'fix the account configuration or pick another '
+                    'account.\n\n') + '%s' % account.name_get())
             if policy == 'always' and not analytic:
                 raise UserError(_(
-                    'You must use analytic accounts on a move line with Analytic '
-                    'Policy "Always" contact the account manager or fix the '
-                    'account configuration or pick another account.\n\n') +
-                                '%s' % account.name_get())
+                    'You must use analytic accounts on a move line with '
+                    'Analytic Policy "Always" contact the account manager '
+                    'or fix the account configuration or pick another '
+                    'account.\n\n') + '%s' % account.name_get())
         return True
 
     @api.model
     def create(self, vals):
-        self._is_analytic_policy_ok(vals)
-        return super(AccountMoveLine, self).create(vals)
+        res = super().create(vals)
+        res._is_analytic_policy_ok(vals)
+        return res
 
     @api.multi
     def write(self, vals):
         self._is_analytic_policy_ok(vals)
-        return super(AccountMoveLine, self).write(vals)
+        return super().write(vals)


### PR DESCRIPTION
When a stock_move_line is created, validation does not work because self is empty, therefore, the creation (called super) must be first, and then, validation works correctly.