### PR TITLE
[FIX] mrp_workcenter_account_move: use context_today(self) instead of…

### DIFF
--- a/mrp_workcenter_account_move/model/mrp.py
+++ b/mrp_workcenter_account_move/model/mrp.py
@@ -114,7 +114,7 @@ class MrpProduction(models.Model):
     def _create_account_move(self):
         self.ensure_one()
         am_obj = self.env['account.move']
-        date = fields.Date.today()
+        date = fields.Date.context_today(self)
         journal_id = self.routing_id and self.routing_id.journal_id or \
             self.product_id.categ_id.property_stock_journal
         vals = {


### PR DESCRIPTION
[FIX] mrp_workcenter_account_move: use context_today(self) instead of today() in order to use client's timezone

Related to issue 9173

There is a dummy pr at: https://git.vauxoo.com/vauxoo/quebec/merge_requests/68

This is actually a regression 

The right code prior regression:
https://github.com/Vauxoo/addons-vauxoo/commit/f98b720ac43af42c8f3b4362964b0a79dff1d48e#diff-4f88a6aec1e93733f63628f20ca22e33R87

The code that is wrong after regression
https://github.com/Vauxoo/addons-vauxoo/commit/07ed0faa6d834aee8302f57917d857eda04b4601#diff-4f88a6aec1e93733f63628f20ca22e33L143-R117