### PR TITLE
[FIX] stock_cost_segmentation: Decrease logistic qty on multi-step outputs

### DIFF
--- a/stock_cost_segmentation/models/stock_move.py
+++ b/stock_cost_segmentation/models/stock_move.py
@@ -327,7 +327,8 @@ class StockMove(models.Model):
         candidates = (
             move.product_id._get_fifo_logistic_candidates_in_move(
                 move.location_id or
-                move.picking_type_id.default_location_src_id) or
+                move.picking_type_id.default_location_src_id,
+                move.warehouse_id) or
             move.product_id._get_fifo_candidates_in_move())
         candidates -= used
 
@@ -499,7 +500,8 @@ class StockMoveLine(models.Model):
                         move_id.product_id.
                         _get_fifo_logistic_candidates_in_move(
                             move_id.location_id or
-                            move_id.picking_type_id.default_location_src_id),
+                            move_id.picking_type_id.default_location_src_id,
+                            move_id.warehouse_id),
                         order='date, id desc', limit=1)
                     if candidates_receipt:
                         candidates_receipt.write({


### PR DESCRIPTION
Currently, when a product delivery is processed  and that product has no
associated lot/serial, the logistic remaining quantity is decreased from
the source location of the stock move that is processing the output.
However, that beavior is not correct on multi-step outputs, because the
source location will be the previous step, instead of the actual stock
location.

To solve the above, when the product is not found on the stock move's
source location, it is looked for on the warehouse's stock location,
along with its childs locations.