### PR TITLE
[FIX] Called ir_rule does not reflect changes because it stays in cache T#38574

### DIFF
--- a/default_warehouse_from_sale_team/models/account_journal.py
+++ b/default_warehouse_from_sale_team/models/account_journal.py
@@ -1,10 +1,35 @@
-# coding: utf-8
-
-from openerp import fields, models
+# Copyright 2020 Vauxoo
+# License AGPL-3 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, models, fields
 
 
 class AccountJournal(models.Model):
+    _inherit = "account.journal"
 
-    _inherit = 'account.journal'
+    section_id = fields.Many2one("crm.team", string="Sale team")
 
-    section_id = fields.Many2one('crm.team', string='Sale team')
+    @api.multi
+    def write(self, vals):
+        """The workers cache is cleared when the `section_id` field is modified to reflect the changes when the
+        following domain is called:
+        * `rule_default_warehouse_journal`
+        """
+        if vals.get("section_id"):
+            self.clear_caches()
+        return super(AccountJournal, self).write(vals)
+
+    @api.multi
+    def create(self, values):
+        """The workers cache is cleared to reflect the changes when the following domain is called:
+        * `rule_default_warehouse_journal`
+        """
+        if values.get("section_id"):
+            self.clear_caches()
+        return super(AccountJournal, self).create(values)
+
+    @api.multi
+    def unlink(self):
+        """The workers cache is cleared when a record it's deleted,
+        """
+        self.clear_caches()
+        return super(AccountJournal, self).unlink()

--- a/default_warehouse_from_sale_team/models/res_users.py
+++ b/default_warehouse_from_sale_team/models/res_users.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
-
-from openerp import api, fields, models, _
-from openerp.exceptions import ValidationError
+# Copyright 2020 Vauxoo
+# License AGPL-3 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 
 
 class ResUsers(models.Model):
-
     _inherit = "res.users"
 
     sale_team_ids = fields.Many2many(
@@ -25,3 +24,24 @@ class ResUsers(models.Model):
                 ' do not belongs to the sale teams.\nPlease go to Sales >'
                 ' Settings > Users > Sales Teams if you will like to add this'
                 ' user to the sales team') % (user.sale_team_id.name))
+
+    @api.multi
+    def write(self, vals):
+        """The workers cache is cleared when the `sale_team_ids` field is modified to reflect the changes when the
+        following domain is called:
+        * `rule_default_warehouse_journal`
+        """
+        res = super(ResUsers, self).write(vals)
+        if vals.get("sale_team_ids"):
+            self.clear_caches()
+        return res
+
+    @api.multi
+    def create(self, values):
+        """The workers cache is cleared to reflect the changes when the following domain is called:
+        * `rule_default_warehouse_journal`
+        """
+        res = super(ResUsers, self).create(values)
+        if values.get("sale_team_ids"):
+            self.clear_caches()
+        return res

--- a/default_warehouse_from_sale_team/models/sales_team.py
+++ b/default_warehouse_from_sale_team/models/sales_team.py
@@ -1,10 +1,9 @@
-# coding: utf-8
-
-from openerp import api, fields, models
+# Copyright 2020 Vauxoo
+# License AGPL-3 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
 
 
 class InheritedCrmSaseSection(models.Model):
-
     _inherit = "crm.team"
 
     default_warehouse = fields.Many2one('stock.warehouse',
@@ -20,6 +19,31 @@ class InheritedCrmSaseSection(models.Model):
         help='It indicates journal to be used when move line is created with'
         'the warehouse of this sale team')
 
+    @api.multi
+    def write(self, vals):
+        """The workers cache is cleared when the `journal_team_ids` field is modified to reflect the changes when the
+        following domain is called:
+        * `rule_default_warehouse_journal`
+        """
+        if vals.get("journal_team_ids"):
+            self.clear_caches()
+        return super(InheritedCrmSaseSection, self).write(vals)
+
+    @api.multi
+    def create(self, values):
+        """The workers cache is cleared to reflect the changes when the following domain is called:
+        * `rule_default_warehouse_journal`
+        """
+        if values.get("journal_team_ids"):
+            self.clear_caches()
+        return super(InheritedCrmSaseSection, self).create(values)
+
+    @api.multi
+    def unlink(self):
+        """The workers cache is cleared when a record it's deleted,
+        """
+        self.clear_caches()
+        return super(InheritedCrmSaseSection, self).unlink()
 
 class WarehouseDefault(models.Model):
     """If you inherit from this model and add a field called warehouse_id into


### PR DESCRIPTION
<p align="center">
    <h2 align="center">
        List of  Changes:
        <a href="https://www.vauxoo.com/web#id=38574&view_type=form&model=project.task&menu_id=">
            <img src="https://img.shields.io/badge/Vauxoo%20Task-38574-red.svg?labelColor=black&style=flat-square&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAMAAAC6V+0/AAAA21BMVEUAAAD/////////zMzR6Oj/tMPV4+PxuMa8hZCqVWjIbYn/ttHKjZWzYG7/vtXUnanSfJa+dYCxXnG0ZHKeQVCfRFTJADy8CDq8Cjq5Bji7CDm7CjnOAjy0Cji0Czu9BznNBT7OAzzW2d7X2uKfEy6gEi+gEyygEy6iEiyiEi6kES6kEi+1DDq2Czq3Cjm4Cjm5Bzi6Bze6CTm6CTq6CTu7Bzu7CTi7CjrEy9PEztfFzNLFzdXHBj3JAj3KAj3OAzzV2N/V2eDV2uDW2d3W2eDW2eHc3+Pe4ebf4uaGO/zkAAAAJHRSTlMAAgMFCxESEhcbHBwdJStBREpfaXaA9fv8/f39/f7+/v7+/v58w8n4AAAAh0lEQVQYGa3BxRKCUABA0Wt3d7eCwbP7GZj//0UuZBiBrefwL+8nDrfXq43NQ79f9A42+nZ/xWLmw3vYuUluMC3EIojfRWYiphiOUuuqMcgpg5U889U6af1hAELqSJNNDA2x9pBNEZ2LGqYKpBU1QaTMr/C4N5rHsSqKpSYK2NSlLOFQzfMnH4ejDoMK990cAAAAAElFTkSuQmCC" alt="Vauxoo Task">
        </a>
    </h2>    
</p>

* The ir.rule with dynamic domain [`rule_default_warehouse_journal`](https://github.com/Vauxoo/addons-vauxoo/blob/11.0/default_warehouse_from_sale_team/security/ir_rule.xml#L44)was susceptible to not properly reflects the changes in time on all odoo workers, causing errors when any of the following fields were modified:

  * From `res.users` the field `sale_team_ids`.
  * From `crm.team` the field `journal_team_ids`.
  * From `account.journal` the field `section_id`.

That's explained by @moylop260 in this [video](https://zoom.us/rec/play/7sEqIrz5-2k3TtyW5QSDB6IqW47sf6Os0SgX_vAKyk_mVXgEZ1rzMOAVNOrCpiHR-zlC7IbntA7JEEvt?continueMode=true&_x_zm_rtaid=UU1uwGnhTKmR96c97FvTKQ.1585752961598.c1676439f098ff0c90a95e85c0f2a0da&_x_zm_rhtaid=840)

This PR replace the MR made in [Vauxoo Gitlab](https://git.vauxoo.com/vauxoo/dhm/-/merge_requests/93)