### PR TITLE
[issue#9479] [FIX] partner_credit_limit: avoid error `OverflowError: date value out of range`

### DIFF
--- a/partner_credit_limit/__manifest__.py
+++ b/partner_credit_limit/__manifest__.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     "name": "Partner Credit Limit",
-    "version": "11.0.0.0.2",
+    "version": "11.0.0.0.3",
     "author": "Vauxoo",
     "category": "",
     "website": "http://www.vauxoo.com/",

--- a/partner_credit_limit/i18n/es.po
+++ b/partner_credit_limit/i18n/es.po
@@ -91,6 +91,12 @@ msgid "Late Payments"
 msgstr "Pagos Atrasados"
 
 #. module: partner_credit_limit
+#: code:addons/partner_credit_limit/model/partner.py:35
+#, python-format
+msgid "Payment grace days must be between 0 and 999999"
+msgstr "Los días de gracia de pago deben estar entre 0 y 999999"
+
+#. module: partner_credit_limit
 #: model:ir.model,name:partner_credit_limit.model_sale_order
 msgid "Quotation"
 msgstr "Presupuesto"

--- a/partner_credit_limit/migrations/11.0.0.0.3/post-migration.py
+++ b/partner_credit_limit/migrations/11.0.0.0.3/post-migration.py
@@ -1,0 +1,19 @@
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    set_grace_payment_days_between_limits(cr)
+
+
+def set_grace_payment_days_between_limits(cr):
+    """In this migration the negative values of the grace_payment_day field are
+      set to 0, as there is no point in negative of that value.
+    Values greater than 999999 are also searched and set to 999999 to avoid
+    OverflowError: date value out of range error.
+    This to create the python constraint for this field.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['res.partner'].search([('grace_payment_days', '<', 0.0)]).write(
+        {'grace_payment_days': 0.0})
+    env['res.partner'].search([('grace_payment_days', '>', 999999)]).write(
+        {'grace_payment_days': 999999})

--- a/partner_credit_limit/model/partner.py
+++ b/partner_credit_limit/model/partner.py
@@ -2,7 +2,8 @@
 # Copyright 2016 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from datetime import timedelta
-from odoo import models, fields, api
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
@@ -24,6 +25,13 @@ class ResPartner(models.Model):
         compute='get_allowed_sale', string="Allowed Sales", type='Boolean',
         help="If the Partner has credit overloaded or late payments,"
         " he can't validate invoices and sale orders.")
+
+    @api.constrains('grace_payment_days')
+    def _check_grace_payment_days_value(self):
+        for record in self:
+            if not 0 < record.grace_payment_days < 999999:
+                raise ValidationError(
+                    _('Payment grace days must be between 0 and 999999'))
 
     @api.multi
     def _get_credit_overloaded(self):


### PR DESCRIPTION
Since the grace_payment_days field is a float, in some cases the user
can set really high values `(> 999999)` which causes the traceback
`OverflowError: date value out of range`.

Since that field is used for date operations in the [debit_credit_maturity](https://github.com/Vauxoo/addons-vauxoo/blob/11.0/partner_credit_limit/model/partner.py#L61-L63) method of the `res.partner` model.

**issue**

When the user see the contact, it gets the following traceback

![image](https://user-images.githubusercontent.com/11479473/78194959-bbbf7280-743b-11ea-9f49-e4737e7673ad.png)
