### PR TITLE
[FIX] partner_credit_limit: Add = to the validation condition

### DIFF
--- a/partner_credit_limit/i18n/es.po
+++ b/partner_credit_limit/i18n/es.po
@@ -91,10 +91,10 @@ msgid "Late Payments"
 msgstr "Pagos Atrasados"
 
 #. module: partner_credit_limit
-#: code:addons/partner_credit_limit/model/partner.py:35
+#: code:addons/partner_credit_limit/model/partner.py:34
 #, python-format
-msgid "Payment grace days must be between 0 and 999999"
-msgstr "Los días de gracia de pago deben estar entre 0 y 999999"
+msgid "Invalid value %s for payment grace days: value must be between 0 and 999999."
+msgstr "Valor incorrecto %s para los días de gracia de pago: el valor debe estar entre 0 y 999999."
 
 #. module: partner_credit_limit
 #: model:ir.model,name:partner_credit_limit.model_sale_order

--- a/partner_credit_limit/model/partner.py
+++ b/partner_credit_limit/model/partner.py
@@ -29,9 +29,10 @@ class ResPartner(models.Model):
     @api.constrains('grace_payment_days')
     def _check_grace_payment_days_value(self):
         for record in self:
-            if not 0 < record.grace_payment_days < 999999:
+            if not 0 <= record.grace_payment_days <= 999999:
                 raise ValidationError(
-                    _('Payment grace days must be between 0 and 999999'))
+                    _('Invalid value %s for payment grace days: value must be '
+                      'between 0 and 999999.') % record.grace_payment_days)
 
     @api.multi
     def _get_credit_overloaded(self):


### PR DESCRIPTION
There is data demo with the value of the grace_payment_days field set to
999999, that value must be included.

Improve message that is displayed to the user when the constraint is
executed, to show the value that is trying to save.

![Screenshot from 2020-04-03 14-23-36](https://user-images.githubusercontent.com/11479473/78401822-c6eadd80-75b6-11ea-8de3-546fbf50295e.png)
