### PR TITLE
[FIX] partner_credit_limit: fix error `OverflowError: date value out of  range`

### DIFF
--- a/partner_credit_limit/__manifest__.py
+++ b/partner_credit_limit/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Partner Credit Limit",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "author": "Vauxoo",
     "category": "",
     "website": "http://www.vauxoo.com/",

--- a/partner_credit_limit/i18n/es.po
+++ b/partner_credit_limit/i18n/es.po
@@ -91,10 +91,10 @@ msgid "Late Payments"
 msgstr "Pagos Atrasados"
 
 #. module: partner_credit_limit
-#: code:addons/partner_credit_limit/model/partner.py:35
+#: code:addons/partner_credit_limit/model/partner.py:34
 #, python-format
-msgid "Payment grace days must be between 0 and 999999"
-msgstr "Los días de gracia de pago deben estar entre 0 y 999999"
+msgid "Invalid value %s for payment grace days: value must be between 0 and 999999."
+msgstr "Valor incorrecto %s para los días de gracia de pago: el valor debe estar entre 0 y 999999."
 
 #. module: partner_credit_limit
 #: model:ir.model,name:partner_credit_limit.model_sale_order

--- a/partner_credit_limit/i18n/es.po
+++ b/partner_credit_limit/i18n/es.po
@@ -91,6 +91,12 @@ msgid "Late Payments"
 msgstr "Pagos Atrasados"
 
 #. module: partner_credit_limit
+#: code:addons/partner_credit_limit/model/partner.py:35
+#, python-format
+msgid "Payment grace days must be between 0 and 999999"
+msgstr "Los días de gracia de pago deben estar entre 0 y 999999"
+
+#. module: partner_credit_limit
 #: model:ir.model,name:partner_credit_limit.model_sale_order
 msgid "Quotation"
 msgstr "Presupuesto"

--- a/partner_credit_limit/migrations/12.0.1.0.1/post-migration.py
+++ b/partner_credit_limit/migrations/12.0.1.0.1/post-migration.py
@@ -1,0 +1,19 @@
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    set_grace_payment_days_between_limits(cr)
+
+
+def set_grace_payment_days_between_limits(cr):
+    """In this migration the negative values of the grace_payment_day field are
+      set to 0, as there is no point in negative of that value.
+    Values greater than 999999 are also searched and set to 999999 to avoid
+    OverflowError: date value out of range error.
+    This to create the python constraint for this field.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['res.partner'].search([('grace_payment_days', '<', 0.0)]).write(
+        {'grace_payment_days': 0.0})
+    env['res.partner'].search([('grace_payment_days', '>', 999999)]).write(
+        {'grace_payment_days': 999999})

--- a/partner_credit_limit/models/partner.py
+++ b/partner_credit_limit/models/partner.py
@@ -26,9 +26,10 @@ class ResPartner(models.Model):
     @api.constrains('grace_payment_days')
     def _check_grace_payment_days_value(self):
         for record in self:
-            if not 0 < record.grace_payment_days < 999999:
+            if not 0 <= record.grace_payment_days <= 999999:
                 raise ValidationError(
-                    _('Payment grace days must be between 0 and 999999'))
+                    _('Invalid value %s for payment grace days: value must be '
+                      'between 0 and 999999.') % record.grace_payment_days)
 
     @api.multi
     def _get_credit_overloaded(self):

--- a/partner_credit_limit/models/partner.py
+++ b/partner_credit_limit/models/partner.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
-from odoo import models, fields, api
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
@@ -21,6 +22,13 @@ class ResPartner(models.Model):
         compute='get_allowed_sale', string="Allowed Sales", type='Boolean',
         help="If the Partner has credit overloaded or late payments,"
         " he can't validate invoices and sale orders.")
+
+    @api.constrains('grace_payment_days')
+    def _check_grace_payment_days_value(self):
+        for record in self:
+            if not 0 < record.grace_payment_days < 999999:
+                raise ValidationError(
+                    _('Payment grace days must be between 0 and 999999'))
 
     @api.multi
     def _get_credit_overloaded(self):


### PR DESCRIPTION
1. [FIX] partner_credit_limit: fix error `OverflowError: date value out of  range`
- Since the grace_payment_days field is a float, in some cases the user can set really high values (> 999999) which causes the traceback `OverflowError: date value out of range`.
- Since that field is used for date operations in the `debit_credit_maturity` method of the` res.partner` model.

2. [FIX] partner_credit_limit: Add = to the validation condition

- There is data demo with the value of the grace_payment_days field set to 999999, that value must be included.

- Improve message that is displayed to the user when the constraint is executed, to show the value that is trying to save.