### PR TITLE
[ADD] stock_custom_exchange_rate_date: Module to set custom rate date

### DIFF
--- a/stock_custom_exchange_rate_date/README.rst
+++ b/stock_custom_exchange_rate_date/README.rst
@@ -1,0 +1,32 @@
+Customized Rate Date in Stock
+=============================
+
+This module allows to set a customized date on transfers to be used when
+computing product unit prices, instead of the date when the transfer  is
+validated, in case exchange rates are involved.
+
+The use for the above is that created journal entries take the newly
+computed unit price, which makes the inventory to be valuated using the
+specified rate.
+
+Contributors
+------------
+
+* Luis González <lgonzalez@vauxoo.com>
+
+
+Maintainer
+==========
+
+.. image:: https://www.vauxoo.com/logo.png
+   :alt: Vauxoo
+   :target: https://vauxoo.com
+
+This module is maintained by Vauxoo.
+
+a latinamerican company that provides training, coaching,
+development and implementation of enterprise management
+systems and bases its entire operation strategy in the use
+of Open Source Software and its main product is Odoo.
+
+To contribute to this module, please visit http://www.vauxoo.com.

--- a/stock_custom_exchange_rate_date/__init__.py
+++ b/stock_custom_exchange_rate_date/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_custom_exchange_rate_date/__manifest__.py
+++ b/stock_custom_exchange_rate_date/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "Customized Rate Date in Stock",
+    "version": "12.0.1.0.0",
+    "author": "Vauxoo",
+    "category": "stock",
+    "website": "http://www.vauxoo.com/",
+    "license": "LGPL-3",
+    "depends": [
+        "purchase_stock",
+    ],
+    "data": [
+        "views/stock_picking_views.xml",
+    ],
+    "demo": [
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/stock_custom_exchange_rate_date/i18n/es.po
+++ b/stock_custom_exchange_rate_date/i18n/es.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_custom_exchange_rate_date
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-07 01:08+0000\n"
+"PO-Revision-Date: 2020-06-07 01:08+0000\n"
+"Last-Translator: Luis González <lgonzalez@vauxoo.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_custom_exchange_rate_date
+#: model:ir.model.fields,field_description:stock_custom_exchange_rate_date.field_stock_picking__exchange_rate_date
+msgid "Exchange Rate Date"
+msgstr "Fecha de tasa de cambio"
+
+#. module: stock_custom_exchange_rate_date
+#: model:ir.model.fields,help:stock_custom_exchange_rate_date.field_stock_picking__exchange_rate_date
+msgid "If set, specifies a customized date that will be used when computing product unit prices, instead of the date when the transfer is validated, in case exchange rates are involved."
+msgstr "Si se establece, especifica una fecha personalizada que se utilizará al calcular precios unitarios de productos, en lugar de la fecha en que se valide la transferencia, en caso que haya tasas de cambio involucradas."
+
+#. module: stock_custom_exchange_rate_date
+#: model:ir.model,name:stock_custom_exchange_rate_date.model_stock_move
+msgid "Stock Move"
+msgstr "Movimiento de existencias"
+
+#. module: stock_custom_exchange_rate_date
+#: model:ir.model,name:stock_custom_exchange_rate_date.model_stock_picking
+msgid "Transfer"
+msgstr "Transferencia"
+

--- a/stock_custom_exchange_rate_date/models/__init__.py
+++ b/stock_custom_exchange_rate_date/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_move
+from . import stock_picking

--- a/stock_custom_exchange_rate_date/models/stock_move.py
+++ b/stock_custom_exchange_rate_date/models/stock_move.py
@@ -1,0 +1,26 @@
+from odoo import api, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    @api.multi
+    def _get_price_unit(self):
+        """Take into account custom rate date, if provided"""
+        line = self.purchase_line_id
+        if (not self.picking_id.exchange_rate_date or not line or self.product_id != line.product_id
+                or line.currency_id == line.company_id.currency_id):
+            return super()._get_price_unit()
+        price_unit = line.price_unit
+        if line.taxes_id:
+            price_unit = line.taxes_id.with_context(round=False).compute_all(
+                price_unit, currency=line.currency_id, quantity=1.0)['total_excluded']
+        if line.product_uom.id != line.product_id.uom_id.id:
+            price_unit *= line.product_uom.factor / line.product_id.uom_id.factor
+        price_unit = line.currency_id._convert(
+            price_unit,
+            line.company_id.currency_id,
+            line.company_id,
+            self.picking_id.exchange_rate_date,
+            round=False)
+        return price_unit

--- a/stock_custom_exchange_rate_date/models/stock_picking.py
+++ b/stock_custom_exchange_rate_date/models/stock_picking.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    exchange_rate_date = fields.Date(
+        states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
+        copy=False,
+        help="If set, specifies a customized date that will be used when "
+        "computing product unit prices, instead of the date when the transfer "
+        "is validated, in case exchange rates are involved.")

--- a/stock_custom_exchange_rate_date/tests/__init__.py
+++ b/stock_custom_exchange_rate_date/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock

--- a/stock_custom_exchange_rate_date/tests/test_stock.py
+++ b/stock_custom_exchange_rate_date/tests/test_stock.py
@@ -1,0 +1,135 @@
+from datetime import timedelta
+
+from odoo import fields
+from odoo.tests import Form, TransactionCase
+
+
+class TestStock(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.vendor = self.env.ref('base.res_partner_1')
+        self.usd = self.env.ref('base.USD')
+        self.eur = self.env.ref('base.EUR')
+        self.today = fields.Date.context_today(self.env.user)
+        self.yesterday = self.today - timedelta(days=1)
+        self.set_currency_rates(self.today, usd_rate=1, eur_rate=1.25)
+        self.set_currency_rates(self.yesterday, usd_rate=1, eur_rate=2)
+        self.env.user.company_id.currency_id = self.usd
+
+        # Creating a new product to ensure valuation is clean
+        self.product = self.env['product.product'].create({
+            'name': 'Product fifo',
+            'type': 'product',
+            'default_code': 'PR-FIFO',
+            'valuation': 'real_time',
+            'cost_method': 'fifo',
+        })
+
+    def create_purchase_order(self, partner=None, **line_kwargs):
+        if partner is None:
+            partner = self.vendor
+        purchase_order = Form(self.env['purchase.order'])
+        purchase_order.partner_id = partner
+        purchase_order.currency_id = self.eur
+        purchase_order = purchase_order.save()
+        self.create_po_line(purchase_order, **line_kwargs)
+        return purchase_order
+
+    def create_po_line(self, purchase_order, product=None, quantity=1, price=100):
+        if product is None:
+            product = self.product
+        with Form(purchase_order) as po:
+            with po.order_line.new() as line:
+                line.product_id = product
+                line.product_qty = quantity
+                line.price_unit = price
+
+    def process_immediate_transfer(self, picking):
+        immediate_transfer = self.env['stock.immediate.transfer'].create({
+            'pick_ids': [(6, 0, picking.ids)],
+        })
+        return immediate_transfer.process()
+
+    def set_currency_rates(self, rate_date, usd_rate, eur_rate):
+        # Remove existing rates, if any
+        rate_model = self.env['res.currency.rate']
+        current_rates = rate_model.search([
+            ('name', '=', rate_date),
+            ('currency_id', 'in', [self.usd.id, self.eur.id]),
+        ])
+        current_rates.unlink()
+
+        # Create new rates
+        rate_model.create({
+            'currency_id': self.usd.id,
+            'rate': usd_rate,
+            'name': rate_date,
+        })
+        rate_model.create({
+            'currency_id': self.eur.id,
+            'rate': eur_rate,
+            'name': rate_date
+        })
+
+    def test_01_date_rate_set(self):
+        """Set a custom rate date on a transfer, valuation should be computed using that date"""
+        # Purchase product
+        po = self.create_purchase_order()
+        po.button_confirm()
+        self.assertEqual(po.state, 'purchase')
+        self.assertEqual(po.picking_count, 1)
+
+        # Set custom rate date on the receipt transfer and confirm
+        picking_po = po.picking_ids
+        picking_po.exchange_rate_date = self.yesterday
+        self.process_immediate_transfer(picking_po)
+        self.assertEqual(picking_po.state, 'done')
+
+        # Check valuation according to stock moves
+        # Yesterday's rate was 1 USD = 2 EUR, so 100 EUR should be valued as 50 USD
+        self.assertRecordValues(picking_po.move_lines, [{
+            'remaining_qty': 1.0,
+            'remaining_value': 50.0,
+            'value': 50.0,
+        }])
+
+        # Check valuation according to journal entries
+        self.assertEqual(self.product.stock_value, 50.0)
+        self.assertRecordValues(self.product.stock_fifo_real_time_aml_ids, [{
+            'debit': 50.0,
+            'credit': 0.0,
+            'amount_currency': 100.0,
+            'currency_id': self.eur.id,
+            'account_id': self.product.categ_id.property_stock_valuation_account_id.id,
+        }])
+
+    def test_02_date_rate_not_set(self):
+        """Don't set a custom date rate, valuation should be computed using today"""
+        # Purchase product
+        po = self.create_purchase_order()
+        po.button_confirm()
+        self.assertEqual(po.state, 'purchase')
+        self.assertEqual(po.picking_count, 1)
+
+        # Confirm receipt transfer
+        picking_po = po.picking_ids
+        self.process_immediate_transfer(picking_po)
+        self.assertEqual(picking_po.state, 'done')
+
+        # Check valuation according to stock moves
+        # Today's rate is 1 USD = 1.25 EUR, so 100 EUR should be valued as 80 USD
+        self.assertRecordValues(picking_po.move_lines, [{
+            'remaining_qty': 1.0,
+            'remaining_value': 80.0,
+            'value': 80.0,
+        }])
+
+        # Check valuation according to journal entries
+        self.assertEqual(self.product.stock_value, 80.0)
+        self.assertRecordValues(self.product.stock_fifo_real_time_aml_ids, [{
+            'debit': 80.0,
+            'credit': 0.0,
+            'amount_currency': 100.0,
+            'currency_id': self.eur.id,
+            'account_id': self.product.categ_id.property_stock_valuation_account_id.id,
+        }])

--- a/stock_custom_exchange_rate_date/views/stock_picking_views.xml
+++ b/stock_custom_exchange_rate_date/views/stock_picking_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form.inherit.custom.rate.date</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='scheduled_date']" position="before">
+                <field name="purchase_id" invisible="1"/>
+                <field name="exchange_rate_date" attrs="{'invisible': ['|', ('purchase_id', '=', False), ('picking_type_code', '!=', 'incoming')]}"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This module allows to set a customized date on transfers to be used when
computing product unit prices, instead of the date when the transfer  is
validated, in case exchange rates are involved.

The use for the above is that created journal entries take the newly
computed unit price, which makes the inventory to be valuated using the
specified rate.