### PR TITLE
[FIX] partner_credit_limit: New Raise Limit Credit Message

### DIFF
--- a/partner_credit_limit/__manifest__.py
+++ b/partner_credit_limit/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Partner Credit Limit",
-    "version": "12.0.1.0.1",
+    "version": "12.0.1.0.2",
     "author": "Vauxoo",
     "category": "",
     "website": "http://www.vauxoo.com/",

--- a/partner_credit_limit/i18n/es.po
+++ b/partner_credit_limit/i18n/es.po
@@ -22,26 +22,6 @@ msgid "Allowed Sales"
 msgstr "Venta a crédito permitida"
 
 #. module: partner_credit_limit
-#: code:addons/partner_credit_limit/model/sale.py:28
-#, python-format
-msgid "Can not confirm the Sale Order because Partner has late payments or has exceeded the credit limit.\n"
-"Please cover the late payment or check credit limit\n"
-"Credit Limit : %s"
-msgstr "No se puede confirmar la orden de venta por que el cliente tiene pagos atrasados o tiene un límite de crédito excedido.\n"
-"Por favor cubrir los pagos atrasados o revisar el límite de crédito.\n"
-"Límite de Crédito : %s"
-
-#. module: partner_credit_limit
-#: code:addons/partner_credit_limit/model/account_invoice.py:30
-#, python-format
-msgid "Can not validate the Invoice because Partner has late payments or has exceeded the credit limit.\n"
-"Please cover the late payment or check credit limit\n"
-"Credit Limit : %s"
-msgstr "No se puede validar la Factura porque el cliente tiene pagos atrasados o tiene un límite de crédito excedido.\n"
-"Por favor cubrir los pagos atrasados o revisar el límite de crédito.\n"
-"Límite de Crédito : %s"
-
-#. module: partner_credit_limit
 #: model:ir.model,name:partner_credit_limit.model_res_partner
 msgid "Contact"
 msgstr "Contacto"
@@ -79,6 +59,7 @@ msgid "Indicates when the customer has late payments"
 msgstr "Indica cuando el cliente tiene pagos atrasados"
 
 #. module: partner_credit_limit
+#: code:addons/partner_credit_limit/models/account_invoice.py:23
 #: model:ir.model,name:partner_credit_limit.model_account_invoice
 msgid "Invoice"
 msgstr "Factura"
@@ -100,3 +81,55 @@ msgstr "Valor incorrecto %s para los días de gracia de pago: el valor debe esta
 #: model:ir.model,name:partner_credit_limit.model_sale_order
 msgid "Quotation"
 msgstr "Presupuesto"
+
+#. module: partner_credit_limit
+#: code:addons/partner_credit_limit/models/partner.py:107
+#, python-format
+msgid "Please: \n"
+""
+msgstr "Por favor: \n"
+""
+
+#. module: partner_credit_limit
+#: code:addons/partner_credit_limit/models/sale.py:21
+#, python-format
+msgid "Sale Order"
+msgstr "Pedido de venta"
+
+#. module: partner_credit_limit
+#: code:addons/partner_credit_limit/models/partner.py:107
+#, python-format
+msgid "record"
+msgstr "registro"
+
+#. module: partner_credit_limit
+#: code:addons/partner_credit_limit/models/partner.py:114
+#, python-format
+msgid "• Check credit limit.\n"
+""
+msgstr "• Revisar el límite de crédito.\n"
+""
+
+#. module: partner_credit_limit
+#: code:addons/partner_credit_limit/models/partner.py:111
+#, python-format
+msgid "• Cover the late payments.\n"
+""
+msgstr "• Cubrir los pagos atrasados.\n"
+""
+
+#. module: partner_credit_limit
+#: code:addons/partner_credit_limit/models/partner.py:113
+#, python-format
+msgid "• Has exceeded the credit limit.\n"
+""
+msgstr "• Tiene un límite de crédito excedido.\n"
+""
+
+#. module: partner_credit_limit
+#: code:addons/partner_credit_limit/models/partner.py:110
+#, python-format
+msgid "• Has late payments.\n"
+""
+msgstr "• Tiene pagos atrasados.\n"
+""

--- a/partner_credit_limit/models/account_invoice.py
+++ b/partner_credit_limit/models/account_invoice.py
@@ -1,5 +1,5 @@
 from odoo import models, api, _
-from odoo import exceptions
+from odoo.exceptions import ValidationError
 
 
 class AccontInvoice(models.Model):
@@ -18,18 +18,13 @@ class AccontInvoice(models.Model):
                          inv.type != 'out_invoice'):
             return True
         for invoice in self:
-            allowed_sale = invoice.partner_id.with_context(
-                {'new_amount': invoice.amount_total,
-                 'new_currency': invoice.currency_id}).allowed_sale
-            if allowed_sale:
-                return True
-            else:
-                msg = _('Can not validate the Invoice because Partner '
-                        'has late payments or has exceeded the credit limit.'
-                        '\nPlease cover the late payment or check credit limit'
-                        '\nCredit'
-                        ' Limit : %s') % (invoice.partner_id.credit_limit)
-                raise exceptions.Warning(msg)
+            msg = invoice.partner_id.with_context(
+                new_amount=invoice.amount_total,
+                new_currency=invoice.currency_id)._check_credit_limit(model_name=_('Invoice'))
+            if not msg:
+                continue
+            raise ValidationError(msg)
+        return True
 
     @api.multi
     def action_invoice_open(self):

--- a/partner_credit_limit/models/partner.py
+++ b/partner_credit_limit/models/partner.py
@@ -2,6 +2,9 @@ from datetime import timedelta
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
 
+NO_BREAK_SPACE = "\u00a0"
+TAB_SPACE = 4 * NO_BREAK_SPACE
+
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
@@ -92,3 +95,23 @@ class ResPartner(models.Model):
         for partner in self:
             partner.allowed_sale = not partner.credit_overloaded and \
                 not partner.overdue_credit
+
+    def _check_credit_limit(self, model_name=False):
+        """Method that will return a message when the partner has late payments and/or has exceeded the credit limit.
+        """
+        self.ensure_one()
+        if self.allowed_sale:
+            return False
+        credit_overloaded = self.credit_overloaded
+        overdue_credit = self.overdue_credit
+        msg = _('Can not confirm the %s because the Partner:\n') % (model_name and model_name or _('record'))
+        do_msg = _('Please: \n')
+
+        if overdue_credit:
+            msg += TAB_SPACE + _('• Has late payments.\n')
+            do_msg += TAB_SPACE + _('• Cover the late payments.\n')
+        if credit_overloaded:
+            msg += TAB_SPACE + _('• Has exceeded the credit limit.\n')
+            do_msg += TAB_SPACE + _('• Check credit limit.\n')
+            do_msg += TAB_SPACE*2 + _('Credit limit: %s') % self.credit_limit
+        return '%s %s' % (msg, do_msg)

--- a/partner_credit_limit/tests/test_invoice_credit_limit.py
+++ b/partner_credit_limit/tests/test_invoice_credit_limit.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from odoo import exceptions
+from odoo.exceptions import ValidationError
 from . import common
 
 
@@ -46,7 +46,7 @@ class TestCreditLimits(common.TestCommon):
         # credit limit exceded
         # credit_limit = 500
         # amount_total = 600
-        with self.assertRaises(exceptions.Warning):
+        with self.assertRaises(ValidationError):
             invoice_id.action_invoice_open()
 
     def test_partner_with_late_payments(self):
@@ -96,7 +96,7 @@ class TestCreditLimits(common.TestCommon):
              'name': 'product that cost 100', })
         # Validate the invoice, should fail, couse there are late payments
         # since the invoice 1 was validate with curent day minus 2 days
-        with self.assertRaises(exceptions.Warning):
+        with self.assertRaises(ValidationError):
             invoice_id2.action_invoice_open()
 
     def test_overdue_credit(self):

--- a/partner_credit_limit/tests/test_sale_credit_limit.py
+++ b/partner_credit_limit/tests/test_sale_credit_limit.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from odoo import exceptions
+from odoo.exceptions import ValidationError
 from . import common
 
 
@@ -48,7 +48,7 @@ class TestSalesCreditLimits(common.TestCommon):
         # credit limit exceded
         # credit_limit = 500
         # amount_total = 600
-        with self.assertRaises(exceptions.Warning):
+        with self.assertRaises(ValidationError):
             sale_id.action_confirm()
 
         # CASE WHERE PARTNER HAVE CREDIT
@@ -105,7 +105,7 @@ class TestSalesCreditLimits(common.TestCommon):
         # should not confirm sale order should fail,
         # couse there are late payments
         # since the invoice 1 was validate with curent day minus 2 days
-        with self.assertRaises(exceptions.Warning):
+        with self.assertRaises(ValidationError):
             sale_id.action_confirm()
 
     def test_credit_limit_overloaded_with_diferent_currency(self):
@@ -138,5 +138,5 @@ class TestSalesCreditLimits(common.TestCommon):
                             sale_id.company_id.currency_id)
         # Should not confirm sale order
         # Credit limit exceded when conversion is done from USD to MXN
-        with self.assertRaises(exceptions.Warning):
+        with self.assertRaises(ValidationError):
             sale_id.action_confirm()


### PR DESCRIPTION
### [T#39965](https://www.vauxoo.com/web#id=39965&view_type=form&model=project.task)

Adding new messages to allow the user know the real reason why its invoice or sale order can't be validated/confirmed. The reasons can be if the partner has late payments, has exceeded the credit limit or both.

![Task 39965 - Raise New Message](https://user-images.githubusercontent.com/26889951/84715848-4db52280-af37-11ea-8bcf-f1d51280bd4a.png)
