### PR TITLE
[FIX] stock_by_warehouse: Set Most Quantity Location

### DIFF
--- a/stock_by_warehouse/models/product_product.py
+++ b/stock_by_warehouse/models/product_product.py
@@ -155,7 +155,7 @@ class ProductProduct(models.Model):
                 {'location': location.display_name, 'quantity': quantity} for quantity, location in qty_per_location]
             info['content'].append({
                 'warehouse_name': warehouse.name,
-                'most_quantity_location_id': most_quantity_location.id,
+                'most_quantity_location_id': most_quantity_location and most_quantity_location.id or 0,
                 'info_content': info_content,
                 'locations_available': locations_available
             })


### PR DESCRIPTION
When there is no available location for a warehouse the set of the most quantity location was giving an error, now if there is no location available a zero will be set indicating it.

**ERROR**
![Error Stock by Warehouse](https://user-images.githubusercontent.com/26889951/87344970-f2198d00-c514-11ea-8a61-6890bca256d9.png)
