### PR TITLE
[FIX] default_warehouse_from_sale_team: Default Sales Team Constraint

### DIFF
--- a/default_warehouse_from_sale_team/models/res_users.py
+++ b/default_warehouse_from_sale_team/models/res_users.py
@@ -16,10 +16,11 @@ class ResUsers(models.Model):
 
     @api.constrains('sale_team_id')
     def _check_section_id(self):
-        """ Can only set the Default Sales team if the user is part o
+        """ Can only set the Default Sales team if the user has that team on its
+        Sales Teams (`sale_team_ids`).
         """
         for user in self.filtered(
-                lambda dat: dat.sale_team_id not in dat.sale_team_ids):
+                lambda dat: dat.sale_team_id and dat.sale_team_id not in dat.sale_team_ids):
             raise ValidationError(_(
                 'You can not set the sales team %s as default because the user'
                 ' does not belongs to that sale teams.\nPlease go to Sales >'


### PR DESCRIPTION
### [T#40491](https://www.vauxoo.com/web#id=40491&view_type=form&model=project.task)

When a user is created without a default sales team or if a user is being deleted the field `sale_team_id` will be set to False, the constraint will fail since the value False is not on the `sale_team_ids` list.