### PR TITLE
[ADD] partner_credit_limit: Credit for demo partners

### DIFF
--- a/partner_credit_limit/__manifest__.py
+++ b/partner_credit_limit/__manifest__.py
@@ -11,9 +11,11 @@
         "account",
         "sale",
         "payment_term_type", ],
-    "demo": [],
     "data": [
         "view/partner_view.xml",
+    ],
+    "demo": [
+        "demo/res_partner_demo.xml",
     ],
     "post_init_hook": "post_init_hook",
     "installable": True,

--- a/partner_credit_limit/demo/res_partner_demo.xml
+++ b/partner_credit_limit/demo/res_partner_demo.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="base.res_partner_1" model="res.partner">
+        <field name="credit_limit">1000000</field>
+    </record>
+    <record id="base.res_partner_2" model="res.partner">
+        <field name="credit_limit">1000000</field>
+    </record>
+    <record id="base.res_partner_3" model="res.partner">
+        <field name="credit_limit">1000000</field>
+    </record>
+    <record id="base.res_partner_12" model="res.partner">
+        <field name="credit_limit">1000000</field>
+    </record>
+    <record id="base.res_partner_18" model="res.partner">
+        <field name="credit_limit">1000000</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
In order to don't break tests from other modules when this one is
installed, default demo partners are given enough credit limit.