### PR TITLE
[FIX] account_move_report: report definition with template

### DIFF
--- a/account_move_report/report/account_move_report.py
+++ b/account_move_report/report/account_move_report.py
@@ -1,4 +1,4 @@
-from odoo import api, models
+from odoo import models
 
 
 class ParticularReport(models.AbstractModel):

--- a/account_move_report/views/account_reports.xml
+++ b/account_move_report/views/account_reports.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <report
-        id="template_account_move_report"
-        string="Account Move Report"
-        model="account.move"
-        report_type="qweb-pdf"
-        name="account_move_report.account_entries_report"
-        file="account_move_report.account_entries_report"
-    />
+    <record id="template_account_move_report" model="ir.actions.report">
+        <field name="name">Account Move Report</field>
+        <field name="model">account.move</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">account_move_report.account_entries_report</field>
+        <field name="report_file">account_move_report.account_entries_report</field>
+        <field name="binding_model_id" ref="account.model_account_move"/>
+        <field name="binding_type">report</field>
+    </record>
 </odoo>


### PR DESCRIPTION
This avoids:
```
warnings.warn(f"The <report> tag is deprecated, use a <record> tag for
{xml_id!r}.", DeprecationWarning)
```