### PR TITLE
[FIX] default_warehouse_from_sale_team: Field name in rules

### DIFF
--- a/default_warehouse_from_sale_team/security/ir_rule.xml
+++ b/default_warehouse_from_sale_team/security/ir_rule.xml
@@ -5,7 +5,7 @@
             <record id="rule_default_warehouse_stock_picking_type_team" model="ir.rule">
                 <field name="name">Limited access to picking types (filtered by sale teams)</field>
                 <field name="model_id" search="[('model','=','stock.picking.type')]" model="ir.model"/>
-                <field name="domain_force">[('warehouse_id', 'in', [team.default_warehouse.id for team in user.sale_team_ids if team.default_warehouse])]</field>
+                <field name="domain_force">[('warehouse_id', 'in', [team.default_warehouse_id.id for team in user.sale_team_ids if team.default_warehouse_id])]</field>
                 <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_spt')])]"/>
             </record>
             <record id="rule_default_warehouse_stock_picking_type_all" model="ir.rule">
@@ -19,14 +19,14 @@
             <record id="rule_default_warehouse_stock_picking_team" model="ir.rule">
                 <field name="name">Limited access to pickings (filtered by sale teams)</field>
                 <field name="model_id" search="[('model','=','stock.picking')]" model="ir.model"/>
-                <field name="domain_force">[('warehouse_id', 'in', [team.default_warehouse.id for team in user.sale_team_ids if team.default_warehouse])]</field>
+                <field name="domain_force">[('warehouse_id', 'in', [team.default_warehouse_id.id for team in user.sale_team_ids if team.default_warehouse_id])]</field>
                 <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_sp')])]"/>
             </record>
             <record id="rule_default_warehouse_stock_picking_team12" model="ir.rule">
                 <field name="name">Limited access to pickings (filtered by not in sale teams)</field>
                 <field name="model_id" search="[('model','=','stock.picking')]" model="ir.model"/>
                 <field name="perm_read" eval="False"/>
-                <field name="domain_force">[('warehouse_id', 'not in', [team.default_warehouse.id for team in user.sale_team_ids if team.default_warehouse])]</field>
+                <field name="domain_force">[('warehouse_id', 'not in', [team.default_warehouse_id.id for team in user.sale_team_ids if team.default_warehouse_id])]</field>
                 <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_sp')])]"/>
             </record>
             <record id="rule_default_warehouse_stock_picking_all" model="ir.rule">
@@ -54,7 +54,7 @@
             <record id="rule_default_warehouse_wh" model="ir.rule">
                 <field name="name">Limited access to warehouse (filtered by sale teams)</field>
                 <field name="model_id" search="[('model','=','stock.warehouse')]" model="ir.model"/>
-                <field name="domain_force">[('id', 'in', [team.default_warehouse.id for team in user.sale_team_ids if team.default_warehouse])]</field>
+                <field name="domain_force">[('id', 'in', [team.default_warehouse_id.id for team in user.sale_team_ids if team.default_warehouse_id])]</field>
                 <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_sp')])]"/>
             </record>
             <record id="rule_default_warehouse_wh_all" model="ir.rule">


### PR DESCRIPTION
When migrated, field was renamed from:
`default_warehouse` -> `default_warehouse_id`
but record rules were not updated.