### PR TITLE
[FIX] default_warehouse_from_sale_team: avoid sequence re-call

### DIFF
--- a/default_warehouse_from_sale_team/models/sales_team.py
+++ b/default_warehouse_from_sale_team/models/sales_team.py
@@ -64,7 +64,7 @@ class WarehouseDefault(models.Model):
     def create(self, vals):
         sequence_obj = self.env['ir.sequence']
         pick_type_obj = self.env['stock.picking.type']
-        if vals.get('warehouse_id', 'picking_type_id'):
+        if vals.get('warehouse_id', 'picking_type_id') and 'name' not in vals:
             code = self._name
             if code == 'purchase.requisition':
                 code = 'purchase.order.requisition'


### PR DESCRIPTION
### Resume
The sequence is calling two times, one from original model and another from 'default.warehouse' inherit, this fix avoid the
re-call to next_sequence number if it was called previously, this is just by checking if the name has been already set.

Before:
- Current Purchase Order P00039, next P000041.
Now:
- Current Purchase Order P00041, next P00042.

![Solicitudes de presupuesto - Odoo](https://user-images.githubusercontent.com/5335402/97667261-21f98b80-1a45-11eb-8ee9-3aa968ead486.png)

### Debugging:
![Captura de pantalla de 2020-10-30 00-07-08](https://user-images.githubusercontent.com/5335402/97667220-09897100-1a45-11eb-8c0c-d660d39cff62.png)
![Captura de pantalla de 2020-10-29 23-46-47](https://user-images.githubusercontent.com/5335402/97667226-0b533480-1a45-11eb-828a-4922fb2489bc.png)


