### PR TITLE
[REF] stock_by_warehouse: Locations Widget

### DIFF
--- a/stock_by_warehouse/i18n/es.po
+++ b/stock_by_warehouse/i18n/es.po
@@ -126,6 +126,13 @@ msgstr "El producto está disponible en:"
 
 #. module: stock_by_warehouse
 #. openerp-web
+#: code:addons/stock_by_warehouse/static/src/js/widget.js:28
+#, python-format
+msgid "There is no stock available"
+msgstr "No hay existencias disponibles"
+
+#. module: stock_by_warehouse
+#. openerp-web
 #: code:addons/stock_by_warehouse/static/src/xml/template.xml:21
 #, python-format
 msgid "This is real(on hand) quantity  minus reserved quantity"

--- a/stock_by_warehouse/models/product_product.py
+++ b/stock_by_warehouse/models/product_product.py
@@ -169,7 +169,8 @@ class ProductProduct(models.Model):
                 most_quantity_location = qty_per_location[0][1]
 
             info_content = [
-                {'location': location.display_name, 'quantity': quantity} for quantity, location in qty_per_location]
+                {'location': location.display_name, 'quantity': quantity, 'location_id': location.id}
+                for quantity, location in qty_per_location]
             info['content'].append({
                 'warehouse_name': warehouse.name,
                 'most_quantity_location_id': most_quantity_location and most_quantity_location.id or 0,

--- a/stock_by_warehouse/static/src/js/widget.js
+++ b/stock_by_warehouse/static/src/js/widget.js
@@ -6,27 +6,34 @@ var Widget = require('web.Widget');
 var form_common = require('web.AbstractField');
 var formats = require('web.field_utils');
 var fieldRegistry = require('web.field_registry');
+var {EventDispatcherMixin} = require('web.mixins');
 var QWeb = core.qweb;
+var _t = core._t;
 
-var Locations = Widget.extend({
-    init: function (info) {
+var Locations = Widget.extend(EventDispatcherMixin, {
+    init: function (parent, info) {
+        this._super(...arguments);
         this.info = info;
     },
 
     start: function () {
+        this._super(...arguments);
         var info = this.info;
         if (info !== false) {
             _.each(info.content, function (k, v) {
                 k.index = v;
-                k.name = k.warehouse_name
+                k.name = k.warehouse_name;
                 k.locations_quantity_formatted = formats.format["integer"](
                     k.locations_available, "", {digits: k.digits});
                 k.locations_info = k.info_content;
             });
         }
-        var popover = QWeb.render('StockAvailabilityPopOver', {
-            'lines': info.content || [],
-        });
+        var popover = _t('There is no stock available');
+        if (info !== false && info.available_locations !== 0) {
+            popover = QWeb.render('StockAvailabilityPopOver', {
+                'lines': info.content || [],
+            });
+        }
 
         var options = {
             content: popover,
@@ -53,7 +60,7 @@ var ShowPaymentLineWidget = form_common.extend({
                         digits: self.info.digits || 0}),
             }));
 
-            var popover = new Locations(this.info);
+            var popover = new Locations(this, this.info);
             popover.attachTo($('.js_available_info'));
         } else{
             this.$el.html(QWeb.render('ShowWarehouseInfo', {


### PR DESCRIPTION
### [T#43330](https://www.vauxoo.com/web#id=43330&view_type=form&model=project.task)

Sending on the content info of the method `_compute_get_stock_location` the location id.
Showing a new message when there are no locations where the product is available on the widget `Locations`, and extending from the class `EventDispatcherMixin` to allow the reload of the parent.