### PR TITLE
[FIX] sale_margin_percentage: Avoid clear cache value computed - ticket#13578

### DIFF
--- a/sale_margin_percentage/models/sale_order.py
+++ b/sale_margin_percentage/models/sale_order.py
@@ -43,7 +43,7 @@ class SaleOrderLine(models.Model):
         readonly=True, help="Price purchase of product")
 
     @api.depends('product_id', 'purchase_price', 'product_uom_qty',
-                 'price_unit')
+                 'price_unit', 'price_subtotal')
     def _compute_margin_percentage(self):
         """ Same margin but we return a percentage from the purchase price.
         """


### PR DESCRIPTION
The order of the methods could be executed of different way if the method doesn't depend of price_subtotal
Adding it you can be sure that price_subtotal was computed before to use this method
In order to avoid to reset the original value from database because this will be zero