### PR TITLE
[FIX] stock_landed_segmentation: Missing dependency to mrp

### DIFF
--- a/stock_landed_segmentation/__manifest__.py
+++ b/stock_landed_segmentation/__manifest__.py
@@ -10,6 +10,7 @@
     'category': 'Accounting',
     'license': 'OEEL-1',
     'depends': [
+        "mrp",
         "stock_cost_segmentation",
         "stock_landed_costs",
     ],


### PR DESCRIPTION
This module adds a relationship between landed costs and unbuild orders
(with the field `unbuild_ids`), but it was missing the dependency to the
`mrp` module, where the unbuild model is defined.