### PR TITLE
[FIX] default_warehouse_from_sale_team: CRM Team Read Permission

### DIFF
--- a/default_warehouse_from_sale_team/models/purchase.py
+++ b/default_warehouse_from_sale_team/models/purchase.py
@@ -19,7 +19,7 @@ class DefaultPickingType(models.Model):
 
         res = super(DefaultPickingType, self).default_get(fields_list)
         user_id = user_obj.browse(self._uid)
-        sale_team_warehouse_id = user_id.sale_team_id.default_warehouse
+        sale_team_warehouse_id = user_id.sudo().sale_team_id.default_warehouse
         if sale_team_warehouse_id:
             pick_type_id = picking_type_obj.search(
                 [('code', '=', 'incoming'),

--- a/default_warehouse_from_sale_team/models/sales_team.py
+++ b/default_warehouse_from_sale_team/models/sales_team.py
@@ -36,7 +36,7 @@ class WarehouseDefault(models.Model):
                          self).default_get(fields_list)
         res_users_obj = self.env['res.users']
         user_brw = res_users_obj.browse(self._uid)
-        warehouse = user_brw.sale_team_id.default_warehouse
+        warehouse = user_brw.sudo().sale_team_id.default_warehouse
         if warehouse:
             warehouse_id = warehouse.id
             model_obj = self.env['ir.model']


### PR DESCRIPTION
### [T#40512](https://www.vauxoo.com/web#id=40512&view_type=form&model=project.task)

Using `sudo()` to avoid creating `ir.model.access` but allowing all the users with access to create a purchase order using the default warehouse.