### PR TITLE
[ADD] internal_transfer with partner_id

### DIFF
--- a/internal_transfer_with_agreed_amount/wizards/internal_transfer_multicurrency_view.xml
+++ b/internal_transfer_with_agreed_amount/wizards/internal_transfer_multicurrency_view.xml
@@ -7,6 +7,7 @@
             <form>
                 <group>
                     <p>Fill with the total amount that you will receive for this operation</p>
+                    <field name="partner_id"/>
                     <field name="agreed_amount"/>
                     <field name="currency_id" invisible="1"/>
                 </group>


### PR DESCRIPTION
Main
-

Allow that internal transfer has partner_id.

Explanation
-

Having that `internal_tranfer_with_agreed_amount` module already deals with the Internal Transfer feature in Odoo.
We are adding the feature of making it possible to assign a partner in the process thus avoid too much code.

