### PR TITLE
[FIX]  purchase_third_validation: Don't hide cancel i#15838

### DIFF
--- a/purchase_third_validation/views/purchase_view.xml
+++ b/purchase_third_validation/views/purchase_view.xml
@@ -8,6 +8,9 @@
                 <xpath expr="//button[@name='button_approve']" position="after">
                     <button name="button_approve" type="object" states='third approve' string="Approve Order" class="oe_highlight" groups="purchase_third_validation.general_purchase_manager"/>
                 </xpath>
+                <xpath expr="//button[@name='button_cancel']" position="attributes">
+                    <attribute name="states" add="third approve" />
+                </xpath>
             </field>
         </record>
 </odoo>


### PR DESCRIPTION
The cancellation button was being hidden when the purchase order is in
"Third Approve" status.