### PR TITLE
[FIX] account_chatter: change category group

### DIFF
--- a/account_chatter/security/account_chatter_security.xml
+++ b/account_chatter/security/account_chatter_security.xml
@@ -3,7 +3,7 @@
 
     <record id="group_show_account_chatter_notifications" model="res.groups">
         <field name="name">Show account chatter notifications</field>
-        <field name="category_id" ref="base.module_category_accounting_accounting"/>
+        <field name="category_id" ref="base.module_category_hidden"/>
         <field name="comment">Show notifications of accounting entries, journal and accounts reflecting changes and observations.</field>
     </record>
 


### PR DESCRIPTION
* Change category group to avoid conflicts with account group

##### BEFORE
<img width="880" alt="Screen Shot 2021-09-16 at 11 06 09 PM" src="https://user-images.githubusercontent.com/16024775/133727633-83798393-6c92-40b0-9933-ab560faa11a8.png">

##### AFTER
<img width="930" alt="Screen Shot 2021-09-16 at 11 13 25 PM" src="https://user-images.githubusercontent.com/16024775/133728255-e83fcf01-1788-48a5-b247-19def7d3801d.png">


