### PR TITLE
Revert "[FIX] account_chatter: change category group"

### DIFF
--- a/account_chatter/security/account_chatter_security.xml
+++ b/account_chatter/security/account_chatter_security.xml
@@ -3,7 +3,7 @@
 
     <record id="group_show_account_chatter_notifications" model="res.groups">
         <field name="name">Show account chatter notifications</field>
-        <field name="category_id" ref="base.module_category_hidden"/>
+        <field name="category_id" ref="base.module_category_accounting_accounting"/>
         <field name="comment">Show notifications of accounting entries, journal and accounts reflecting changes and observations.</field>
     </record>
 


### PR DESCRIPTION
This reverts commit a7e4b8c749f5d6a739efbe3010f9fb22c30475a1.

The "hidden" category is used for thechnical groups (the ones enabled/disabled
for all users), which is not the case for the account chatter group.