### PR TITLE
[FIX] stock_by_warehouse_sale: Edit SO line using form view i#16357

### DIFF
--- a/stock_by_warehouse_sale/views/sale_view.xml
+++ b/stock_by_warehouse_sale/views/sale_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="sale_order_form_view" model="ir.ui.view">
+    <record id="view_order_form" model="ir.ui.view">
         <field name="name">sale.order.stock.warehouse</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
@@ -21,6 +21,9 @@
                             groups="stock.group_stock_multi_warehouses"/>
                     </p>
                 </div>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree" position="attributes">
+                <attribute name="editable" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
In previous Odoo versions, the form view was poped up when editing a
sale order line, as long as the option "Manage Product packaging" was
enabled. This is no longer the case [1], so we re-enable it manually,
in order to be able to see current inventory when filling a line.

[1] https://github.com/odoo/odoo/commit/e813487e75f1