### PR TITLE
[IMP] default_warehouse_from_sale_team: Improving Rules

### DIFF
--- a/default_warehouse_from_sale_team/security/ir_rule.xml
+++ b/default_warehouse_from_sale_team/security/ir_rule.xml
@@ -5,7 +5,9 @@
             <record id="rule_default_warehouse_stock_picking_type_team" model="ir.rule">
                 <field name="name">Limited access to picking types (filtered by sale teams)</field>
                 <field name="model_id" search="[('model','=','stock.picking.type')]" model="ir.model"/>
-                <field name="domain_force">[('warehouse_id', 'in', [team.default_warehouse_id.id for team in user.sale_team_ids if team.default_warehouse_id])]</field>
+                <field name="domain_force">[
+                    ('warehouse_id', 'in', user.sale_team_ids.default_warehouse_id.ids),
+                ]</field>
                 <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_spt')])]"/>
             </record>
             <record id="rule_default_warehouse_stock_picking_type_all" model="ir.rule">
@@ -19,14 +21,18 @@
             <record id="rule_default_warehouse_stock_picking_team" model="ir.rule">
                 <field name="name">Limited access to pickings (filtered by sale teams)</field>
                 <field name="model_id" search="[('model','=','stock.picking')]" model="ir.model"/>
-                <field name="domain_force">[('warehouse_id', 'in', [team.default_warehouse_id.id for team in user.sale_team_ids if team.default_warehouse_id])]</field>
+                <field name="domain_force">[
+                    ('warehouse_id', 'in', user.sale_team_ids.default_warehouse_id.ids),
+                ]</field>
                 <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_sp')])]"/>
             </record>
             <record id="rule_default_warehouse_stock_picking_team12" model="ir.rule">
                 <field name="name">Limited access to pickings (filtered by not in sale teams)</field>
                 <field name="model_id" search="[('model','=','stock.picking')]" model="ir.model"/>
                 <field name="perm_read" eval="False"/>
-                <field name="domain_force">[('warehouse_id', 'not in', [team.default_warehouse_id.id for team in user.sale_team_ids if team.default_warehouse_id])]</field>
+                <field name="domain_force">[
+                    ('warehouse_id', 'not in', user.sale_team_ids.default_warehouse_id.ids),
+                ]</field>
                 <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_sp')])]"/>
             </record>
             <record id="rule_default_warehouse_stock_picking_all" model="ir.rule">
@@ -40,7 +46,11 @@
             <record id="rule_default_warehouse_journal" model="ir.rule">
                 <field name="name">Limited access to journal (filtered by sale teams)</field>
                 <field name="model_id" search="[('model','=','account.journal')]" model="ir.model"/>
-                <field name="domain_force">[('id', 'in', user.sale_team_ids.mapped('journal_team_ids').ids)]</field>
+                <field name="domain_force">[
+                    '|',
+                    ('id', 'in', user.sale_team_ids.journal_team_ids.ids),
+                    ('section_id', '=', False ),
+                ]</field>
                 <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_journal')])]"/>
             </record>
             <record id="rule_default_warehouse_journal_all" model="ir.rule">
@@ -54,7 +64,9 @@
             <record id="rule_default_warehouse_wh" model="ir.rule">
                 <field name="name">Limited access to warehouse (filtered by sale teams)</field>
                 <field name="model_id" search="[('model','=','stock.warehouse')]" model="ir.model"/>
-                <field name="domain_force">[('id', 'in', [team.default_warehouse_id.id for team in user.sale_team_ids if team.default_warehouse_id])]</field>
+                <field name="domain_force">[
+                    ('id', 'in', user.sale_team_ids.default_warehouse_id.ids),
+                ]</field>
                 <field name="groups" eval="[(6, 0, [ref('default_warehouse_from_sale_team.group_limited_default_warehouse_sp')])]"/>
             </record>
             <record id="rule_default_warehouse_wh_all" model="ir.rule">


### PR DESCRIPTION
### [Ticket#16321](https://www.vauxoo.com/web#id=16321&view_type=form&model=helpdesk.ticket)

Adding to the rule `rule_default_warehouse_journal` an `or` if the journal doesn't have its field `section_id` set.

Also, improving the domains of the rules to avoid list comprehensions using the mapped for related fields.