### PR TITLE
[REF] default_warehouse_from_sale_team: Sequence assignation in v14.0 i#16547

### DIFF
--- a/default_warehouse_from_sale_team/models/__init__.py
+++ b/default_warehouse_from_sale_team/models/__init__.py
@@ -11,3 +11,4 @@ from . import sale_order
 from . import stock_move
 from . import stock_picking
 from . import stock_picking_type
+from . import stock_warehouse

--- a/default_warehouse_from_sale_team/models/default_warehouse_mixing.py
+++ b/default_warehouse_from_sale_team/models/default_warehouse_mixing.py
@@ -5,6 +5,10 @@ class DefaultWarehouseMixing(models.AbstractModel):
     """If you inherit from this model and add a field called warehouse_id into
     the model, then the default value for such model will be the one
     set into the sales team.
+
+    Make sure to put this mixing at the top of inheritance (before the base model), e.g.
+
+        _inherit = ["default.warehouse.mixing", "sale.order"]
     """
     _name = "default.warehouse.mixing"
     _description = "Default Warehouse"
@@ -32,21 +36,19 @@ class DefaultWarehouseMixing(models.AbstractModel):
 
     @api.model
     def create(self, vals):
-        if vals.get('warehouse_id') and 'name' not in vals:
-            code = self._get_sequence_code()
-            pick_warehouse = self.env['stock.picking.type'].browse(vals.get('picking_type_id')).warehouse_id
-            warehouse_id = vals.get('warehouse_id', pick_warehouse.id)
-            section = self.env['crm.team'].search([('default_warehouse_id', '=', warehouse_id)], limit=1)
-            sequence = self.env['ir.sequence'].search(
-                [
-                    ('section_id', '=', section.id),
-                    ('code', '=', code),
-                ],
-                limit=1,
-            )
-            if sequence:
-                vals['name'] = sequence.next_by_id()
-        return super().create(vals)
+        """Pass sales team by context so it's taken into account when computing sequence name"""
+        salesteam = self._get_salesteam_from_vals(vals)
+        self_team = self.with_context(sequence_salesteam_id=salesteam.id)
+        return super(DefaultWarehouseMixing, self_team).create(vals)
 
-    def _get_sequence_code(self):
-        return self._name
+    def _get_salesteam_from_vals(self, vals):
+        """Determine sales team from creation values"""
+        if "name" in vals:
+            # Already has a name, so salesteam won't be used anyway
+            return self.env["crm.team"]
+        warehouse = (
+            self.env["stock.warehouse"].browse(vals.get("warehouse_id"))
+            or self.env["stock.picking.type"].browse(vals.get("picking_type_id")).warehouse_id
+        )
+        salesteam = warehouse.sale_team_ids[:1]
+        return salesteam

--- a/default_warehouse_from_sale_team/models/ir_sequence.py
+++ b/default_warehouse_from_sale_team/models/ir_sequence.py
@@ -1,7 +1,28 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class IrSequence(models.Model):
     _inherit = "ir.sequence"
 
     section_id = fields.Many2one('crm.team', string='Sales Team')
+
+    @api.model
+    def next_by_code(self, sequence_code, sequence_date=None):
+        """If a sales team is provided by context, give priority to sequences having it set"""
+        if "sequence_salesteam_id" not in self.env.context:
+            return super().next_by_code(sequence_code, sequence_date)
+        salesteam_id = self.env.context["sequence_salesteam_id"]
+        self.check_access_rights('read')
+        company_id = self.env.company.id
+        sequence = self.search(
+            [
+                ("code", "=", sequence_code),
+                ("company_id", "in", [company_id, False]),
+                ("section_id", "in", [salesteam_id, False]),
+            ],
+            limit=1,
+            order="section_id, company_id"
+        )
+        if sequence:
+            return sequence._next(sequence_date=sequence_date)
+        return super().next_by_code(sequence_code, sequence_date)

--- a/default_warehouse_from_sale_team/models/purchase_order.py
+++ b/default_warehouse_from_sale_team/models/purchase_order.py
@@ -3,4 +3,4 @@ from odoo import models
 
 class PurchaseOrder(models.Model):
     _name = 'purchase.order'
-    _inherit = ['purchase.order', 'default.picking.type.mixing']
+    _inherit = ["default.picking.type.mixing", "purchase.order"]

--- a/default_warehouse_from_sale_team/models/purchase_requisition.py
+++ b/default_warehouse_from_sale_team/models/purchase_requisition.py
@@ -5,5 +5,11 @@ class PurchaseRequisition(models.Model):
     _name = 'purchase.requisition'
     _inherit = ['purchase.requisition', 'default.picking.type.mixing']
 
-    def _get_sequence_code(self):
-        return 'purchase.order.requisition'
+    def action_in_progress(self):
+        """Pass team by context so sequence number is computed
+
+        Since requisition name is not assigned when it's created but when confirmed,
+        we need to pass the sales team by context also here.
+        """
+        self_team = self.with_context(sequence_salesteam_id=self.warehouse_id.sale_team_ids[:1].id)
+        return super(PurchaseRequisition, self_team).action_in_progress()

--- a/default_warehouse_from_sale_team/models/sale_order.py
+++ b/default_warehouse_from_sale_team/models/sale_order.py
@@ -2,7 +2,8 @@ from odoo import models
 
 
 class SaleOrder(models.Model):
-    _inherit = "sale.order"
+    _name = "sale.order"
+    _inherit = ["default.warehouse.mixing", "sale.order"]
 
     def _prepare_invoice(self):
         """Add team by context so it's taken into account when choosing default journal"""

--- a/default_warehouse_from_sale_team/models/stock_picking_type.py
+++ b/default_warehouse_from_sale_team/models/stock_picking_type.py
@@ -3,4 +3,4 @@ from odoo import models
 
 class StockPickingType(models.Model):
     _name = "stock.picking.type"
-    _inherit = ['stock.picking.type', 'default.warehouse.mixing']
+    _inherit = ["default.warehouse.mixing", "stock.picking.type"]

--- a/default_warehouse_from_sale_team/models/stock_warehouse.py
+++ b/default_warehouse_from_sale_team/models/stock_warehouse.py
@@ -1,0 +1,9 @@
+from odoo import models, fields
+
+
+class StockWarehouse(models.Model):
+    _inherit = "stock.warehouse"
+
+    sale_team_ids = fields.One2many(
+        "crm.team", "default_warehouse_id", string="Sales teams",
+    )

--- a/default_warehouse_from_sale_team/tests/test_default_warehouse.py
+++ b/default_warehouse_from_sale_team/tests/test_default_warehouse.py
@@ -106,10 +106,6 @@ class TestSalesTeamDefaultWarehouse(TransactionCase):
         sales team for that warehouse
         """
         account_id = self.env['account.account'].search([], limit=1)
-        sales_team = self.env.ref(
-            'default_warehouse_from_sale_team.section_sales_default_team'
-        )
-        payment_term = self.env.ref('account.account_payment_term_immediate')
         self.product.categ_id.write({
             'property_valuation': 'real_time',
             'property_stock_account_input_categ_id': account_id.id,


### PR DESCRIPTION
Automatic sequence numbering was not working in 14.0. For instance, now
purchase requisitions have different sequence codes, depending on
their types.