### PR TITLE
[IMP] default_warehouse_from_sale_team: Rename field Default Warehouse i#16598

### DIFF
--- a/default_warehouse_from_sale_team/migrations/14.0.0.0.0/pre-migration.py
+++ b/default_warehouse_from_sale_team/migrations/14.0.0.0.0/pre-migration.py
@@ -1,0 +1,20 @@
+import logging
+
+from odoo import tools
+
+_logger = logging.getLogger()
+
+
+def migrate(cr, version):
+    rename_default_warehouse(cr)
+
+
+def rename_default_warehouse(cr):
+    """Rename field ``default_warehouse`` from sales teams to add the correct suffix"""
+    table_name = "crm_team"
+    old_field = "default_warehouse"
+    new_field = "default_warehouse_id"
+    if not tools.column_exists(cr, table_name, old_field):
+        return
+    _logger.info("Renaming database column on table %s: %s -> %s", table_name, old_field, new_field)
+    tools.rename_column(cr, table_name, old_field, new_field)


### PR DESCRIPTION
Field name for default warehouse on sales teams was missing the proper
suffix on previous versions of this module.

This implements a migration script so the database column is renamed
when we're coming from previous versions.