### PR TITLE
[FIX] default_warehouse_from_Sale_team: Don't overwrite team nor warehouse i#16738

### DIFF
--- a/default_warehouse_from_sale_team/models/crm_team.py
+++ b/default_warehouse_from_sale_team/models/crm_team.py
@@ -19,6 +19,16 @@ class CrmTeam(models.Model):
         'the warehouse of this sales team',
     )
 
+    def _get_default_team_id(self, user_id=None, domain=None):
+        """When specified by context, ensure the sales team is taken from the current user"""
+        if (
+            user_id is not None
+            and self.env.context.get("keep_current_user_salesteam")
+            and self.env.user.sale_team_id
+        ):
+            user_id = self.env.uid
+        return super()._get_default_team_id(user_id=user_id, domain=domain)
+
     def _get_default_journal_sale(self):
         for journal in self.journal_team_ids:
             if journal.type == "sale":

--- a/default_warehouse_from_sale_team/models/default_warehouse_mixing.py
+++ b/default_warehouse_from_sale_team/models/default_warehouse_mixing.py
@@ -52,3 +52,12 @@ class DefaultWarehouseMixing(models.AbstractModel):
         )
         salesteam = warehouse.sale_team_ids[:1]
         return salesteam
+
+    def onchange(self, values, field_name, field_onchange):
+        """Add an extra context to prevent current user's salesteam from being overwritten by onchanges
+
+        This is useful in e.g. sale orders, where sales person's sales team has priority over current
+        user's sales team.
+        """
+        self_team_ctx = self.with_context(keep_current_user_salesteam=True)
+        return super(DefaultWarehouseMixing, self_team_ctx).onchange(values, field_name, field_onchange)

--- a/default_warehouse_from_sale_team/models/res_users.py
+++ b/default_warehouse_from_sale_team/models/res_users.py
@@ -29,6 +29,6 @@ class ResUsers(models.Model):
     def _get_default_warehouse_id(self):
         """Take the warehouse set in sales team as default one, otherwise fallback on user's one"""
         return (
-            self.sudo().sale_team_id.default_warehouse_id
+            self.env.user.sale_team_id.default_warehouse_id
             or super()._get_default_warehouse_id()
         )


### PR DESCRIPTION
When the partner is changed in a sale order, the current user's sales
team and warehouse should have priority over other ones.

Dummy MR: https://git.vauxoo.com/vauxoo/typ/-/merge_requests/885