### PR TITLE
[FIX] default_warehouse_from_sale_team: only session company sale teams

### DIFF
--- a/default_warehouse_from_sale_team/models/sales_team.py
+++ b/default_warehouse_from_sale_team/models/sales_team.py
@@ -34,7 +34,8 @@ class WarehouseDefault(models.Model):
         defaults = super().default_get(fields_list)
         res_users_obj = self.env['res.users']
         user_brw = res_users_obj.browse(self._uid)
-        allowed_warehouse_ids = user_brw.sale_team_ids.default_warehouse_id.sorted('sequence')
+        allowed_warehouse_ids = user_brw.sale_team_ids.filtered(
+            lambda x: x.company_id in self.env.companies).default_warehouse_id.sorted('sequence')
         default_warehouse_id = allowed_warehouse_ids[:1].id
         if default_warehouse_id:
             model_obj = self.env['ir.model']


### PR DESCRIPTION
The field sale teams retrieve all sale teams configured to user,
regardless the company. In this fix, we add a filter to sale teams
field to get only the sale teams for company in session.

![Captura de pantalla de 2021-11-29 11-39-23](https://user-images.githubusercontent.com/5335402/143921358-9b5cb426-0930-45b2-8b56-94cf633821fa.png)
