### PR TITLE
[FIX] default_warehouse_from_sale_team: multi-company support on PO

### DIFF
--- a/default_warehouse_from_sale_team/models/purchase.py
+++ b/default_warehouse_from_sale_team/models/purchase.py
@@ -14,16 +14,17 @@ class DefaultPickingType(models.Model):
         instead warehouse like purchase order and purchase requisition
         returning the first picking type that match with the warehouse
         of the sale team """
-        user_obj = self.env['res.users']
-        picking_type_obj = self.env['stock.picking.type']
-
         res = super(DefaultPickingType, self).default_get(fields_list)
-        user_id = user_obj.browse(self._uid)
-        sale_team_warehouse_id = user_id.sale_team_id.default_warehouse_id
-        if sale_team_warehouse_id:
+        res_users_obj = self.env['res.users']
+        picking_type_obj = self.env['stock.picking.type']
+        user_brw = res_users_obj.browse(self._uid)
+        allowed_warehouse_ids = user_brw.sale_team_ids.filtered(
+            lambda x: x.company_id in self.env.companies).default_warehouse_id.sorted('sequence')
+        default_warehouse_id = allowed_warehouse_ids[:1].id
+        if default_warehouse_id:
             pick_type_id = picking_type_obj.search(
                 [('code', '=', 'incoming'),
-                 ('warehouse_id', '=', sale_team_warehouse_id.id)], limit=1)
+                 ('warehouse_id', '=', default_warehouse_id)], limit=1)
             res.update({'picking_type_id': pick_type_id.id})
 
         return res


### PR DESCRIPTION
This time at Purchase model was changed default warehouse reading by
searching into all sales team assigned to user in the current company.

The previous designed get the company from field sale_team_id and
that field show the sales team assigned regardless of company in
session, this cause an error in multi-company environment.