### PR TITLE
[FIX] default_warehouse_from_sale_team: access error when chained rule i#17897

### DIFF
--- a/default_warehouse_from_sale_team/models/__init__.py
+++ b/default_warehouse_from_sale_team/models/__init__.py
@@ -4,6 +4,7 @@ from . import crm_team
 from . import default_warehouse_mixin
 from . import default_picking_type_mixin
 from . import ir_sequence
+from . import procurement_group
 from . import purchase_order
 from . import purchase_requisition
 from . import res_users

--- a/default_warehouse_from_sale_team/models/procurement_group.py
+++ b/default_warehouse_from_sale_team/models/procurement_group.py
@@ -1,0 +1,12 @@
+from odoo import api, models
+
+
+class ProcurementGroup(models.Model):
+    _inherit = "procurement.group"
+
+    @api.model
+    def _search_rule(self, route_ids, product_id, warehouse_id, domain):
+        """Grant access to provided warehouse if it's not allowed to the current user"""
+        if warehouse_id._access_unallowed_current_user_salesteams():
+            warehouse_id = warehouse_id.sudo()
+        return super()._search_rule(route_ids, product_id, warehouse_id, domain)

--- a/default_warehouse_from_sale_team/models/stock_warehouse.py
+++ b/default_warehouse_from_sale_team/models/stock_warehouse.py
@@ -7,3 +7,18 @@ class StockWarehouse(models.Model):
     sale_team_ids = fields.One2many(
         "crm.team", "default_warehouse_id", string="Sales teams",
     )
+
+    def _access_unallowed_current_user_salesteams(self):
+        """Check if access will be denied because warehouse is not allowed on current user's sales teams
+
+        In some cases, it's required to grant access to warehouses not allowed for the current user, e.g.
+        when an inventory rule is triggered that involves other warehouses.
+        """
+        rule_warehouse = self.env.ref("default_warehouse_from_sale_team.rule_default_warehouse_wh")
+        warehouses = self.exists()
+        return (
+            warehouses
+            and not self.env.su
+            and warehouses.check_access_rights("read", raise_exception=False)
+            and self.env["ir.rule"]._get_failing(warehouses, mode="read") == rule_warehouse
+        )


### PR DESCRIPTION
When a stock movement triggers an inventory rule that involves another
warehouse on which the current user has no access, an access error is
triggered. That's because, thanks to this module, users can only see
warehouses allowed in their sales teams.

To solve the above, access is granted to all warehouses when computing
inventory rules to apply.

### Dummy MR:

- [vauxoo/typ!936](https://git.vauxoo.com/vauxoo/typ/-/merge_requests/936)