### PR TITLE
[FIX] stock_by_warehouse: Scrollbar bug on stock_by_warehouse widget

### DIFF
--- a/stock_by_warehouse/static/src/js/widget.js
+++ b/stock_by_warehouse/static/src/js/widget.js
@@ -80,7 +80,8 @@ var ShowPaymentLineWidget = form_common.extend({
                 'placement': this.nodeOptions.placement || 'right',
                 'title': this.nodeOptions.title || self.info.title || "",
                 'trigger': 'focus',
-                'delay': { "show": 0, "hide": 100 }
+                'delay': { "show": 0, "hide": 100 },
+                'template': QWeb.render('StockByWarehousePopoverTemplate'),
             };
             $(button).popover(options);
         }

--- a/stock_by_warehouse/static/src/scss/main.scss
+++ b/stock_by_warehouse/static/src/scss/main.scss
@@ -1,3 +1,9 @@
 .js_product_warehouse, .js_available_info{
     cursor: pointer;
 }
+
+.popover-body.stock-by-warehouse-widget{
+    overflow: auto;
+    max-height: 400px;
+    padding: 0px;
+}

--- a/stock_by_warehouse/static/src/xml/template.xml
+++ b/stock_by_warehouse/static/src/xml/template.xml
@@ -2,6 +2,14 @@
 
 <templates xml:space="preserve">
 
+    <t t-name="StockByWarehousePopoverTemplate">
+        <div class="popover" role="tooltip">
+            <div class="arrow"/>
+            <h3 class="popover-header"/>
+            <div class="popover-body stock-by-warehouse-widget"/>
+        </div>
+    </t>
+
     <t t-name="ShowWarehouseInfo">
         <div>
             <a role="button" tabindex="0" class="js_product_warehouse">
@@ -10,7 +18,7 @@
     </t>
 
     <t t-name="ProductWarehousePopOver">
-        <div class="panel clearfix">
+        <div class="panel clearfix container">
             <div class="list-group">
                 <t t-foreach="lines" t-as="warehouse">
                     <div t-if="warehouse.available_not_res &gt; 0 or warehouse.available &gt; 0 or warehouse.outgoing &gt; 0 or warehouse.saleable &gt; 0 or warehouse.incoming &gt; 0 or warehouse.virtual &gt; 0" class="list-group-item row">


### PR DESCRIPTION
### This MR refers to the ticket [#17884](https://www.vauxoo.com/web#id=17884&action=1809&model=helpdesk.ticket&view_type=form&cids=1&menu_id=1431)

Problem
- Scrollbar hidden and no height limit when the product is on several warehouses
![image](https://user-images.githubusercontent.com/96079875/155244594-a0ee64c7-54df-4247-80e2-8c8eb5684e30.png)


Solution
- Import class to add overflow and height to the div on the scss file
![Screenshot from 2022-02-22 18-42-47](https://user-images.githubusercontent.com/96079875/155244619-61d2eda9-340f-4832-8b1f-1a4746ce9435.png)