### PR TITLE
[ADD] default_warehouse_from_sale_team_jit: Default warehouse + JIT i#17897

### DIFF
--- a/default_warehouse_from_sale_team_jit/README.rst
+++ b/default_warehouse_from_sale_team_jit/README.rst
@@ -1,0 +1,44 @@
+Default Warehouse from Sales Team + Just In Time Scheduling
+===========================================================
+
+This module is just to ensure the module "Default Warehouse from Sales Team"
+works correctly when sold products are configured to be reserved immediately
+after sales order confirmation, i.e. module "Just In Time Scheduling"
+(``procurement_jit``) is installed.
+
+This helps to avoid access errors when product reservation of sale orders
+requires access to warehouses not allowed to current user on their sales teams.
+
+Bug Tracker
+===========
+
+Bugs are tracked on
+`GitHub Issues <https://github.com/Vauxoo/addons-vauxoo/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and
+welcomed feedback
+`here <https://github.com/Vauxoo/addons-vauxoo/issues/new?body=module:%20
+default_warehouse_from_sale_team_jit
+%0Aversion:%20
+14.0
+%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_
+
+Credits
+=======
+
+Contributors
+------------
+
+- Luis González <lgonzalez@vauxoo.com>
+
+Maintainer
+==========
+
+.. image:: https://s3.amazonaws.com/s3.vauxoo.com/description_logo.png
+   :alt: Vauxoo
+   :target: https://www.vauxoo.com
+   :width: 200
+
+This module is maintained by Vauxoo.
+
+To contribute to this module, please visit https://www.vauxoo.com.

--- a/default_warehouse_from_sale_team_jit/__init__.py
+++ b/default_warehouse_from_sale_team_jit/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/default_warehouse_from_sale_team_jit/__manifest__.py
+++ b/default_warehouse_from_sale_team_jit/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "Default Warehouse from Sales Team with JIT",
+    "author": "Vauxoo",
+    "website": "https://www.vauxoo.com",
+    "license": "LGPL-3",
+    "category": "Inventory/Inventory",
+    "version": "14.0.1.0.0",
+    "depends": [
+        "default_warehouse_from_sale_team",
+        "procurement_jit",
+    ],
+    "data": [
+    ],
+    "demo": [
+    ],
+    "installable": True,
+    "auto_install": True,
+}

--- a/default_warehouse_from_sale_team_jit/models/__init__.py
+++ b/default_warehouse_from_sale_team_jit/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_line

--- a/default_warehouse_from_sale_team_jit/models/sale_order_line.py
+++ b/default_warehouse_from_sale_team_jit/models/sale_order_line.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _action_launch_stock_rule(self, previous_product_uom_qty=False):
+        """Allow to run procurement in warehouses not allowed on current user's sales teams"""
+        warehouses = self.route_id.rule_ids.warehouse_id
+        if warehouses._access_unallowed_current_user_salesteams():
+            self = self.sudo()
+        return super()._action_launch_stock_rule(previous_product_uom_qty)


### PR DESCRIPTION
This module is just to ensure the module "Default Warehouse from Sales
Team" works correctly when sold products are configured to be reserved
immediately after sales order confirmation, i.e. module "Just In Time
Scheduling" (`procurement_jit`) is installed.

This helps to avoid access errors when product reservation of sale
orders requires access to warehouses not allowed to current user on
their sales teams.

### Dummy MR:

- - [vauxoo/typ!936](https://git.vauxoo.com/vauxoo/typ/-/merge_requests/936)