### PR TITLE
[IMP] default_warehouse_from_sale_team: Default journal for vendor bills i#17892

### DIFF
--- a/default_warehouse_from_sale_team/models/account_move.py
+++ b/default_warehouse_from_sale_team/models/account_move.py
@@ -7,20 +7,18 @@ class AccountMove(models.Model):
     @api.model
     def _search_default_journal(self, journal_types):
         """If a team is provided and it has a sales journal set, take it as 1st alternative"""
-        team = self.env.context.get("salesteam")
-        journal_on_team = None
-        if team and journal_types == ["sale"]:
-            journal_on_team = team._get_default_journal_sale()
+        team = self.env.context.get("salesteam") or self.team_id
+        journal_on_team = team._get_default_journal(journal_types)
         return journal_on_team or super()._search_default_journal(journal_types)
 
     @api.onchange('team_id')
     def _onchange_team_id(self):
-        if (
-            self.state != "draft"
-            or not self.team_id
-            or self.move_type not in self.get_sale_types(include_receipts=True)
-        ):
+        if self.state != "draft" or not self.is_invoice(include_receipts=True) or not self.team_id.journal_team_ids:
             return {}
-        default_journal = self.team_id._get_default_journal_sale()
-        if default_journal:
-            self.journal_id = default_journal
+        self = self.with_company(self.company_id)
+        default_journal_ctx = {
+            "default_move_type": self.move_type,
+            "default_currency_id": self.currency_id.id,
+        }
+        default_journal = self.with_context(**default_journal_ctx)._get_default_journal()
+        self.journal_id = default_journal


### PR DESCRIPTION
Currently, when creating a customer invoice, a default journal is set
if it's configured in the sales team. However, that feature only works
for customer invoices but not for vendor bills.

This change implements the default journal feature also for vendor
bills.

In addition, now company and currency are also considered when
computing default journal, for more accurate results.

### Dummy MR:

- [vauxoo/typ!950](https://git.vauxoo.com/vauxoo/typ/-/merge_requests/950)