### PR TITLE
[FIX] default_warehouse_from_sale_team: typo in README t#53868

### DIFF
--- a/default_warehouse_from_sale_team/README.rst
+++ b/default_warehouse_from_sale_team/README.rst
@@ -107,7 +107,7 @@ Credits
 
 * Nhomar Hernández <nhomar@vauxoo.com> (Planner/Developer)
 * Katherine Zaoral <kathy@vauxoo.com> (Planner/Developer)
-- Luis González <lgonzalez@vauxoo.com> (Developer)
+* Luis González <lgonzalez@vauxoo.com> (Developer)
 
 Maintainer
 ==========


### PR DESCRIPTION
Which was causing list of contributors not being correctly rendered.