### PR TITLE
[FIX] default_warehouse_from_sale_team: Sale Team Constraint Message

### DIFF
--- a/default_warehouse_from_sale_team/i18n/es.po
+++ b/default_warehouse_from_sale_team/i18n/es.po
@@ -52,6 +52,11 @@ msgstr ""
 " equipos de ventas"
 
 #. module: default_warehouse_from_sale_team
+#: model:ir.model.fields,field_description:default_warehouse_from_sale_team.field_res_users__sale_team_ids
+msgid "Allowed sales teams"
+msgstr "Equipos de ventas permitidos"
+
+#. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_default_picking_type_mixin
 msgid "Default Operation Type"
 msgstr "Tipo de Operación por defecto"
@@ -203,6 +208,12 @@ msgid "Sales Team"
 msgstr "Equipo de ventas"
 
 #. module: default_warehouse_from_sale_team
+#: model:ir.model.fields,help:default_warehouse_from_sale_team.field_res_users__sale_team_ids
+msgid ""
+"Sales teams allowed for the user, to give access to warehouses and their related documents."
+msgstr "Equipos de venta permitidos para el usuario, para dar acceso a almacenes y sus documentos relacionados."
+
+#. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_ir_sequence
 msgid "Sequence"
 msgstr "Secuencia"
@@ -219,22 +230,15 @@ msgid "Stock Move"
 msgstr "Movimiento de existencias"
 
 #. module: default_warehouse_from_sale_team
-#: model:ir.model.fields,help:default_warehouse_from_sale_team.field_res_users__sale_team_ids
-msgid ""
-"This is only an informative field. Go to Sales > Sales > Sales Teams to edit"
-msgstr ""
-"Esto es sólo un campo informativo. Vaya a Ventas> Ventas> Equipos de ventas "
-"para editar"
+#: code:addons/default_warehouse_from_sale_team/models/res_users.py:0
+#, python-format
+msgid "The chosen team (%s) is not in the allowed sales teams for this user"
+msgstr "El equipo de venta seleccionado (%s) no está entre los equipos permitidos para este usuario"
 
 #. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_stock_picking
 msgid "Transfer"
 msgstr "Traslado"
-
-#. module: default_warehouse_from_sale_team
-#: model:ir.model.fields,field_description:default_warehouse_from_sale_team.field_res_users__sale_team_ids
-msgid "User's sales teams"
-msgstr "Equipos de ventas de usuarios."
 
 #. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_res_users
@@ -277,11 +281,3 @@ msgstr "Almacén"
 #: model_terms:ir.ui.view,arch_db:default_warehouse_from_sale_team.crm_team_view_form
 msgid "Warehouse settings for the sales team"
 msgstr "Configuración de almacén para el equipo de ventas"
-
-#. module: default_warehouse_from_sale_team
-#: code:addons/default_warehouse_from_sale_team/models/res_users.py:0
-#, python-format
-msgid ""
-"You can not set the sales team %s as default because the user does not belongs to that sales team.\n"
-"Please go to Sales > Settings > Users > Sales Teams if you would like to add this user to the sales team"
-msgstr ""

--- a/default_warehouse_from_sale_team/models/res_users.py
+++ b/default_warehouse_from_sale_team/models/res_users.py
@@ -7,8 +7,8 @@ class ResUsers(models.Model):
 
     sale_team_ids = fields.Many2many(
         "crm.team", "sale_member_rel", "member_id", "section_id",
-        string="User's sales teams",
-        help="This is only an informative field. Go to Sales > Sales > Sales Teams to edit",
+        string="Allowed sales teams",
+        help="Sales teams allowed for the user, to give access to warehouses and their related documents.",
     )
 
     @api.constrains('sale_team_id')
@@ -19,10 +19,7 @@ class ResUsers(models.Model):
         user_wrong_team = self.filtered(lambda u: u.sale_team_id - u.sale_team_ids)
         if user_wrong_team:
             raise ValidationError(_(
-                "You can not set the sales team %s as default because the user"
-                " does not belongs to that sales team.\n"
-                "Please go to Sales > Settings > Users > Sales Teams if you would like to add this "
-                "user to the sales team",
+                "The chosen team (%s) is not in the allowed sales teams for this user",
                 user_wrong_team[0].sale_team_id.name
             ))
 


### PR DESCRIPTION
### [T#53868](https://www.vauxoo.com/web#id=53868&view_type=form&model=project.task)

Improving the message of the `sale_team_id` constraint, also, changing the `string` and `help` of the `sale_team_ids` field because is not readonly and the allowed teams should be set that field.