### PR TITLE
[FIX] default_warehouse_from_sale_team: access error on journal name i#17898

### DIFF
--- a/default_warehouse_from_sale_team/models/account_journal.py
+++ b/default_warehouse_from_sale_team/models/account_journal.py
@@ -5,3 +5,12 @@ class AccountJournal(models.Model):
     _inherit = 'account.journal'
 
     section_id = fields.Many2one('crm.team', string='Sales Team')
+
+    def name_get(self):
+        """Avoid access errors when computing journal's display name
+
+        Avoid access errors when user has access to a journal item but not to its journal, e.g. when
+        reconciling bank statements.
+        """
+        self = self.sudo()
+        return super().name_get()


### PR DESCRIPTION
Avoid access errors when user has access to a journal item but not to its
journal, e.g. when reconciling bank statements.

### Dummy MR:
 - [vauxoo/typ!950](https://git.vauxoo.com/vauxoo/typ/-/merge_requests/950)