### PR TITLE
[FIX] stock_by_warehouse: Fix unittest error caused by action_confirm

### DIFF
--- a/stock_by_warehouse/tests/test_stock_available_unreserved.py
+++ b/stock_by_warehouse/tests/test_stock_available_unreserved.py
@@ -9,14 +9,15 @@ class TestStockLogisticsWarehouse(TransactionCase):
         self.product_obj = self.env['product.product'].with_context(tracking_disable=True)
         self.template_obj = self.env['product.template']
         self.supplier_location = self.env.ref('stock.stock_location_suppliers')
-        self.stock_location = self.env.ref(
-            'stock.stock_location_stock')
+        self.stock_location = self.env.ref('stock.stock_location_stock')
         self.customer_location = self.env.ref('stock.stock_location_customers')
         self.uom_unit = self.env.ref('uom.product_uom_unit')
 
         # Create attribute
-        self.attribute = self.env['product.attribute'].create({'name': 'Type',
-                                                               'sequence': 1})
+        self.attribute = self.env['product.attribute'].create({
+            'name': 'Type',
+            'sequence': 1
+        })
         self.attribute_a = self.env['product.attribute.value'].create({
             'name': 'A',
             'attribute_id': self.attribute.id,
@@ -29,19 +30,20 @@ class TestStockLogisticsWarehouse(TransactionCase):
         })
 
         # Create product template
-        self.template_ab = self.template_obj.create(
-            {'name': 'templAB',
-             'standard_price': 1,
-             'type': 'product',
-             'uom_id': self.uom_unit.id,
-             'attribute_line_ids': [(0, 0, {
-                 'attribute_id': self.attribute.id,
-                 'value_ids': [(6, 0, (self.attribute_a + self.attribute_b).ids)]
-             })],
-             })
-        self.product_values = {'name': 'product A',
-                               'default_code': 'A',
-                               }
+        self.template_ab = self.template_obj.create({
+            'name': 'templAB',
+            'standard_price': 1,
+            'type': 'product',
+            'uom_id': self.uom_unit.id,
+            'attribute_line_ids': [(0, 0, {
+                'attribute_id': self.attribute.id,
+                'value_ids': [(6, 0, (self.attribute_a + self.attribute_b).ids)]
+            })],
+        })
+        self.product_values = {
+            'name': 'product A',
+            'default_code': 'A',
+        }
 
     def update_product(self, position, values):
         self.template_ab.product_variant_ids[position].write(values)
@@ -60,7 +62,8 @@ class TestStockLogisticsWarehouse(TransactionCase):
                     'product_uom_qty': qty,
                     'location_id': loc_orig.id,
                     'location_dest_id': loc_dest.id,
-                })]
+                })
+            ]
         })
         return picking
 
@@ -75,22 +78,29 @@ class TestStockLogisticsWarehouse(TransactionCase):
         # Update product A and B
 
         product_a = self.update_product(0, self.product_values)
-        self.product_values.update({'name': 'product B',
-                                    'default_code': 'B',
-                                    })
+        self.product_values.update({
+            'name': 'product B',
+            'default_code': 'B',
+        })
         product_b = self.update_product(1, self.product_values)
 
         # Create a picking move from INCOMING to STOCK
 
-        picking_in_a = self.create_picking(self.ref('stock.picking_type_in'),
-                                           self.supplier_location,
-                                           self.stock_location,
-                                           product_a, 2)
+        picking_in_a = self.create_picking(
+            self.ref('stock.picking_type_in'),
+            self.supplier_location,
+            self.stock_location,
+            product_a,
+            2,
+        )
 
-        picking_in_b = self.create_picking(self.ref('stock.picking_type_in'),
-                                           self.supplier_location,
-                                           self.stock_location,
-                                           product_b, 3)
+        picking_in_b = self.create_picking(
+            self.ref('stock.picking_type_in'),
+            self.supplier_location,
+            self.stock_location,
+            product_b,
+            3,
+        )
 
         self.compare_qty_available_not_res(product_a, 0)
         self.compare_qty_available_not_res(self.template_ab, 0)
@@ -118,10 +128,13 @@ class TestStockLogisticsWarehouse(TransactionCase):
         self.compare_qty_available_not_res(self.template_ab, 5)
 
         # Create a picking from STOCK to CUSTOMER
-        picking_out_a = self.create_picking(self.ref('stock.picking_type_out'),
-                                            self.stock_location,
-                                            self.customer_location,
-                                            product_b, 2)
+        picking_out_a = self.create_picking(
+            self.ref('stock.picking_type_out'),
+            self.stock_location,
+            self.customer_location,
+            product_b,
+            2,
+        )
 
         self.compare_qty_available_not_res(product_b, 3)
         self.compare_qty_available_not_res(self.template_ab, 5)

--- a/stock_by_warehouse/tests/test_stock_available_unreserved.py
+++ b/stock_by_warehouse/tests/test_stock_available_unreserved.py
@@ -140,9 +140,6 @@ class TestStockLogisticsWarehouse(TransactionCase):
         self.compare_qty_available_not_res(self.template_ab, 5)
 
         picking_out_a.action_confirm()
-        self.compare_qty_available_not_res(product_b, 3)
-        self.compare_qty_available_not_res(self.template_ab, 5)
-
         picking_out_a.action_assign()
         self.compare_qty_available_not_res(product_b, 1)
         self.compare_qty_available_not_res(self.template_ab, 3)


### PR DESCRIPTION
The issue was that the action_confirm takes 2 units of product immediately before action_assign.
On v14.0 the products were taken from picking after action_assign. Using action_confirm and
action_assign consecutively mantains the original behaviour from the test. This explained behaviour
is due to stock.move changes where this model handles action_assign when action_confirm is
executed. Functionality is preserved, but the change in the unittest is necessary to follow new
behaviour.

**References:**
https://github.com/odoo/odoo/commit/a838f2af683e03cd03ba02532f002ccd5c2642f5,
https://github.com/odoo/odoo/blob/14.0/addons/stock/models/stock_move.py#L1169
https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_move.py#L1239

**Before:**

![stock_by_warehouse_fix_unitest_error](https://user-images.githubusercontent.com/90422721/157941089-95521690-8d89-4c01-b619-33ebed1316f0.png)

**After:**

![stock_by_warehouse_fix_unitest_solution](https://user-images.githubusercontent.com/90422721/157940901-826b306f-b5ec-4f31-bff7-3260b239d3ab.png)

