### PR TITLE
[IMP] account_chatter: add tracking to allowed_journal_ids field in account.account model

### DIFF
--- a/account_chatter/models/account_account.py
+++ b/account_chatter/models/account_account.py
@@ -18,16 +18,17 @@ class AccountAccount(models.Model):
     tax_ids = fields.Many2many(tracking=True)
     tag_ids = fields.Many2many(tracking=True)
     group_id = fields.Many2one(tracking=True)
+    allowed_journal_ids = fields.Many2many(tracking=True)
 
     def _message_track(self, tracked_fields, initial):
-        """Perform a field tracking over tax_ids and tag_ids
+        """Perform a field tracking over tax_ids, tag_ids and allowed_journal_ids
 
         This is performed manually because field tracking over many2many fields is not
         natively supported.
         """
         changes, tracking_value_ids = super()._message_track(tracked_fields, initial)
         for display_name, display_info in tracked_fields.items():
-            if display_name not in ('tag_ids', 'tax_ids'):
+            if display_name not in ('tag_ids', 'tax_ids', 'allowed_journal_ids'):
                 continue
             initial_value = initial[display_name]
             new_value = self[display_name]
@@ -37,7 +38,7 @@ class AccountAccount(models.Model):
                 new_value = ", ".join(new_value.mapped('name')) if new_value else False
                 display_info['type'] = 'char'
                 tracking = self.env['mail.tracking.value'].create_tracking_values(
-                    initial_value, new_value, display_name, display_info, tracking_sequence)
+                    initial_value, new_value, display_name, display_info, tracking_sequence, self._name)
                 if tracking:
                     tracking_value_ids.append([0, 0, tracking])
                 changes.add(display_name)


### PR DESCRIPTION
- Add tracking to `allowed_journal_ids` field in `account.account` model.

- Avoid traceback adding `tag_ids` or `tax_ids` fields.

```
Traceback (most recent call last):
  File "/home/odoo/instance/odoo/odoo/http.py", line 639, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/odoo/instance/odoo/odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: create_tracking_values() missing 1 required positional argument: 'model_name'
```