### PR TITLE
[REF] account_chatter: remove inherit and tracking in some fields

### DIFF
--- a/account_chatter/models/account_account.py
+++ b/account_chatter/models/account_account.py
@@ -6,15 +6,8 @@ from odoo import models, fields
 
 class AccountAccount(models.Model):
 
-    _name = "account.account"
-    _inherit = ['account.account', 'mail.thread']
+    _inherit = 'account.account'
 
-    name = fields.Char(tracking=True)
-    currency_id = fields.Many2one(tracking=True)
-    code = fields.Char(tracking=True)
-    deprecated = fields.Boolean(tracking=True)
-    reconcile = fields.Boolean(tracking=True)
-    user_type_id = fields.Many2one(tracking=True)
     tax_ids = fields.Many2many(tracking=True)
     tag_ids = fields.Many2many(tracking=True)
     group_id = fields.Many2one(tracking=True)


### PR DESCRIPTION
- This change is because in `15.0` the `account.account` model has tracking to some fields, so is not necessary the `mail.thread` inherit and overwrite the fields to add tracking.