### PR TITLE
[IMP] account_chatter: Add admin and root users as defaults on groups

### DIFF
--- a/account_chatter/security/account_chatter_security.xml
+++ b/account_chatter/security/account_chatter_security.xml
@@ -4,6 +4,7 @@
     <record id="group_show_account_chatter_notifications" model="res.groups">
         <field name="name">Show account chatter notifications</field>
         <field name="comment">Show notifications of accounting entries, journal and accounts reflecting changes and observations.</field>
+        <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]" />
     </record>
 
 </odoo>


### PR DESCRIPTION
- Add admin and root users as default on the group `group_show_account_chatter_notifications`.