### PR TITLE
[FIX] account_chatter: missing activities on chatters t#56103

### DIFF
--- a/account_chatter/models/account_account.py
+++ b/account_chatter/models/account_account.py
@@ -6,7 +6,8 @@ from odoo import models, fields
 
 class AccountAccount(models.Model):
 
-    _inherit = 'account.account'
+    _name = "account.account"
+    _inherit = ['account.account', 'mail.thread', 'mail.activity.mixin']
 
     tax_ids = fields.Many2many(tracking=True)
     tag_ids = fields.Many2many(tracking=True)

--- a/account_chatter/views/account_account_views.xml
+++ b/account_chatter/views/account_account_views.xml
@@ -1,6 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="view_account_form_inherit" model="ir.ui.view">
-        <field name="name">account.account.form.inherit</field>
+
+    <record id="view_account_form" model="ir.ui.view">
+        <field name="name">account.account.form.inherit.account.chatter</field>
         <field name="model">account.account</field>
         <field name="inherit_id" ref="account.view_account_form"/>
         <field name="groups_id" eval="[(4, ref('account_chatter.group_show_account_chatter_notifications'))]"/>
@@ -8,9 +10,11 @@
             <xpath expr="//sheet" position="after">
                 <div class="oe_chatter">
                     <field name="message_follower_ids"/>
+                    <field name="activity_ids"/>
                     <field name="message_ids"/>
                 </div>
             </xpath>
         </field>
     </record>
+
 </odoo>

--- a/account_chatter/views/account_journal_views.xml
+++ b/account_chatter/views/account_journal_views.xml
@@ -1,27 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="view_account_journal_form_inherit" model="ir.ui.view">
-        <field name="name">account.journal.form.inherit</field>
+
+    <record id="view_account_journal_form_show_chatter" model="ir.ui.view">
+        <field name="name">account.journal.form.inherit.account.chatter.show</field>
         <field name="model">account.journal</field>
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="groups_id" eval="[(4, ref('account_chatter.group_show_account_chatter_notifications'))]"/>
-        <field eval="100" name="priority"/>
+        <field name="priority" eval="100"/>
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="after">
                 <div class="oe_chatter">
                     <field name="message_follower_ids"/>
+                    <field name="activity_ids"/>
                     <field name="message_ids"/>
                 </div>
             </xpath>
         </field>
     </record>
+
     <record id="view_account_journal_form_inherit_hidden" model="ir.ui.view">
-        <field name="name">account.journal.form.inherit.hidden</field>
+        <field name="name">account.journal.form.inherit.account.chatter</field>
         <field name="model">account.journal</field>
         <field name="inherit_id" ref="account.view_account_journal_form"/>
-        <field eval="99" name="priority"/>
+        <field name="priority" eval="99"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_chatter')]" position="replace">
             </xpath>
         </field>
     </record>
+
 </odoo>

--- a/account_chatter/views/account_move_views.xml
+++ b/account_chatter/views/account_move_views.xml
@@ -1,27 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="view_move_form_inherit" model="ir.ui.view">
-        <field name="name">account.move.form.inherit</field>
+
+    <record id="view_move_form_show_chatter" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.account.chatter.show</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="groups_id" eval="[(4, ref('account_chatter.group_show_account_chatter_notifications'))]"/>
-        <field eval="100" name="priority"/>
+        <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <xpath expr="//sheet" position="after">
+            <xpath expr="//div[hasclass('o_attachment_preview')]" position="after">
                 <div class="oe_chatter">
                     <field name="message_follower_ids"/>
+                    <field name="activity_ids"/>
                     <field name="message_ids"/>
                 </div>
             </xpath>
         </field>
     </record>
+
     <record id="view_move_form_inherit_hidden" model="ir.ui.view">
-        <field name="name">account.move.form.inherit.hidden</field>
+        <field name="name">account.move.form.inherit.account.chatter</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
-        <field eval="99" name="priority"/>
+        <field name="priority" eval="99"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('oe_chatter')]" position="replace">
-            </xpath>
+            <xpath expr="//div[hasclass('oe_chatter')]" position="replace"/>
         </field>
     </record>
+
 </odoo>


### PR DESCRIPTION
To be able to show chatter only to certain users, we:
- Hide chatter for everywhere by removing it
- Re-introduce it only for the specific group

However, the new chatter is missing the activity widget, which was
already present on the removed one.

This atts missing activity widget to journal and journal entries, and
improve accounts by adding it also there.

In addition, journal entry's chatter was being placed on  a wrong
position, before attachments preview instead of after it.

Forward-port of #1544