### PR TITLE
[FIX] addons-vauxoo: Added PoSBlindClose module task#57812

### DIFF
--- a/pos_blind_close/__init__.py
+++ b/pos_blind_close/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2021 Vauxoo
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+from . import models

--- a/pos_blind_close/__manifest__.py
+++ b/pos_blind_close/__manifest__.py
@@ -1,0 +1,32 @@
+# Copyright 2021 Vauxoo
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+{
+    'name': 'Point of Sale Blind Close',
+    'summary': '''
+    ''',
+    'author': 'Vauxoo',
+    'website': 'https://www.vauxoo.com',
+    'license': 'LGPL-3',
+    'category': 'Installer',
+    'version': '15.0.1.0.0',
+    'depends': [
+        'point_of_sale',
+    ],
+    'data': [
+        'views/pos_config_views.xml',
+    ],
+    'assets': {
+        'point_of_sale.assets': [
+            'pos_blind_close/static/src/pos/js/**/*',
+        ],
+        'web.assets_qweb': [
+            'pos_blind_close/static/src/pos/xml/**/*',
+        ],
+        'web.assets_tests': [
+            'pos_blind_close/static/src/pos/tests/tours/**/*',
+        ],
+    },
+    'installable': True,
+    'auto_install': False,
+    'application': True,
+}

--- a/pos_blind_close/models/__init__.py
+++ b/pos_blind_close/models/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2021 Vauxoo
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+from . import pos_config

--- a/pos_blind_close/models/pos_config.py
+++ b/pos_blind_close/models/pos_config.py
@@ -1,0 +1,10 @@
+
+from odoo import fields, models, api, _
+
+
+class PosConfig(models.Model):
+    _inherit = "pos.config"
+
+    hide_totals_at_closing_session = fields.Boolean(help="""If this field is checked, the totals are going to be
+ hidden in the closing control pop up, when closing a session. Also, the check box for "Accept payments
+ difference and post a profit/loss journal entry" will be automatically hidden and checked.""")

--- a/pos_blind_close/static/src/pos/js/ClosePosPopup.js
+++ b/pos_blind_close/static/src/pos/js/ClosePosPopup.js
@@ -1,0 +1,52 @@
+/**
+ * Refers to vauxoo task#57812 to more information.
+ */
+odoo.define('villagroup.ClosePosPopup', require => {
+    const ClosePosPopup = require('point_of_sale.ClosePosPopup');
+    const Registries = require('point_of_sale.Registries');
+
+    const ClosePosPopupInherit = _ClosePosPopup => class ClosePosPopup extends _ClosePosPopup {
+        /**
+         * Extended to always allow the user to end the session (even if there are differences in the totals
+         * payment and the money cashed).
+         * 
+         * The above only happens when the field `hide_totals_at_closing_session` is checked in the configurations
+         * of this PoS.
+         */
+        canCloseSession () {
+            return this.env.pos.config.hide_totals_at_closing_session || super.canCloseSession.call(this);
+        }
+        /**
+         * Extended because the initial setUp of this component sets the `acceptClosing` state to False.
+         * We need to set it to the value within the field `hide_totals_at_closing_session` in the configs.
+         *
+         * We also want to set all the input for entering the counted cash/money to zero.
+         */
+        async willStart() {
+            const res = await super.willStart.call(this);
+            if (this.state.acceptClosing = this.env.pos.config.hide_totals_at_closing_session)
+                Object.values(this.state.payments).forEach(paymentInfo => paymentInfo.counted = 0);
+            return res;
+        }
+        /**
+         * Extended because the original method, sets the state acceptClosing to False after its execution.
+         * We need to set it to the value within the field `hide_totals_at_closing_session` in the configs.
+         */
+        handleInputChange () {
+            const res = super.handleInputChange.apply(this, arguments);
+            this.state.acceptClosing = this.env.pos.config.hide_totals_at_closing_session;
+            return res;
+        }
+        /**
+         * Extended because the original method, sets the state acceptClosing to False after its execution.
+         * We need to set it to the value within the field `hide_totals_at_closing_session` in the configs.
+         */
+        updateCountedCash () {
+            const res = super.updateCountedCash.apply(this, arguments);
+            this.state.acceptClosing = this.env.pos.config.hide_totals_at_closing_session;
+            return res;
+        }
+    };
+    
+    Registries.Component.extend(ClosePosPopup, ClosePosPopupInherit);
+});

--- a/pos_blind_close/static/src/pos/tests/tours/TipScreen.tour.js
+++ b/pos_blind_close/static/src/pos/tests/tours/TipScreen.tour.js
@@ -1,0 +1,14 @@
+odoo.define('pos_blind_close.tour.ClosePosPopup', require => {
+    const { ClosePosPopup } = require('pos_blind_close.helpers.ClosePosPopup');
+    const { ProductScreen } = require('point_of_sale.tour.ProductScreenTourMethods');
+    const { getSteps, startSteps } = require('point_of_sale.tour.utils');
+    const Tour = require('web_tour.tour');
+
+    startSteps();
+    ProductScreen.do.confirmOpeningPopup();
+    ClosePosPopup.do.ClosePosButton();
+    ClosePosPopup.check.RemovedExpectedAndDifferenceHeaders();
+    ClosePosPopup.check.RemovedExpectedAndDifferenceValues();
+
+    Tour.register('pos_blind_close_ClosePosPopup', { test: true, url: '/pos/ui' }, getSteps());
+});

--- a/pos_blind_close/static/src/pos/tests/tours/helpers/TipScreenTourMethods.js
+++ b/pos_blind_close/static/src/pos/tests/tours/helpers/TipScreenTourMethods.js
@@ -1,0 +1,52 @@
+odoo.define('pos_blind_close.helpers.ClosePosPopup', require => {
+    const { createTourMethods } = require('point_of_sale.tour.utils');
+
+    class Do {
+        ClosePosButton () {
+            return [
+                {
+                    content: "close the Point of Sale frontend",
+                    trigger: ".status-buttons .header-button",
+                }
+            ];
+        }
+    }
+
+    class Check {
+        RemovedExpectedAndDifferenceHeaders () {
+            return [
+                {
+                    content: "Check the 'Expected' and 'Diference' header are gone",
+                    trigger: ".modal-dialog .payment-methods-overview",
+                    run () {
+                        const $headers = $('.payment-methods-overview table thead tr');
+                        if ($headers.find(':contains(Expected)').length) console.error('Expected header found!')
+                        if ($headers.find(':contains(Difference)').length) console.error('Difference header found!')
+                    }
+                }
+            ];
+        }
+        RemovedExpectedAndDifferenceValues () {
+            return [
+                {
+                    content: "Check the 'Expected' and 'Diference' values are gone",
+                    trigger: ".modal-dialog .payment-methods-overview",
+                    run () {
+                        // Each row of this line is gonna be a line of values.
+                        // [0] Name of the payment method
+                        // [1] Expected ammount
+                        // [2] Input to enter amounts
+                        // [3] The difference of inputed amounts
+                        $('.payment-methods-overview table tbody tr').each(function () {
+                            const $children = $(this).children();
+                            if ($children.length > 2) 
+                               console.error(`Unexpected value found in ${$children.eq(0)}`)
+                        })
+                    }
+                }
+            ];
+        }
+    }
+
+    return createTourMethods('ClosePosPopup', Do, Check);
+});

--- a/pos_blind_close/static/src/pos/xml/ClosePosPopup.xml
+++ b/pos_blind_close/static/src/pos/xml/ClosePosPopup.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <!--
+        Refers to vauxoo task#57812 to more information.
+    -->
+    <t t-name="ClosePosPopup" t-inherit="point_of_sale.ClosePosPopup" t-inherit-mode="extension" owl="1">
+        <!--
+            Hides the payments done with customer acounts. (Section 1 of requirements).
+        -->
+        <xpath expr="//div[hasclass('session-overview')]//div[hasclass('info-title')]/span[2]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('session-overview')]//div[hasclass('info-title')]/span[3]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('session-overview')]//div[hasclass('info-value')]/span[2]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('session-overview')]//div[hasclass('info-value')]/span[3]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <!--
+            Here we remove the headers for expected and differences
+        -->
+        <xpath expr="//div[hasclass('payment-methods-overview')]//thead//th[2]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('payment-methods-overview')]//thead//th[4]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <!--
+            Here we hide the total expected and differences of the payment methods that are cash.
+            (Section 2 of requirements).
+        -->
+        <xpath expr="//div[hasclass('payment-methods-overview')]/table/t/tbody[1]//td[2]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('payment-methods-overview')]/table/t/tbody[1]//td[last()]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('payment-methods-overview')]/table/t/tbody[2]/tr[1]/td[2]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('payment-methods-overview')]/table/t/tbody[2]/tr[2]/td[2]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('payment-methods-overview')]/table/t/tbody[2]/tr[3]/td[2]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        <!--
+            Here we hide the input, difference and total expected of the payment methods that are not cash.
+            (Section 2,3 and 4 of requirements).
+        <xpath expr="//div[hasclass('payment-methods-overview')]/table/tbody[last()]/tr/td[2]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+        -->
+        <xpath expr="//div[hasclass('payment-methods-overview')]/table/tbody[last()]/tr" position="replace">
+            <tr t-foreach="otherPaymentMethods" t-as="pm" t-key="pm.id">
+                <t t-set="_showDiff" t-value="_getShowDiff(pm)" />
+                <td t-esc="pm.name"/>
+                <t t-if="env.pos.config.hide_totals_at_closing_session">
+                    <td t-if="_showDiff" t-on-input="handleInputChange(pm.id)"><input class="pos-input" type="number" t-model.number="state.payments[pm.id].counted"/></td>
+                </t>
+                <t t-if="!env.pos.config.hide_totals_at_closing_session">
+                    <td t-esc="env.pos.format_currency(pm.amount)"/>
+                    <td t-if="_showDiff" t-on-input="handleInputChange(pm.id)"><input class="pos-input" type="number" t-model.number="state.payments[pm.id].counted"/></td>
+                    <td t-if="_showDiff" t-esc="env.pos.format_currency(state.payments[pm.id].difference)" t-att-class="{'warning': state.payments[pm.id].difference}"/>
+                </t>
+            </tr>
+        </xpath>
+        <!--
+            Here we hide the input, the "accept difference and total" checkbox.
+        -->
+        <xpath expr="//div[hasclass('accept-closing')]" position="attributes">
+            <attribute name="t-if">!env.pos.config.hide_totals_at_closing_session</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/pos_blind_close/tests/__init__.py
+++ b/pos_blind_close/tests/__init__.py
@@ -1,0 +1,2 @@
+
+from . import test_point_of_sale

--- a/pos_blind_close/tests/test_point_of_sale.py
+++ b/pos_blind_close/tests/test_point_of_sale.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestFrontend(odoo.tests.HttpCase):
+    def setUp(self):
+        super().setUp()
+        self.main_user = self.env.ref('base.user_admin')
+        self.env = self.env(user=self.main_user)
+        self.pos_config = self.env['pos.config'].create({
+            'name': 'Bar',
+            'hide_totals_at_closing_session': True,
+            'pricelist_id': self.env.ref('product.list0').id,
+        })
+        main_company = self.env.ref('base.main_company')
+        test_sale_journal = self.env['account.journal'].create({
+            'name': 'Sales Journal - Test',
+            'code': 'TSJ',
+            'type': 'sale',
+            'company_id': main_company.id
+        })
+        cash_journal = self.env['account.journal'].create({
+            'name': 'Cash Test',
+            'code': 'TCJ',
+            'type': 'cash',
+            'company_id': main_company.id
+        })
+        account_receivable = self.env['account.account'].create({
+            'code': 'X1012',
+            'name': 'Account Receivable - Test',
+            'user_type_id': self.env.ref('account.data_account_type_receivable').id,
+            'reconcile': True,
+        })
+        self.pos_config.write({
+            'journal_id': test_sale_journal.id,
+            'invoice_journal_id': test_sale_journal.id,
+            'payment_method_ids': [(0, 0, {
+                'name': 'Cash restaurant',
+                'split_transactions': True,
+                'receivable_account_id': account_receivable.id,
+                'journal_id': cash_journal.id,
+            })],
+        })
+
+    def test_01_pos_blind_closing(self):
+        self.pos_config.with_user(self.main_user).open_session_cb(check_coa=False)
+        self.start_tour(
+            '/pos/ui?config_id=%d' % self.pos_config.id,
+            'pos_blind_close_ClosePosPopup',
+            login='admin')

--- a/pos_blind_close/views/pos_config_views.xml
+++ b/pos_blind_close/views/pos_config_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="pos_config_view_form_inherit" model="ir.ui.view">
+        <field name="name">pos.config.form.inherit.villagroup</field>
+        <field name="model">pos.config</field>
+        <field name="priority">100</field>
+        <field name="inherit_id" ref="point_of_sale.pos_config_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='payment_methods_new']/.." position="inside">
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="hide_totals_at_closing_session" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <span class="o_form_label">Hide totals at closing session</span>
+                        <p class="text-muted">If this field is checked, the totals are going to be
+hidden in the closing control pop up, when closing a session. Also, the check box for "Accept payments
+difference and post a profit/loss journal entry" will be automatically hidden and checked.</p>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
### Descripción:
El concepto de corte de caja ciego consiste en otorgar al cajero la posibilidad de realizar un cierre de caja, sin mostrar los totales por cada método de pago. Esto se hace por motivos de seguridad y de fiabilidad. De este modo el empleado no "busca" lo que tiene que haber en caja, sino que introduce lo que realmente cuenta.


### Diseño:
Añadir en pos.config un boolean en el apartado de Payments, para configurar el corte de caja con las siguientes características:

1. Ocultar de la vista
2. Ocultar de la vista
3. Por defecto se setea el valor obtenido en bancos, por defecto setear en cero.
4. Ocultar de la vista
5. Se setea en TRUE y se oculta de la vista
6. Ocultar de la vista

![image](https://user-images.githubusercontent.com/34751857/177206912-69417415-4306-4a09-ac19-2f5527b080f5.png)




