### PR TITLE
[FIX] search_action_domain: Make installable with base_automation T#59176

### DIFF
--- a/search_action_domain/models/__init__.py
+++ b/search_action_domain/models/__init__.py
@@ -1,2 +1,3 @@
 from . import ir_actions_server
+from . import ir_ui_view
 from . import models

--- a/search_action_domain/models/ir_ui_view.py
+++ b/search_action_domain/models/ir_ui_view.py
@@ -1,0 +1,18 @@
+from odoo import models
+
+
+class IrUiView(models.Model):
+    _inherit = "ir.ui.view"
+
+    def _validate_tag_button(self, node, name_manager, node_info):
+        """At the moment to install search_action_domain with base_automation, an error
+        appears to indicate the created button is not a valid action for base.automation.
+        This fix avoid the validation for the created button if base_automation
+        installation is in process.
+        """
+        if (
+            name_manager.model._name == "base.automation"
+            and node.get("name") == "create_as_ir_filter"
+        ):
+            node_info.update({"validate": 0})
+        return super()._validate_tag_button(node, name_manager, node_info)

--- a/search_action_domain/views/ir_actions_server_views.xml
+++ b/search_action_domain/views/ir_actions_server_views.xml
@@ -5,11 +5,13 @@
         <field name="inherit_id" ref="base.view_server_action_form"/>
         <field name="arch" type="xml">
             <header position="inside">
+                <field name="usage" invisible="True"/>
                 <button 
                     name="create_as_ir_filter"
                     string="Create As Filter"
                     type="object"
                     class="btn-primary"
+                    attrs="{'invisible': [('usage', '=', 'base_automation')]}"
                     help="Display a filter in the 'Favorites' section in the selected menu to apply the action."
                 />
             </header>


### PR DESCRIPTION
At the moment to install search_action_domain with base_automation appears
 an error. Error indicates 'create_as_ir_filter is not a valid action on
base.automation'. This fix avoid the validation for the buttons if
base automation is in process.