### PR TITLE
[FIX] product_cost_usd: inheritance errors related to the old view id t#53862

### DIFF
--- a/product_cost_usd/__manifest__.py
+++ b/product_cost_usd/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
 This module adds the field Cost in USD to the Product form.
     """,
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.0.2",
     "author": "Vauxoo",
     "category": "Sales/Sales",
     "website": "https://vauxoo.com",

--- a/product_cost_usd/migrations/11.0.1.0.2/pre-migration.py
+++ b/product_cost_usd/migrations/11.0.1.0.2/pre-migration.py
@@ -1,0 +1,13 @@
+def delete_inherited_views(cr):
+    cr.execute("""
+        DELETE FROM ir_ui_view AS iuv
+        USING ir_model_data AS imd
+        WHERE iuv.inherit_id=imd.res_id
+        AND imd.name='view_product_template_tann_inhrt'
+        AND imd.module='product_cost_usd'
+        AND imd.model='ir.ui.view'
+        """)
+
+
+def migrate(cr, version):
+    delete_inherited_views(cr)


### PR DESCRIPTION
## This PR refers to the task[#53862](https://www.vauxoo.com/web#action=1928&cids=1&id=53862&menu_id=1490&model=project.task&view_type=form)

- add pre-migration in order to remove fix errors on inherited views of_product_template_tann_inhrt view