### PR TITLE
[FIX] account_multicompany_code: Use of @class

### DIFF
--- a/account_multicompany_code/views/res_company_views.xml
+++ b/account_multicompany_code/views/res_company_views.xml
@@ -31,7 +31,7 @@
             <xpath expr="//kanban/field[@name='name']" position="after">
                 <field name="code" />
             </xpath>
-            <xpath expr="//i[@class='fa fa-building']" position="after">
+            <xpath expr="//i[hasclass('fa', 'fa-building')" position="after">
                 <strong t-if="record.code.value"><field name="code" /> - </strong>
             </xpath>
         </field>


### PR DESCRIPTION
Removing the use of the `@class` in the view, since is deprecated and is giving warnings.