### PR TITLE
[FIX] default_warehouse_from_sale_team: xpath dependency on flaky element

### DIFF
--- a/default_warehouse_from_sale_team/views/crm_team_views.xml
+++ b/default_warehouse_from_sale_team/views/crm_team_views.xml
@@ -5,6 +5,7 @@
         <field name="name">crm.team.form.inherit.default.warehouse</field>
         <field name="model">crm.team</field>
         <field name="inherit_id" ref="sales_team.crm_team_view_form"/>
+        <field name="priority">14</field>
         <field name="arch" type="xml">
             <xpath expr="//page[@name='members']" position="after">
                 <page string="Warehouse settings for the sales team">


### PR DESCRIPTION
This commit fixes an xpath expression that relies on a `page` element that can later be removed by the enterprise module `website_crm_score`. When trying to add the previous module as a dependency for another module, it would prevent this module from loading with an "xpath not found" error.