### PR TITLE
[IMP] ci: support test-oca_dependencies.txt file T#53882

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
           source ${REPO_REQUIREMENTS}/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/activate
           source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
           source /usr/local/rvm/scripts/rvm
+          cp test-oca_dependencies.txt oca_dependencies.txt
           travis_install_nightly
           travis_run_tests
           travis_after_tests_success || true


### PR DESCRIPTION
This is done here instead of on MQT because that's an archived project and vxci is not ready to work with GitHub yet.