### PR TITLE
[IMP] .travis.yml: support test-oca_dependencies.txt also in Runbot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
   - source ${TRAVIS_BUILD_DIR}/variables.sh
   - git clone --single-branch --depth=1 https://github.com/vauxoo/maintainer-quality-tools.git -b master ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
+  - cp test-oca_dependencies.txt oca_dependencies.txt   
   - travis_install_nightly
 
 script:


### PR DESCRIPTION
Previous commit added support for it in tests, but Runbot was missing.