### PR TITLE
[REF] pr_line_related_po_line: General module cleanup T#66089

### DIFF
--- a/pr_line_related_po_line/README.rst
+++ b/pr_line_related_po_line/README.rst
@@ -1,9 +1,5 @@
 PR Line related PO Line
 =======================
 
-Add purchase_requisition_line_id field, it is id of purchase requisition line from where purchase
-order line is created, overwrite  the make_purchase_order method for add value of
-purchase_requisition_line_id to record purchase order line, it is help to make best inherit and
-modification of make_purchase_order method, as can be seen in
-purchase_requisition_line_description, purchase_requisition_line_analytic and
-purchase_requisition_requisitor modules.
+This module adds a new field to purchase order lines to link them to the requisition lines from which the purchase
+order is created. It also links the related purchase requisition line to a purchase order line when one is created

--- a/pr_line_related_po_line/models/purchase_order_line.py
+++ b/pr_line_related_po_line/models/purchase_order_line.py
@@ -2,7 +2,6 @@ from odoo import fields, models
 
 
 class PurchaseOrderLine(models.Model):
-
     _inherit = "purchase.order.line"
 
     purchase_requisition_line_id = fields.Many2one("purchase.requisition.line")

--- a/pr_line_related_po_line/models/purchase_requisition_line.py
+++ b/pr_line_related_po_line/models/purchase_requisition_line.py
@@ -9,7 +9,7 @@ class PurchaseRequisitionLine(models.Model):
     )
 
     def _prepare_purchase_order_line(self, name, product_qty=0.0, price_unit=0.0, taxes_ids=False):
-        """Inherit method to add the relation between the purchase order line that is being created from the
+        """Inherited method to add the relation between the purchase order line that is being created from the
         requisition and the purchase requisition line.
         """
         res = super()._prepare_purchase_order_line(name, product_qty, price_unit, taxes_ids)

--- a/pr_line_related_po_line/static/description/index.html
+++ b/pr_line_related_po_line/static/description/index.html
@@ -9,12 +9,8 @@
    PR Line related PO Line
   </h2>
   <p class="oe_mt32">
-   Add purchase_requisition_line_id field, it is id of purchase requisition line from where purchase
-order line is created, overwrite  the make_purchase_order method for add value of
-purchase_requisition_line_id to record purchase order line, it is help to make best inherit and
-modification of make_purchase_order method, as can be seen in
-purchase_requisition_line_description, purchase_requisition_line_analytic and
-purchase_requisition_requisitor modules.
+    This module adds a new field to purchase order lines to link them to the requisition lines from which the purchase 
+    order is created. It also links the related purchase requisition line to a purchase order line when one is created
   </p>
  </div>
 </section>

--- a/pr_line_related_po_line/views/purchase_order_views.xml
+++ b/pr_line_related_po_line/views/purchase_order_views.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
-    <record model="ir.ui.view" id="purchase_order_form">
+    <record id="purchase_order_form" model="ir.ui.view">
         <field name="name">purchase.order.prl.related.pol.inherit.form</field>
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.purchase_order_form" />


### PR DESCRIPTION
- In purchase_order_views model attribute was set after id
- In the same view encoding was added to the header