### PR TITLE
[FIX] product_cost_usd: Show standard_price_usd field as USD T#71674

### DIFF
--- a/product_cost_usd/__manifest__.py
+++ b/product_cost_usd/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """
 This module adds the field Cost in USD to the Product form.
     """,
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.0.1",
     "author": "Vauxoo",
     "category": "Sales/Sales",
     "website": "https://vauxoo.com",
@@ -15,6 +15,7 @@ This module adds the field Cost in USD to the Product form.
         "demo/product_pricelist_demo.xml",
     ],
     "data": [
+        "data/res_currency_data.xml",
         "views/product_template_views.xml",
     ],
     "installable": True,

--- a/product_cost_usd/data/res_currency_data.xml
+++ b/product_cost_usd/data/res_currency_data.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="base.USD" model="res.currency">
+        <field name="active" eval="True" />
+    </record>
+</odoo>

--- a/product_cost_usd/i18n/es.po
+++ b/product_cost_usd/i18n/es.po
@@ -41,6 +41,12 @@ msgid "Cost in USD"
 msgstr "Costo en USD"
 
 #. module: product_cost_usd
+#: model:ir.model.fields,field_description:product_cost_usd.field_product_product__currency_usd_id
+#: model:ir.model.fields,field_description:product_cost_usd.field_product_template__currency_usd_id
+msgid "Currency USD"
+msgstr "Moneda USD"
+
+#. module: product_cost_usd
 #: model:ir.model.fields,help:product_cost_usd.field_product_product__standard_price_usd
 #: model:ir.model.fields,help:product_cost_usd.field_product_template__standard_price_usd
 msgid "Price cost of the product in USD currency"
@@ -70,6 +76,13 @@ msgstr "Plantilla de producto"
 #: model:ir.model,name:product_cost_usd.model_sale_order_line
 msgid "Sales Order Line"
 msgstr "Línea de pedido de venta"
+
+#. module: product_cost_usd
+#: model:ir.model.fields,help:product_cost_usd.field_product_product__currency_usd_id
+#: model:ir.model.fields,help:product_cost_usd.field_product_template__currency_usd_id
+msgid "Technical field to show the price fields as USD in the products"
+msgstr ""
+"Campo técnico para mostrar los campos de precio como USD en los productos"
 
 #. module: product_cost_usd
 #: code:addons/product_cost_usd/models/product_template.py:0

--- a/product_cost_usd/models/product_template.py
+++ b/product_cost_usd/models/product_template.py
@@ -6,9 +6,22 @@ from odoo.tools import float_compare
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    standard_price_usd = fields.Float(
-        "Cost in USD", digits="Product Price", help="Price cost of the product in USD currency"
+    currency_usd_id = fields.Many2one(
+        "res.currency",
+        string="Currency USD",
+        compute="_compute_currency_usd_id",
+        help="Technical field to show the price fields as USD in the products",
     )
+    standard_price_usd = fields.Float(
+        "Cost in USD",
+        digits="Product Price",
+        help="Price cost of the product in USD currency",
+    )
+
+    def _compute_currency_usd_id(self):
+        currency_usd = self.env.ref("base.USD")
+        for product in self:
+            product.currency_usd_id = currency_usd
 
     @api.constrains("standard_price_usd", "seller_ids")
     def check_cost_and_price(self):

--- a/product_cost_usd/views/product_template_views.xml
+++ b/product_cost_usd/views/product_template_views.xml
@@ -6,7 +6,12 @@
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//div[@name='pricing']" position="after">
-                <field name="standard_price_usd" widget="monetary" />
+                <field name="currency_usd_id" invisible="1" />
+                <field
+                    name="standard_price_usd"
+                    widget="monetary"
+                    options="{'currency_field': 'currency_usd_id', 'field_digits': True}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
When the currency of the company is different to USD, the field is shown with the currency of the company instead of USD, the field is set to be shown as USD.