### PR TITLE
[IMP] stock_by_warehouse_*: Make warehouses_stock visible for storable products T#71799

### DIFF
--- a/stock_by_warehouse/views/product_product_views.xml
+++ b/stock_by_warehouse/views/product_product_views.xml
@@ -7,13 +7,19 @@
         <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='default_code']" position="before">
-                <field name="warehouses_stock" widget="warehouse" groups="stock.group_stock_multi_warehouses" />
+                <field
+                    name="warehouses_stock"
+                    widget="warehouse"
+                    groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
+                />
                 <field
                     name="warehouses_stock_location"
                     widget="warehouse"
                     options='{"by_location": True}'
                     colspan="1"
                     groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
                 />
                 <field
                     name="warehouses_stock_recompute"
@@ -21,6 +27,7 @@
                     colspan="1"
                     widget="toggle_button"
                     groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
                 />
             </xpath>
         </field>

--- a/stock_by_warehouse/views/product_template_views.xml
+++ b/stock_by_warehouse/views/product_template_views.xml
@@ -12,6 +12,7 @@
                     colspan="1"
                     widget="warehouse"
                     groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
                 />
                 <field
                     name="warehouses_stock_recompute"
@@ -19,6 +20,7 @@
                     colspan="1"
                     widget="toggle_button"
                     groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
                 />
             </xpath>
         </field>

--- a/stock_by_warehouse_mrp_bom/models/mrp_bom.py
+++ b/stock_by_warehouse_mrp_bom/models/mrp_bom.py
@@ -7,6 +7,7 @@ class MrpBomLine(models.Model):
     warehouses_stock = fields.Text(store=False, readonly=True)
     warehouse_id = fields.Many2one(string="Warehouse", related="bom_id.picking_type_id.warehouse_id")
     warehouses_stock_recompute = fields.Boolean(store=False, readonly=False)
+    detailed_type = fields.Selection(related="product_id.detailed_type")
 
     def _compute_get_warehouses_stock(self):
         for line in self:

--- a/stock_by_warehouse_mrp_bom/views/mrp_bom_line_views.xml
+++ b/stock_by_warehouse_mrp_bom/views/mrp_bom_line_views.xml
@@ -7,7 +7,12 @@
         <field name="inherit_id" ref="mrp.mrp_bom_line_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//form/sheet/group" position="before">
-                <div class="text-center alert alert-info" role="alert">
+                <field name="detailed_type" invisible="1" />
+                <div
+                    class="text-center alert alert-info"
+                    role="alert"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
+                >
                     <p>The stock <span attrs="{'invisible':[('warehouse_id','=',False)]}">in: <field
                                 name="warehouse_id"
                             /></span> that is immediately available is:

--- a/stock_by_warehouse_sale/views/sale_order_views.xml
+++ b/stock_by_warehouse_sale/views/sale_order_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='order_line']/form//field[@name='sequence']" position="after">
-                <div class="text-center alert alertdialog">
+                <div class="text-center alert alertdialog" attrs="{'invisible': [('product_type', '!=', 'product')]}">
                     <p>The saleable stock in: <field name="warehouse_id" /> that can be delivered immediately is:
                         <field
                             name="warehouses_stock"


### PR DESCRIPTION
This functionality is for storable products to show the information in
the warehouses, now this field is invisible for products which are not
storable products.