### PR TITLE
[IMP] stock_by_warehouse_*: Make warehouses_stock visible for storable products T#71799

### DIFF
--- a/stock_by_warehouse/views/product_product_views.xml
+++ b/stock_by_warehouse/views/product_product_views.xml
@@ -7,9 +7,23 @@
         <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='default_code']" position="before">
-                <field name="warehouses_stock" widget="warehouse" groups="stock.group_stock_multi_warehouses" />
-                <label for="warehouses_stock_location" groups="stock.group_stock_multi_warehouses" />
-                <div name="location_widget" class="d-flex" groups="stock.group_stock_multi_warehouses">
+                <field
+                    name="warehouses_stock"
+                    widget="warehouse"
+                    groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
+                />
+                <label
+                    for="warehouses_stock_location"
+                    groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
+                />
+                <div
+                    name="location_widget"
+                    class="d-flex"
+                    groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
+                >
                     <field name="warehouses_stock_location" widget="warehouse" options='{"by_location": True}' />
                     <field name="warehouses_stock_recompute" widget="boolean_toggle" />
                 </div>

--- a/stock_by_warehouse/views/product_template_views.xml
+++ b/stock_by_warehouse/views/product_template_views.xml
@@ -7,8 +7,17 @@
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='default_code']" position="before">
-                <label for="warehouses_stock" groups="stock.group_stock_multi_warehouses" />
-                <div name="warehouse_widget" class="d-flex" groups="stock.group_stock_multi_warehouses">
+                <label
+                    for="warehouses_stock"
+                    groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
+                />
+                <div
+                    name="warehouse_widget"
+                    class="d-flex"
+                    groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('detailed_type', '!=', 'product')]}"
+                >
                     <field name="warehouses_stock" widget="warehouse" />
                     <field name="warehouses_stock_recompute" widget="boolean_toggle" />
                 </div>

--- a/stock_by_warehouse_purchase/views/purchase_order_views.xml
+++ b/stock_by_warehouse_purchase/views/purchase_order_views.xml
@@ -7,7 +7,13 @@
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='order_line']/form//field[@name='state']" position="after">
-                <div class="text-center alert alert-info" role="alert" groups="stock.group_stock_multi_warehouses">
+                <field name="product_type" invisible="1" />
+                <div
+                    class="text-center alert alert-info"
+                    role="alert"
+                    groups="stock.group_stock_multi_warehouses"
+                    attrs="{'invisible': [('product_type', '!=', 'product')]}"
+                >
                     <p>The stock in: <field name="warehouse_id" /> that is immediately available is:
                         <field name="warehouses_stock" widget="warehouse" options="{'placement': 'bottom'}" />
                         &amp;nbsp;&amp;nbsp;

--- a/stock_by_warehouse_sale/views/sale_order_views.xml
+++ b/stock_by_warehouse_sale/views/sale_order_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='order_line']/form//field[@name='sequence']" position="after">
-                <div class="text-center alert alertdialog" groups="stock.group_stock_multi_warehouses">
+                <div class="text-center alert alertdialog" attrs="{'invisible': [('product_type', '!=', 'product')]}">
                     <p>The saleable stock in: <field name="warehouse_id" /> that can be delivered immediately is:
                         <field name="warehouses_stock" widget="warehouse" options="{'placement': 'bottom'}" />
                         &amp;nbsp;&amp;nbsp;


### PR DESCRIPTION
This functionality is for storable products to show the information in
the warehouses, now this field is invisible for products which are not
storable products.