### PR TITLE
[FIX] default_warehouse_from_sale_team: Avoid return the same record at create

### DIFF
--- a/default_warehouse_from_sale_team/models/default_warehouse_mixin.py
+++ b/default_warehouse_from_sale_team/models/default_warehouse_mixin.py
@@ -43,12 +43,12 @@ class DefaultWarehouseMixin(models.AbstractModel):
         """Pass sales team by context so it's taken into account when computing sequence name"""
         if not vals_list:
             return super().create(vals_list)
-        default_obj = self
+        result = self.browse()
         salesteams = self._get_salesteam_from_vals_list(vals_list)
         for salesteam, salesteam_vals_list in salesteams.items():
             self = self.with_context(sequence_salesteam_id=salesteam.id)
-            default_obj |= super().create(salesteam_vals_list)
-        return default_obj
+            result |= super().create(salesteam_vals_list)
+        return result
 
     def _get_salesteam_from_vals(self, vals):
         """Determine sales team from creation values"""


### PR DESCRIPTION
The self in the method create inheritance could be not empty, for example, using a recordset.copy(), in that case the self is not empty.

Using the self.browse(), we will ensure that the self is empty, and the split create calls are made as expected.