### PR TITLE
16.0 - [I18n] *: autoformat translations T#61194

### DIFF
--- a/default_warehouse_from_sale_team/i18n/es.po
+++ b/default_warehouse_from_sale_team/i18n/es.po
@@ -42,8 +42,8 @@ msgid ""
 "            View only the transfers which warehouses match with the user sales teams default warehouses\n"
 "        "
 msgstr ""
-"Ver solamente las transferencias que corresponden con el almacén por defecto "
-"de los equipos de venta del usuario"
+"Ver solamente las transferencias que corresponden con el almacén por defecto"
+" de los equipos de venta del usuario"
 
 #. module: default_warehouse_from_sale_team
 #: model:res.groups,name:default_warehouse_from_sale_team.group_manager_default_journal

--- a/pr_line_related_po_line/i18n/sl.po
+++ b/pr_line_related_po_line/i18n/sl.po
@@ -10,11 +10,11 @@ msgstr ""
 "PO-Revision-Date: 2015-08-11 10:44+0200\n"
 "Last-Translator: Matjaz Mozetic <m.mozetic@matmoz.si>\n"
 "Language-Team: \n"
+"Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"Language: sl\n"
 "X-Generator: Poedit 1.8.2\n"
 
 #. module: pr_line_related_po_line

--- a/stock_custom_exchange_rate_date/i18n/es.po
+++ b/stock_custom_exchange_rate_date/i18n/es.po
@@ -40,4 +40,3 @@ msgstr "Movimiento de existencias"
 #: model:ir.model,name:stock_custom_exchange_rate_date.model_stock_picking
 msgid "Transfer"
 msgstr "Transferencia"
-


### PR DESCRIPTION
This runs the translations autoformatter [1], which performs the
following changes over .po files:
- Sort terms alphabetically
- Split lines to 78 characters
- clear message when translated term is the same as original one

This is done to produce a file as if it were re-exported from Odoo. For
more info, see [2].

[1] https://github.com/OCA/odoo-pre-commit-hooks/pull/76  
[2] https://github.com/Vauxoo/pre-commit-vauxoo/issues/104