### PR TITLE
15.0 - [I18n] *: autoformat translations T#61194

### DIFF
--- a/default_warehouse_from_sale_team/i18n/es.po
+++ b/default_warehouse_from_sale_team/i18n/es.po
@@ -210,8 +210,11 @@ msgstr "Equipo de ventas"
 #. module: default_warehouse_from_sale_team
 #: model:ir.model.fields,help:default_warehouse_from_sale_team.field_res_users__sale_team_ids
 msgid ""
-"Sales teams allowed for the user, to give access to warehouses and their related documents."
-msgstr "Equipos de venta permitidos para el usuario, para dar acceso a almacenes y sus documentos relacionados."
+"Sales teams allowed for the user, to give access to warehouses and their "
+"related documents."
+msgstr ""
+"Equipos de venta permitidos para el usuario, para dar acceso a almacenes y "
+"sus documentos relacionados."
 
 #. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_ir_sequence
@@ -233,7 +236,9 @@ msgstr "Movimiento de existencias"
 #: code:addons/default_warehouse_from_sale_team/models/res_users.py:0
 #, python-format
 msgid "The chosen team (%s) is not in the allowed sales teams for this user"
-msgstr "El equipo de venta seleccionado (%s) no está entre los equipos permitidos para este usuario"
+msgstr ""
+"El equipo de venta seleccionado (%s) no está entre los equipos permitidos "
+"para este usuario"
 
 #. module: default_warehouse_from_sale_team
 #: model:ir.model,name:default_warehouse_from_sale_team.model_stock_picking

--- a/stock_by_warehouse_sale/i18n/es.po
+++ b/stock_by_warehouse_sale/i18n/es.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* stock_by_warehouse_sale
+# * stock_by_warehouse_sale
 #
 msgid ""
 msgstr ""
@@ -34,4 +34,3 @@ msgstr "Almacenes de existencia"
 #: model_terms:ir.ui.view,arch_db:stock_by_warehouse_sale.sale_order_form_view
 msgid "that can be delivered immediately is:"
 msgstr "que puede ser enviada inmediatamente es:"
-


### PR DESCRIPTION
This runs the translations autoformatter [1], which performs the
following changes over .po files:
- Sort terms alphabetically
- Split lines to 78 characters
- clear message when translated term is the same as original one

This is done to produce a file as if it were re-exported from Odoo. For
more info, see [2].

[1] https://github.com/OCA/odoo-pre-commit-hooks/pull/76  
[2] https://github.com/Vauxoo/pre-commit-vauxoo/issues/104