### PR TITLE
[FIX] account_chatter: Account move narration field is html field no text I#22876

### DIFF
--- a/account_chatter/models/account_move.py
+++ b/account_chatter/models/account_move.py
@@ -6,5 +6,4 @@ class AccountMove(models.Model):
 
     date = fields.Date(tracking=True)
     journal_id = fields.Many2one(tracking=True)
-    narration = fields.Text(tracking=True)
     reversed_entry_id = fields.Many2one(tracking=True)


### PR DESCRIPTION
This module reassigns the narration field type, from html to text, that
was wrong because when the field being refereced from a related field
following error appears

	TypeError: Type of related field bank.rec.widget.st_line_narration is
	inconsistent with account.move.narration

So we remove the field inheritance, because the only reason this field
was inherited was to make it trackeable, which is not supported for
HTML fields.