### PR TITLE
[FIX] stock_manual_transfer: remove .unlink() method override

### DIFF
--- a/stock_manual_transfer/models/stock_manual_transfer.py
+++ b/stock_manual_transfer/models/stock_manual_transfer.py
@@ -88,7 +88,8 @@ class StockManualTransfer(models.Model):
         for record in self:
             record.picking_ids = record.procurement_group_id.picking_ids
 
-    def unlink(self):
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_state_valid(self):
         for record in self:
             if record.state == "valid":
                 raise ValidationError(


### PR DESCRIPTION
Due to upstream updates adding support for @api.ondelete and pre-commit-vauxoo detecting the override of .unlink() method as a code smell, this transforms the old logic into more idiomatic odoo code.