### PR TITLE
[FIX] stock_manual_transfer: super().unlink() was not removed in original commit

### DIFF
--- a/stock_manual_transfer/models/stock_manual_transfer.py
+++ b/stock_manual_transfer/models/stock_manual_transfer.py
@@ -98,7 +98,6 @@ class StockManualTransfer(models.Model):
                         record.name,
                     )
                 )
-        return super().unlink()
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION

While the original fix (https://github.com/Vauxoo/addons-vauxoo/commit/cbd70ffe5b6693e9ecd299e3c935a3dcfa4a0131) did fix the immediate lint messages, we didn't actually stop it from calling super().unlink(), thus it didn't actually fix what it intended to fix. Here we remove that call to super().unlink() so the issue is properly fixed.