### PR TITLE
[ADD] test-requirements.txt: Add cssutils dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+cssutils


### PR DESCRIPTION
Module controller_report_xls depends on python module cssutils. Adding it on test-requirements.txt prevents it from being recursively installed by instances that don't actually use the module.