### PR TITLE
[FIX] default_warehouse_from_sale_team: update default journal retrieval I#23845

### DIFF
--- a/default_warehouse_from_sale_team/models/account_move.py
+++ b/default_warehouse_from_sale_team/models/account_move.py
@@ -20,5 +20,5 @@ class AccountMove(models.Model):
             "default_move_type": self.move_type,
             "default_currency_id": self.currency_id.id,
         }
-        default_journal = self.with_context(**default_journal_ctx)._get_default_journal()
+        default_journal = self.with_context(**default_journal_ctx)._search_default_journal()
         self.journal_id = default_journal


### PR DESCRIPTION
Change the method previously used as a default value for the journal_id
to retrieve the default journal to the new method defined to search the
default journal.