### PR TITLE
[IMP] internal_transfer_with_agreed_amount: modify write vals in one method i#24002

### DIFF
--- a/internal_transfer_with_agreed_amount/wizards/internal_transfer_multicurrency.py
+++ b/internal_transfer_with_agreed_amount/wizards/internal_transfer_multicurrency.py
@@ -21,14 +21,18 @@ class InternalTransferMulticurrency(models.TransientModel):
         payment = self.env["account.payment"].browse(active_ids)
         return payment.destination_journal_id.currency_id or payment.company_currency_id
 
-    def _validate_currencies_in_internal_transfer(self, payment):
+    def _get_currencies(self, payment):
         payment_currency = payment.currency_id
         company_currency = payment.company_currency_id
         send_currency = payment.journal_id.currency_id or company_currency
         receive_currency = self.currency_id
         currencies = payment_currency | company_currency | send_currency | receive_currency
+        return currencies
+
+    def _validate_currencies_in_internal_transfer(self, payment):
+        currencies = self._get_currencies(payment)
         if len(currencies) == 2:
-            return currencies - payment_currency
+            return currencies - payment.currency_id
         raise ValidationError(
             _(
                 "Agreed amount is available when there are two considered currencies. "
@@ -37,12 +41,22 @@ class InternalTransferMulticurrency(models.TransientModel):
             )
         )
 
-    def _prepare_values_from_lines(self, lines, currency):
+    def _prepare_values_from_lines(self, lines, currency=None, is_same_company_currency=False):
         line = lines[0]
+        if is_same_company_currency:
+            return {"debit": self.agreed_amount} if line.debit > 0 else {"credit": self.agreed_amount}
         vals = {"debit": line.debit} if line.amount_currency > 0 else {"credit": line.credit}
         sign = 1 if line.amount_currency > 0 else -1
         vals.update({"amount_currency": sign * self.agreed_amount, "currency_id": currency.id})
         return vals
+
+    def _preprocess_payments_hooks(self, payment):
+        """This method is to be inherited in case pre-processing is required on the payments."""
+        return payment
+
+    def _postprocess_payments_hooks(self, payment):
+        """This method is to be inherited in case post-processing is required on the payments."""
+        return payment
 
     def apply(self):
         active_ids = self._context.get("active_ids")
@@ -58,14 +72,19 @@ class InternalTransferMulticurrency(models.TransientModel):
         to_reconcile = amls.filtered(
             lambda l: l.account_id == l.company_id.transfer_account_id
         ).full_reconcile_id.reconciled_line_ids
+        context = {"check_move_validity": False, "skip_account_move_synchronization": True}
         if exchange_currency == payment.company_currency_id:
             if len(amls) != 4:
                 return
             amls.move_id.button_draft()
+            self._preprocess_payments_hooks(payment)
             debit = amls.filtered(lambda x: x.debit > 0)
             credit = amls.filtered(lambda x: x.credit > 0)
-            debit.with_context(check_move_validity=False).write({"debit": self.agreed_amount})
-            credit.with_context(check_move_validity=False).write({"credit": self.agreed_amount})
+            vals = self._prepare_values_from_lines(debit, is_same_company_currency=True)
+            debit.with_context(**context).write(vals)
+            vals = self._prepare_values_from_lines(credit, is_same_company_currency=True)
+            credit.with_context(**context).write(vals)
+            self._postprocess_payments_hooks(payment)
             amls.move_id.action_post()
             to_reconcile.reconcile()
             return
@@ -74,10 +93,11 @@ class InternalTransferMulticurrency(models.TransientModel):
         if len(aml_positive) > 2 or len(aml_negative) > 2:
             return
         aml_positive.move_id.button_draft()
-        context = {"check_move_validity": False, "skip_account_move_synchronization": True}
+        self._preprocess_payments_hooks(payment)
         vals = self._prepare_values_from_lines(aml_positive, exchange_currency)
         aml_positive.with_context(**context).write(vals)
         vals = self._prepare_values_from_lines(aml_negative, exchange_currency)
         aml_negative.with_context(**context).write(vals)
+        self._postprocess_payments_hooks(payment)
         aml_positive.move_id.action_post()
         to_reconcile.reconcile()


### PR DESCRIPTION
Modify in a single method the values that will be written in the account
move lines so that the method can be inherited in case it is necessary
to modify more values in the lines.

In addition, two methods are added to pre and post process payments, to
be used if modifications are required in an inheritance.

Finally, obtaining currencies related to the internal transfer have been
moved to a separate method to facilitate the inheritance of the method
that validates the number of currencies.

Changelog:
- Set debit and credit values to write in _prepare_values_from_lines
  method when the exchange currency is the same as the company currency.
- Add methods to be inherited when payments also needs modifications.
- Get the currencies in a new method named _get_currencies.