### PR TITLE
[FIX] stock_by_warehouse: Improve stock information accuracy

### DIFF
--- a/stock_by_warehouse/models/product_template.py
+++ b/stock_by_warehouse/models/product_template.py
@@ -54,6 +54,7 @@ class ProductTemplate(models.Model):
                 .with_company(warehouse.company_id)
                 .with_context(warehouse=warehouse.id, location=False)
             )
+            tmpl.invalidate_recordset()
             if warehouse_id and warehouse_id.id == warehouse.id:
                 info["warehouse"] = tmpl.qty_available_not_res
             info["content"].append(


### PR DESCRIPTION
Issue reported on #1633

With the re-compute information the data it's shown as expected:
![image](https://github.com/Vauxoo/addons-vauxoo/assets/3640142/f7337e2a-3d8d-44fd-a17e-7773bdd36fbc)
