### PR TITLE
[FIX] controller_report_xls: Get Odoo Style

### DIFF
--- a/controller_report_xls/reports/report_xls.py
+++ b/controller_report_xls/reports/report_xls.py
@@ -33,7 +33,8 @@ def get_odoo_style(html, style, node):
                 styleclass = get_css_style(style_element.text, class_style)
                 style.update(dict(item.split(":") for item in text_adapt(styleclass).split(";") if item != ""))
     if node.attrib.get("style", False):
-        style.update(dict(item.split(":") for item in node.attrib.get("style").split(";") if item != ""))
+        style_nodes = [style_node.strip() for style_node in node.attrib.get("style").split(";") if style_node.strip()]
+        style.update(dict(item.split(":", 1) for item in style_nodes))
     return style
 
 

--- a/controller_report_xls/reports/xfstyle.py
+++ b/controller_report_xls/reports/xfstyle.py
@@ -291,8 +291,8 @@ def get_font_height(height):
         factor = 1.5
     elif height == "XX-LARGE":
         factor = 2
-    new_size = float(size * factor * 20)
-    return new_size
+    # NOTE: Rounding without decimals because the expected `height` needs to be an `integer` value
+    return round(size * factor * 20)
 
 
 def get_horizontal_align(halign, align):


### PR DESCRIPTION
**[FIX] controller_report_xls: Get Odoo Style**

When the node had a style like "background-color: #99CCFF; font-weight: bold;" the style that comes after the "; " (with the white-space after the ;) was not being found on the method `css2excel`.
That happened because the `get_odoo_style` returned the styles like: `{'background-color': '#99CCFF', ' font-weight': 'bold'}` and the `process_css` didn't find ' font-weight' in its keys.

<details><summary>Images</summary>

![image](https://github.com/Vauxoo/addons-vauxoo/assets/26889951/5c197d32-28a4-4ad9-9ad6-31d59e7ec9d4)
![image](https://github.com/Vauxoo/addons-vauxoo/assets/26889951/3dfb4573-7778-4f5c-b9bb-59f087d9b744)

</details> 

So now cleaning the values on the `get_odoo_style` by removing the whitespaces from the beginning and the end of the string, the method will now return `{'background-color': '#99CCFF', 'font-weight': 'bold'}` and the `process_css` will find 'font-weight' in its keys.

**[FIX] controller_report_xls: Font Height**

Before this change there was a traceback when a `font-size` was added:
```python
File "/usr/local/lib/python3.8/dist-packages/xlwt/BIFFRecords.py", line 725, in __init__
    self._rec_data = pack('<5H4B%ds' % uname_len, height, options, colour_index, weight, escapement,
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/instance/odoo/odoo/http.py", line 654, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/odoo/instance/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
struct.error: required argument is not an integer
```

That happened because the `height` expected for the fonts is an integer value and the `get_font_height` was returning `float` values, for example: "125.0", now we are rounding the new size to 0 decimals to return the closest integer for that size.


