### PR TITLE
[FIX] default_warehouse_from_sale_team: Fix case of searching a stock rule when there is no warehouse parameter

### DIFF
--- a/default_warehouse_from_sale_team/__manifest__.py
+++ b/default_warehouse_from_sale_team/__manifest__.py
@@ -8,7 +8,7 @@
     "website": "http://www.vauxoo.com",
     "license": "LGPL-3",
     "category": "Inventory/Inventory",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "depends": [
         "sale_stock",
         "purchase_requisition",

--- a/default_warehouse_from_sale_team/models/procurement_group.py
+++ b/default_warehouse_from_sale_team/models/procurement_group.py
@@ -7,6 +7,6 @@ class ProcurementGroup(models.Model):
     @api.model
     def _search_rule(self, route_ids, packaging_id, product_id, warehouse_id, domain):
         """Grant access to provided warehouse if it's not allowed to the current user"""
-        if warehouse_id._access_unallowed_current_user_salesteams():
+        if warehouse_id and warehouse_id._access_unallowed_current_user_salesteams():
             warehouse_id = warehouse_id.sudo()
         return super()._search_rule(route_ids, packaging_id, product_id, warehouse_id, domain)


### PR DESCRIPTION
Fix case of searching a stock rule when there is no warehouse parameter, like when is done by stock rules when the move destination location is for a different company https://github.com/Vauxoo/odoo/blob/8af8846c88bd04bcf3fa0bcbe4a720b415f994a4/addons/stock/models/stock_move.py#L830
 
This commit is a FW port of [this fix](https://github.com/Vauxoo/addons-vauxoo/pull/1645)