### PR TITLE
[FIX] default_warehouse_from_sale_team: Fix case of searching a stock…

### DIFF
--- a/default_warehouse_from_sale_team/models/procurement_group.py
+++ b/default_warehouse_from_sale_team/models/procurement_group.py
@@ -7,6 +7,6 @@ class ProcurementGroup(models.Model):
     @api.model
     def _search_rule(self, route_ids, packaging_id, product_id, warehouse_id, domain):
         """Grant access to provided warehouse if it's not allowed to the current user"""
-        if warehouse_id._access_unallowed_current_user_salesteams():
+        if warehouse_id and warehouse_id._access_unallowed_current_user_salesteams():
             warehouse_id = warehouse_id.sudo()
         return super()._search_rule(route_ids, packaging_id, product_id, warehouse_id, domain)


### PR DESCRIPTION
… rule when there is no warehouse parameter, like when is done by stock rules when the move destination location is for a different company https://github.com/Vauxoo/odoo/blob/8af8846c88bd04bcf3fa0bcbe4a720b415f994a4/addons/stock/models/stock_move.py#L830