### PR TITLE
[FIX] stock_by_warehouse: display stock by warehouse in widget T#79454

### DIFF
--- a/stock_by_warehouse/__manifest__.py
+++ b/stock_by_warehouse/__manifest__.py
@@ -21,7 +21,7 @@
         "web.assets_backend": [
             "stock_by_warehouse/static/src/components/warehouse/warehouse_field.scss",
             "stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml",
-            "stock_by_warehouse/static/src/components/warehouse/warehouse_field.js",
+            "stock_by_warehouse/static/src/components/warehouse/warehouse_field.esm.js",
         ],
     },
     "installable": True,

--- a/stock_by_warehouse/i18n/es.po
+++ b/stock_by_warehouse/i18n/es.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0+e\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-20 18:29+0000\n"
-"PO-Revision-Date: 2023-03-20 18:29+0000\n"
+"POT-Creation-Date: 2024-05-16 01:31+0000\n"
+"PO-Revision-Date: 2024-05-16 01:31+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"

--- a/stock_by_warehouse/static/src/components/warehouse/warehouse_field.scss
+++ b/stock_by_warehouse/static/src/components/warehouse/warehouse_field.scss
@@ -1,5 +1,10 @@
+.availability_product {
+  font-size: 0.8rem
+}
+
 .js_product_warehouse, .js_available_info{
     cursor: pointer;
+    font-size: 0.8rem;
 }
 
 .popover-body.stock-by-warehouse-widget{

--- a/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml
+++ b/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml
@@ -25,7 +25,7 @@
     </t>
 
     <t t-name="stock_by_warehouse.ProductWarehousePopOver">
-        <h3 t-if="this.props.title" class="o_popover_header" t-out="this.props.title" />
+        <h3 t-if="this.props.title" class="popover-header d-flex justify-content-center" t-out="this.props.title" />
         <div class="popover-body stock-by-warehouse-widget">
             <div class="panel clearfix container">
                 <div class="list-group">
@@ -86,7 +86,7 @@
     </t>
 
     <t t-name="stock_by_warehouse.StockAvailabilityPopOver">
-        <h3 t-if="this.props.title" class="o_popover_header" t-out="this.props.title" />
+        <h3 t-if="this.props.title" class="popover-header d-flex justify-content-center" t-out="this.props.title" />
         <div class="popover-body stock-by-warehouse-widget">
             <div t-if="this.props.title">
                 <table class="table table-striped table-bordered">


### PR DESCRIPTION
There was an error when trying to load the stock by warehouse widget caused by the incorrectly use of `onWillUpdateProps` that was change in [1], this commit fixes that error and also adapt the stock by warehouse field to be computed. Finally, some styles were adapted to have a better display and to use recent version of bootstrap.

[1]: https://github.com/odoo/odoo/commit/d682871a