### PR TITLE
[FIX] internal_transfer_with_agreed_amount: Fixing AssertionError in internal_transfer_with_agreed_amount test

### DIFF
--- a/internal_transfer_with_agreed_amount/tests/test_internal_transfer_with_agreed_amount.py
+++ b/internal_transfer_with_agreed_amount/tests/test_internal_transfer_with_agreed_amount.py
@@ -24,9 +24,9 @@ class TestInternalTransferWithAgreedAmount(TransactionCase):
     def create_internal_transfer(self, currency, journal, destination_journal, amount):
         transfer = Form(self.env["account.payment"])
         transfer.payment_type = "outbound"
-        transfer.is_internal_transfer = True
         transfer.journal_id = journal
         transfer.currency_id = currency
+        transfer.is_internal_transfer = True
         transfer.destination_journal_id = destination_journal
         transfer.amount = amount
         return transfer.save()


### PR DESCRIPTION
The test was failing due to an attempt to write to the invisible field 'destination_journal_id'. This occurred because the 'destination_journal_id' field was set to be invisible when the 'is_internal_transfer' field is not True. Consequently, when the 'journal_id' field changed in the form, the 'is_internal_transfer' value changed to False, triggering the error.

This commit resolves the issue and prevents the AssertionError.