### PR TITLE
[FIX] stock_manual_transfer: Avoid Unit of Measure validation error without group

### DIFF
--- a/stock_manual_transfer/__manifest__.py
+++ b/stock_manual_transfer/__manifest__.py
@@ -9,7 +9,7 @@
     "website": "https://www.vauxoo.com",
     "license": "LGPL-3",
     "category": "Inventory/Inventory",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "depends": [
         "stock",
     ],

--- a/stock_manual_transfer/tests/test_stock_manual_transfer.py
+++ b/stock_manual_transfer/tests/test_stock_manual_transfer.py
@@ -8,7 +8,6 @@ class TestStock(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env.user.groups_id += cls.env.ref("uom.group_uom")
         cls.company = cls.env.ref("base.main_company")
         cls.product = cls.env.ref("product.product_product_6")
         cls.warehouse = cls.env.ref("stock_manual_transfer.demo_warehouse_01")

--- a/stock_manual_transfer/views/stock_manual_transfer_views.xml
+++ b/stock_manual_transfer/views/stock_manual_transfer_views.xml
@@ -44,6 +44,7 @@
                                     <field name="sequence" widget="handle" />
                                     <field name="product_id" />
                                     <field name="product_uom_qty" />
+                                    <field name="product_uom_id" invisible="1" />
                                     <field name="product_uom_id" groups="uom.group_uom" optional="show" />
                                     <field name="product_uom_category_id" invisible="1" />
                                 </tree>


### PR DESCRIPTION
A validation error is raised when a user without the "Manage Multiple Units of Measure" access tries to save or validate a manual transfer.

This fix allows any user to create manual transfers, but only users with "Units of Measure" access can modify this attribute on the lines.

This is the answer to the request suggested by German here:
https://github.com/Vauxoo/addons-vauxoo/pull/1652#discussion_r1602424134

I think this is a great solution, better than giving the user access.

Here you can see evidence of the function test:
1. User without group
![User without group](https://github.com/Vauxoo/addons-vauxoo/assets/3640142/b6cb0e25-f94b-4a99-9428-3c79919c56f6)

2. Without the fix we cannot save or validate the Manual Transfer.
![1  Error trying to save without uom permission](https://github.com/Vauxoo/addons-vauxoo/assets/3640142/d5933710-b740-45c8-9523-21b10acdc2b4)

3. With the fix any user could create and modify the lines:
![validated without permision](https://github.com/Vauxoo/addons-vauxoo/assets/3640142/e0d5c78a-041a-44c4-933b-655487aa4a79)
