### PR TITLE
[IMP] stock_manual_transfer: Rename model Manual Transfer Line

### DIFF
--- a/stock_manual_transfer/models/stock_manual_transfer.py
+++ b/stock_manual_transfer/models/stock_manual_transfer.py
@@ -39,7 +39,7 @@ class StockManualTransfer(models.Model):
         states={"draft": [("readonly", False)]},
     )
     transfer_line_ids = fields.One2many(
-        "stock.manual_transfer_line",
+        "stock.manual_transfer.line",
         "transfer_id",
         string="Transfer Lines",
         copy=True,

--- a/stock_manual_transfer/models/stock_manual_transfer_line.py
+++ b/stock_manual_transfer/models/stock_manual_transfer_line.py
@@ -2,7 +2,7 @@ from odoo import api, fields, models
 
 
 class StockManualTransferLine(models.Model):
-    _name = "stock.manual_transfer_line"
+    _name = "stock.manual_transfer.line"
     _description = "Manual Transfer Line"
     _order = "transfer_id, sequence, id"
 


### PR DESCRIPTION
Renamed the model 'stock.manual_transfer_line' to
'stock.manual_transfer.line' for consistency with previous versions of this model.