### PR TITLE
[IMP] stock_manual_transfer: set the default warehouse on manual transfers t#79454

### DIFF
--- a/stock_manual_transfer/models/stock_manual_transfer.py
+++ b/stock_manual_transfer/models/stock_manual_transfer.py
@@ -19,6 +19,7 @@ class StockManualTransfer(models.Model):
         required=True,
         readonly=True,
         states={"draft": [("readonly", False)]},
+        default=lambda self: self.env.user._get_default_warehouse_id(),
     )
     date_planned = fields.Datetime(
         "Planned Date",


### PR DESCRIPTION
Set the default value of the 'warehouse_id' field on the 'stock.manual_transfer' model to the default warehouse of the company.