### PR TITLE
[IMP] default_warehouse_from_sale_team: make abstract model more general T#79454

### DIFF
--- a/default_warehouse_from_sale_team/models/default_warehouse_mixin.py
+++ b/default_warehouse_from_sale_team/models/default_warehouse_mixin.py
@@ -47,7 +47,9 @@ class DefaultWarehouseMixin(models.AbstractModel):
 
     def _get_salesteam_from_vals(self, vals):
         """Determine sales team from creation values"""
-        if "name" in vals:
+        name_field = self._fields["name"]
+        default_name = name_field.default(self) if callable(name_field.default) else name_field.default
+        if vals.get("name", default_name) != default_name:
             # Already has a name, so salesteam won't be used anyway
             return self.env["crm.team"]
         warehouse = (


### PR DESCRIPTION
In v14 when a record is created, the fields with default values were not in the vals passed to the create method but since v15 this behaviour changed so this commit makes the validation of the abstract model more robust considering also the default value.