### PR TITLE
[IMP]  stock_manual_transfer: Add user for default in Manual Transfers group T#79454

### DIFF
--- a/stock_manual_transfer/security/res_groups.xml
+++ b/stock_manual_transfer/security/res_groups.xml
@@ -3,6 +3,7 @@
 
     <record id="group_stock_manual_transfer" model="res.groups">
         <field name="name">Can make manual transfers</field>
+        <field name="users" eval="[Command.link(ref('base.user_root')), Command.link(ref('base.user_admin'))]" />
     </record>
 
 </odoo>


### PR DESCRIPTION
>>>
By default, it is recommended that the admin and root users have all permissions due to their roles and to facilitate functional testing.
>>> 

Added the root user (`base.user_root`) and the admin user (`base.user_admin`) to the `group_stock_manual_transfer` group. Since during functional testing in the TyP module, it was detected that they were not added by default.

