### PR TITLE
[FIX] stock_manual_transfer: name shouldn't be saved in a new record T#79454

### DIFF
--- a/stock_manual_transfer/views/stock_manual_transfer_views.xml
+++ b/stock_manual_transfer/views/stock_manual_transfer_views.xml
@@ -29,7 +29,7 @@
                 <sheet>
                     <group>
                         <h1>
-                            <field name="name" force_save="1" />
+                            <field name="name" readonly="1" />
                         </h1>
                     </group>
                     <group col="4">


### PR DESCRIPTION
The name shouldn't be present in the vals list when creating a record and this commit fixes that by making it readonly instead of force_save which lead to the same functional behaviour but without adding the field to the vals list.

Cherry-pick from: 6aecfd9