### PR TITLE
[IMP] default_warehouse_from_sale_team: hook to fill allowed sales teams T#79454

### DIFF
--- a/default_warehouse_from_sale_team/__init__.py
+++ b/default_warehouse_from_sale_team/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_init_hook

--- a/default_warehouse_from_sale_team/__manifest__.py
+++ b/default_warehouse_from_sale_team/__manifest__.py
@@ -27,6 +27,7 @@
         "demo/stock_warehouse_demo.xml",
         "demo/crm_team_demo.xml",
     ],
+    "post_init_hook": "post_init_hook",
     "installable": True,
     "application": False,
     "auto_install": False,

--- a/default_warehouse_from_sale_team/hooks.py
+++ b/default_warehouse_from_sale_team/hooks.py
@@ -1,0 +1,25 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(env):
+    fill_user_allowed_salesteams(env)
+
+
+def fill_user_allowed_salesteams(env):
+    """Fill allowed sales teams in users that are already members of any team.
+
+    Since this module implements a feature to restrict which sales teams a user may be a member of, users that already
+    belong to any team are configured to be allowed for those teams, to avoid inconsistencies between allowed and
+    already-configured memberships. In other words, if a user already belongs to a team, it most likely means they
+    should be allowed to belong to it, so allowance is granted.
+    """
+    teams_per_user = env["crm.team.member"]._read_group(
+        domain=[],
+        groupby=["user_id"],
+        aggregates=["crm_team_id:recordset"],
+    )
+    for user, teams in teams_per_user:
+        user.sale_team_ids |= teams
+    _logger.info("Field 'Allowed sales Teams' has been set to %d users.", len(teams_per_user))


### PR DESCRIPTION
Implement a hook to fill allowed sales teams in users that are already
a member of any team.

Since this module implements a feature to restrict which sales teams a
user may be a member of, users that already belong to any team are
configured to be allowed for those teams, to avoid
inconsistencies between allowed and already-configured memberships. In
other words, if a user already belongs to a team, it most likely means
they should be allowed to belong to it, so allowance is granted.