### PR TITLE
[FIX] product_cost_usd: order in recompute purchase price I#26616

### DIFF
--- a/product_cost_usd/__manifest__.py
+++ b/product_cost_usd/__manifest__.py
@@ -10,6 +10,7 @@ This module adds the field Cost in USD to the Product form.
     "license": "LGPL-3",
     "depends": [
         "sale_margin",
+        "sale_stock_margin",
     ],
     "demo": [
         "demo/product_pricelist_demo.xml",


### PR DESCRIPTION
The `sale_stock_margin` module recomputes the purchase price in sale
order lines and calls `super()` only over the lines without a stock
move related to it. This causes this module to not recompute the lines
with stock moves related, leading to incorrect computation of the
purchase price.

This commit adds the `sale_stock_margin` module as a dependency in
order to first run this module compute.