### PR TITLE
[IMP] sale_margin_percentage: make purchase price editable I#26616

### DIFF
--- a/sale_margin_percentage/models/sale_order_line.py
+++ b/sale_margin_percentage/models/sale_order_line.py
@@ -7,7 +7,6 @@ class SaleOrderLine(models.Model):
     margin_threshold = fields.Float(
         default=lambda self: self.env.user.company_id.margin_threshold, help="Limit margin set in sales configuration"
     )
-    purchase_price = fields.Float(readonly=True, help="Price purchase of product")
 
     @api.depends("price_subtotal", "product_uom_qty", "purchase_price")
     def _compute_margin(self):


### PR DESCRIPTION
This module was originally created in v11 for a specific customer, and
the purchase price needed to be non-editable for some reason. Now the
purchase price does not need to be non-editable. If it is needed, it
should be managed in the view because the field is natively editable.