### PR TITLE
[FIX] default_warehouse_from_sale_team: remove incorrect record rule T#79454

### DIFF
--- a/default_warehouse_from_sale_team/security/ir_rule_security.xml
+++ b/default_warehouse_from_sale_team/security/ir_rule_security.xml
@@ -21,17 +21,9 @@
     <record id="rule_default_warehouse_stock_picking_team" model="ir.rule">
         <field name="name">Limited access to pickings (filtered by sale teams)</field>
         <field name="model_id" search="[('model','=','stock.picking')]" model="ir.model" />
-        <field name="domain_force">[
-            ('warehouse_id', 'in', user.sale_team_ids.default_warehouse_id.ids),
-        ]</field>
-        <field name="groups" eval="[Command.set([ref('group_limited_default_warehouse_sp')])]" />
-    </record>
-    <record id="rule_default_warehouse_stock_picking_team12" model="ir.rule">
-        <field name="name">Limited access to pickings (filtered by not in sale teams)</field>
-        <field name="model_id" search="[('model','=','stock.picking')]" model="ir.model" />
         <field name="perm_read" eval="False" />
         <field name="domain_force">[
-            ('warehouse_id', 'not in', user.sale_team_ids.default_warehouse_id.ids),
+            ('warehouse_id', 'in', user.sale_team_ids.default_warehouse_id.ids),
         ]</field>
         <field name="groups" eval="[Command.set([ref('group_limited_default_warehouse_sp')])]" />
     </record>


### PR DESCRIPTION
There was a rule to grant read-only access to pickings. However, the correct way to grant read-only access to a model is to uncheck the "Read" field on the desired rule, which would cause that rule to not be considered when verifying accesses.