### PR TITLE
[FIX] website_sale_brand_catalogs: redirection route when selecting brand i#26654

### DIFF
--- a/website_sale_brand_catalogs/views/pages/catalogs.xml
+++ b/website_sale_brand_catalogs/views/pages/catalogs.xml
@@ -15,7 +15,7 @@
                         <div class="row">
                             <t t-foreach="catalog_brands" t-as="brand">
                                 <div class="col-6 col-md-3 text-center brand_card">
-                                    <a t-attf-href="catalog/brand/#{slug(brand)}">
+                                    <a t-attf-href="/catalog/brand/#{slug(brand)}">
                                         <div class="brand_image">
                                             <img
                                                 class="img-responsive img-fluid"


### PR DESCRIPTION
Replace the relative redirection route for brands in the brands catalog on the website with an absolute route to avoid redirecting to nonexistent pages.