### PR TITLE
[FIX] product_cost_usd: correctly set purchase price in multicompany I#27116

### DIFF
--- a/product_cost_usd/models/sale_order_line.py
+++ b/product_cost_usd/models/sale_order_line.py
@@ -11,6 +11,7 @@ class SaleOrderLine(models.Model):
         """
         res = super()._compute_purchase_price()
         for line in self:
+            line = line.with_company(line.company_id)
             pricelist = line.order_id.pricelist_id
             date = line.order_id.date_order
             if not line.product_id:


### PR DESCRIPTION
Since each company has its own purchase price, we must explicitly set the company we are working with (the one in the sale order line) to correctly set the purchase price.