### PR TITLE
[FIX] stock_manual_transfer: make demo route selectable T#79454

### DIFF
--- a/stock_manual_transfer/demo/stock_demo.xml
+++ b/stock_manual_transfer/demo/stock_demo.xml
@@ -15,6 +15,7 @@
         <field name="product_selectable" eval="True" />
         <field name="warehouse_selectable" eval="True" />
         <field name="manual_transfer_selectable" eval="True" />
+        <field name="supplied_wh_id" ref="demo_warehouse_01" />
     </record>
 
     <!-- Pull Rules -->


### PR DESCRIPTION
Since now only routes matching the selected warehouse are displayed [1],
the demo route should have the supplied warehouse set to be selectable.

[1]: https://github.com/Vauxoo/addons-vauxoo/commit/62ec4c4b