### PR TITLE
[FIX] stock_manual_transfer: Missing label in routes view

### DIFF
--- a/stock_manual_transfer/views/stock_route_views.xml
+++ b/stock_manual_transfer/views/stock_route_views.xml
@@ -5,7 +5,7 @@
         <field name="model">stock.route</field>
         <field name="inherit_id" ref="stock.stock_location_route_form_view" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='warehouse_selectable']" position="after">
+            <xpath expr="//div[field[@name='warehouse_selectable']]" position="after">
                 <field name="manual_transfer_selectable" string="Manual transfers" />
             </xpath>
         </field>


### PR DESCRIPTION
The fields for `warehouses_selectable` and `manual_transfers_selectable` were placed on a single line. There was no clarity on what they represented, as they were just two checkboxes without the appropriate labels.

Therefore, `manual_transfers_selectable` was placed on its own line.


#### Form Routes View.
* Before development. Without the `warehouses` checkboxes checked. It doesn't show anything.           
![image](https://github.com/user-attachments/assets/eaf4b3c7-167c-4f58-a119-609fc0e8b805)   
* After development. Without the `warehouses` & `manual_transfers` checkboxes checked. There is a single checkbox per line, and each field has its corresponding label, which provides greater clarity.          
![image](https://github.com/user-attachments/assets/a561bd73-bb7b-4604-93bc-fe13a56bcd59)   


#### Form Routes View.    
* Before development. With the checkboxes checked, it shows a selection field.            
![image](https://github.com/user-attachments/assets/dd716b61-fa1f-400f-ae7c-cfd0b0cbfc8b)     
* After development. With the checkboxes checked, it shows a selection field for warehouses.                
![image](https://github.com/user-attachments/assets/39a811df-386a-4434-917b-fedf739ae660)   