### PR TITLE
[FIX] default_warehouse_from_sale_team: usability for readonly users T#79454

### DIFF
--- a/default_warehouse_from_sale_team/__manifest__.py
+++ b/default_warehouse_from_sale_team/__manifest__.py
@@ -19,6 +19,7 @@
         "views/ir_sequence_views.xml",
         "views/res_users_views.xml",
         "views/stock_picking_type_views.xml",
+        "views/stock_picking_views.xml",
         "security/res_groups_security.xml",
         "security/ir_rule_security.xml",
     ],

--- a/default_warehouse_from_sale_team/models/stock_picking.py
+++ b/default_warehouse_from_sale_team/models/stock_picking.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockPicking(models.Model):
@@ -6,3 +6,18 @@ class StockPicking(models.Model):
     _inherit = ["default.warehouse.mixin", "stock.picking"]
 
     warehouse_id = fields.Many2one(related="picking_type_id.warehouse_id")
+    is_editable = fields.Boolean(compute="_compute_is_editable")
+
+    @api.depends_context("uid")
+    def _compute_is_editable(self):
+        # Using intersection operator to keep original env
+        editable_records = self & self._filter_access_rules_python("write")
+        editable_records.is_editable = True
+        (self - editable_records).is_editable = False
+
+    @api.depends("is_editable")
+    def _compute_show_check_availability(self):
+        res = super()._compute_show_check_availability()
+        non_editable = self - self.filtered("is_editable")
+        non_editable.show_check_availability = False
+        return res

--- a/default_warehouse_from_sale_team/views/stock_picking_views.xml
+++ b/default_warehouse_from_sale_team/views/stock_picking_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form.inherit.default.warehouse</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <field name="show_reserved" position="after">
+                <field name="is_editable" invisible="True" />
+            </field>
+            <button name="action_confirm" position="attributes">
+                <attribute name="invisible" add="not is_editable" separator=" or " />
+            </button>
+            <xpath expr="//button[@name='button_validate' and contains(@invisible, 'draft')]" position="attributes">
+                <attribute name="invisible" add="not is_editable" separator=" or " />
+            </xpath>
+            <xpath expr="//button[@name='button_validate' and contains(@invisible, 'waiting')]" position="attributes">
+                <attribute name="invisible" add="not is_editable" separator=" or " />
+            </xpath>
+            <button name="do_print_picking" position="attributes">
+                <attribute name="invisible" add="not is_editable" separator=" or " />
+            </button>
+            <button name="%(stock.act_stock_return_picking)d" position="attributes">
+                <attribute name="invisible" add="not is_editable" separator=" or " />
+            </button>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Limited users are able to see some pickings in readonly mode, but there were some usability issues that are fixed in this commit:
- It was possible to mark as TODo and check availability, because those actions don't require write access to the pickings. This is fixed by hiding involved buttons.
- Even though validating a picking does require access, it's also hidden because there's no point on showing a button that can't be used anyway.
- Similarly, the Print button is also hidden when the picking is not done yet, because it requires access to mark the picking as printed.
- The Return button is also hidden. Even though it doesn't require write access to the current picking, it will require creation access on the new picking.
- The Cancel button is not hidden because it requires being inventory administrator, which is not compatible with being a limited user.
### Dummy MR:
- [vauxoo/typ!1254](https://git.vauxoo.com/vauxoo/typ/-/merge_requests/1254)