### PR TITLE
[IMP] stock_by_warehouse: Enhance stock visibility for warehouse-Wizard T#79454

### DIFF
--- a/stock_by_warehouse/i18n/es.po
+++ b/stock_by_warehouse/i18n/es.po
@@ -26,22 +26,38 @@ msgstr "... ver todos los almacenes .."
 #. odoo-javascript
 #: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
 #, python-format
-msgid "Available now but not necessarily what I can sale"
-msgstr "Cantidad disponible pero no necesariamente puede ser vendida"
+msgid "Available"
+msgstr "Disponible"
 
 #. module: stock_by_warehouse
 #. odoo-javascript
 #: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
 #, python-format
-msgid "I can sale this quantity now and deliver it immediately"
-msgstr "Puedo vender esta cantidad ahora y entregarla inmediatamente"
+msgid "Available now, but not necessarily for sale"
+msgstr "Disponible ahora, pero no necesariamente para vender"
 
 #. module: stock_by_warehouse
 #. odoo-javascript
 #: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
 #, python-format
-msgid "Is coming in"
-msgstr "Esta llegando"
+msgid "Incoming"
+msgstr "Entrante"
+
+#. module: stock_by_warehouse
+#. odoo-javascript
+#: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
+#, python-format
+msgid "Incoming stock may not cover or will barely meet demand."
+msgstr ""
+"Es posible que el inventario entrante no cubra o apenas satisfaga la "
+"demanda."
+
+#. module: stock_by_warehouse
+#. odoo-javascript
+#: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
+#, python-format
+msgid "It is coming in. It will be available soon."
+msgstr "Está en camino. Estará disponible pronto."
 
 #. module: stock_by_warehouse
 #. odoo-javascript
@@ -56,6 +72,20 @@ msgstr "Ubicación"
 #, python-format
 msgid "Locations:"
 msgstr "Ubicaciones:"
+
+#. module: stock_by_warehouse
+#. odoo-javascript
+#: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
+#, python-format
+msgid "No quantities are coming in."
+msgstr "No hay unidades por llegar."
+
+#. module: stock_by_warehouse
+#. odoo-javascript
+#: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
+#, python-format
+msgid "On Hand"
+msgstr "A mano"
 
 #. module: stock_by_warehouse
 #. odoo-javascript
@@ -131,15 +161,34 @@ msgstr "El producto está disponible en:"
 #. odoo-javascript
 #: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
 #, python-format
-msgid "This is real(on hand) quantity  minus reserved quantity"
-msgstr "Esta es la cantidad real (en mano) menos la cantidad reservada"
+msgid ""
+"There is a deficit. The reserved quantity is greater than the available "
+"stock."
+msgstr ""
+"Hay un déficit. La cantidad reservada es mayor que el inventario disponible."
 
 #. module: stock_by_warehouse
 #. odoo-javascript
 #: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
 #, python-format
-msgid "This will be available next"
-msgstr "Esto estará disponible pronto"
+msgid "This quantity is available for immediate sale and delivery."
+msgstr "Esta cantidad está disponible para venta y entrega inmediata."
+
+#. module: stock_by_warehouse
+#. odoo-javascript
+#: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
+#, python-format
+msgid "This represents on hand quantity minus the picked (outgoing) quantity."
+msgstr ""
+"Esto representa la cantidad disponible menos la cantidad seleccionada "
+"(saliente)."
+
+#. module: stock_by_warehouse
+#. odoo-javascript
+#: code:addons/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml:0
+#, python-format
+msgid "Warehouse"
+msgstr "Almacén"
 
 #. module: stock_by_warehouse
 #. odoo-javascript

--- a/stock_by_warehouse/static/src/components/warehouse/warehouse_field.esm.js
+++ b/stock_by_warehouse/static/src/components/warehouse/warehouse_field.esm.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import {isMobileOS} from "@web/core/browser/feature_detection";
 import {registry} from "@web/core/registry";
 import {useService} from "@web/core/utils/hooks";
 import {localization} from "@web/core/l10n/localization";
@@ -75,7 +76,7 @@ export class StockByWarehouseField extends TextField {
                 onClose: this.closePopover,
             },
             {
-                position: localization.direction === "rtl" ? "bottom" : "right",
+                position: localization.direction === "rtl" || isMobileOS() ? "bottom" : "right",
             }
         );
     }

--- a/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml
+++ b/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml
@@ -27,61 +27,84 @@
     <t t-name="stock_by_warehouse.ProductWarehousePopOver">
         <h3 t-if="this.props.title" class="popover-header d-flex justify-content-center" t-out="this.props.title" />
         <div class="popover-body stock-by-warehouse-widget">
-            <div class="panel clearfix container">
-                <div class="list-group">
+            <table class="table" style="border-collapse: collapse;">
+                <thead style="position: sticky; top: 0; background-color: #017E84; z-index: 1;">
+                    <tr style="text-align: center; background-color: #017E84; color: white;">
+                        <th id="th_warehouse">Warehouse</th>
+                        <th id="th_onhand">On Hand</th>
+                        <th id="th_outgoing">Outgoing</th>
+                        <th id="th_available">Available</th>
+                        <th id="th_incoming">Incoming</th>
+                    </tr>
+                </thead>
+                <tbody>
                     <t t-foreach="this.props.lines" t-as="line" t-key="line_index">
-                        <div
+                        <t
                             t-if="
-                                line.available_not_res &gt; 0
-                                or line.available &gt; 0
-                                or line.outgoing &gt; 0
-                                or line.saleable &gt; 0
-                                or line.incoming &gt; 0
-                                or line.virtual &gt; 0
+                                line.available gt 0
+                                or line.outgoing gt 0
+                                or line.saleable gt 0
+                                or line.incoming gt 0
+                                or line.virtual gt 0
                             "
-                            class="list-group-item row"
                         >
-                            <div name="warehouse_widget" class="d-flex justify-content-between">
-                                <b class="text-left" t-att-title="'Warehouse Name: ' + line.warehouse">
-                                    <t t-out="line.warehouse_short"> | </t>
-                                </b>
-                                <div class="text-right">
-                                    <span
-                                        title="This is real(on hand) quantity  minus reserved quantity"
-                                        class="text-muted"
-                                        t-out="line.available_not_res_formatted"
+                            <tr>
+                                <td style="text-align: center;">
+                                    <b
+                                        class="text-left"
+                                        t-att-title="'Warehouse Name: ' + line.warehouse"
+                                        t-out="line.warehouse_short"
                                     />
-                                    <br />
+                                </td>
+                                <td style="text-align: center;">
                                     <span
-                                        title="Available now but not necessarily what I can sale"
+                                        class="text-muted"
+                                        title="Available now, but not necessarily for sale"
                                         t-out="line.available_formatted"
                                     />
-                                    <br />
-                                    - <span title="Outgoing" class="text-danger" t-out="line.outgoing_formatted" />
-                                    <br />
-                                    = <span
-                                        title="I can sale this quantity now and deliver it immediately"
-                                        class="text-muted"
+                                </td>
+                                <td style="text-align: center;">
+                                    <span class="text-muted" title="Outgoing" t-out="line.outgoing_formatted" />
+                                </td>
+                                <td style="text-align: center;">
+                                    <t t-if="line.virtual gt 0" t-set="saleable_qty_title_message">
+                                        <t>This quantity is available for immediate sale and delivery.</t>
+                                        <t t-out="'\n'" />
+                                        <t>This represents on hand quantity minus the picked (outgoing) quantity.</t>
+                                    </t>
+                                    <t t-else="" t-set="saleable_qty_title_message">
+                                        There is a deficit. The reserved quantity is greater than the available stock.
+                                    </t>
+                                    <span
+                                        t-att-title="saleable_qty_title_message"
+                                        t-att-class="line.saleable gt 0 ? 'text-success' : 'text-danger'"
                                         t-out="line.saleable_formatted"
                                     />
-                                    <br />
-                                    + <span
-                                        title="Is coming in"
-                                        class="text-success"
+                                </td>
+                                <td style="text-align: center;">
+                                    <t
+                                        t-if="line.virtual lt 1 and line.incoming gt 0"
+                                        t-set="incoming_qty_title_message"
+                                    >
+                                        Incoming stock may not cover or will barely meet demand.
+                                    </t>
+                                    <t t-elif="line.incoming lt 1" t-set="incoming_qty_title_message">
+                                        No quantities are coming in.
+                                    </t>
+                                    <t t-else="" t-set="incoming_qty_title_message">
+                                        It is coming in. It will be available soon.
+                                    </t>
+                                    <span
+                                        t-att-title="incoming_qty_title_message"
+                                        t-att-class="line.virtual gt 0 ? '' : 'text-danger'"
                                         t-out="line.incoming_formatted"
                                     />
-                                    <br />
-                                    = <span
-                                        title="This will be available next"
-                                        class="text-muted"
-                                        t-out="line.virtual_formatted"
-                                    />
-                                </div>
-                            </div>
-                        </div>
+                                </td>
+                            </tr>
+                        </t>
                     </t>
-                </div>
-            </div>
+                </tbody>
+            </table>
         </div>
     </t>
 


### PR DESCRIPTION
To enhance user comprehension by improving the visibility of stock levels
across different warehouses, especially when creating a sale and checking
stock availability. This feature is particularly useful for managing stock
across multiple locations. Additionally, conditional help tooltips have
been added to assist in correctly interpreting the values, and translation
terms have been updated.
    

### Requisition 
Change the aesthetics of the Stock by Warehouse Wizard, which is optionally displayed in sales orders. Only the fields of interest need to be kept, and the structure should be made easier to understand. 
Related to: [vauxoo/typ#530](https://git.vauxoo.com/vauxoo/typ/-/issues/530)


#### Sale order form view (Stock by Warehouse Wizard) :
* Before development you have the following default view:   
![image](https://github.com/user-attachments/assets/de8c7fe0-08d5-4c75-95cd-3494a61e4de5)

* After development you have the following default view:   
![image](https://github.com/user-attachments/assets/45b63328-8688-4d8d-aa99-6d1c0b623e8c)
