### PR TITLE
[FIX] default_warehouse_from_sale_team: prevent Sales Team compute on default journal set i#28375

### DIFF
--- a/default_warehouse_from_sale_team/models/account_move.py
+++ b/default_warehouse_from_sale_team/models/account_move.py
@@ -7,7 +7,13 @@ class AccountMove(models.Model):
     def _search_default_journal(self):
         """If a team is provided and it has a sales journal set, take it as 1st alternative"""
         journal = super()._search_default_journal()
-        team = self.env.context.get("salesteam") or self.team_id or self.env.user.sale_team_id
+        team = (
+            self.env.context.get("salesteam")
+            # If the team_id value (ID) is in the cache, it must be converted to a record from the
+            # cached value to avoid triggering the field's compute method when it has not yet been computed.
+            or self._fields["team_id"].convert_to_record(self._cache.get("team_id"), self)
+            or self.env.user.sale_team_id
+        )
         journal_on_team = team._get_default_journal([journal.type or "general"])
         return journal_on_team or journal
 


### PR DESCRIPTION
Use the cached value of the Sales Team field to access its value as a record. This avoids computing its value when it has not been computed yet, which could result in setting the wrong Sales Team on an invoice form creation. This issue occurs because the company is not yet set, and its value is required to determine the correct Sales Team [1].

[1]: https://github.com/odoo/odoo/blob/3884a60e/addons/sale/models/account_move.py#L41