### PR TITLE
[FIX] default_warehouse_from_sale_team: validate cache access when no record exists i#28375

### DIFF
--- a/default_warehouse_from_sale_team/models/account_move.py
+++ b/default_warehouse_from_sale_team/models/account_move.py
@@ -9,9 +9,10 @@ class AccountMove(models.Model):
         journal = super()._search_default_journal()
         team = (
             self.env.context.get("salesteam")
-            # If the team_id value (ID) is in the cache, it must be converted to a record from the
-            # cached value to avoid triggering the field's compute method when it has not yet been computed.
-            or self._fields["team_id"].convert_to_record(self._cache.get("team_id"), self)
+            # If the team_id value (ID) is in the cache on a existing account.move record, it must be
+            # converted to a record from the cached value to avoid triggering the field's compute
+            # method when it has not yet been computed.
+            or (self and self._fields["team_id"].convert_to_record(self._cache.get("team_id"), self))
             or self.env.user.sale_team_id
         )
         journal_on_team = team._get_default_journal([journal.type or "general"])


### PR DESCRIPTION
Add a validation to avoid errors when accessing the cache without a record. The change ensures that the `team_id` value is only retrieved from the cache when a valid `account.move` record exists.