### PR TITLE
[IMP] stock_custom_exchange_rate_date: add the module price t#84027

### DIFF
--- a/stock_custom_exchange_rate_date/__manifest__.py
+++ b/stock_custom_exchange_rate_date/__manifest__.py
@@ -11,7 +11,6 @@
     "data": [
         "views/stock_picking_views.xml",
     ],
-    "demo": [],
-    "installable": True,
-    "auto_install": False,
+    "price": 100,
+    "currency": "USD",
 }


### PR DESCRIPTION
[Task #84027](https://www.vauxoo.com/web#id=84027&cids=1&menu_id=1530&active_id=647534&model=project.task&view_type=form)

Define the price of the module and keep only the necessary keys in the manifest to comply with Odoo's App Store guidelines.