### PR TITLE
[FIX] default_warehouse_from_sale_team: fix migration check_access T#85690

### DIFF
--- a/default_warehouse_from_sale_team/models/stock_warehouse.py
+++ b/default_warehouse_from_sale_team/models/stock_warehouse.py
@@ -22,7 +22,7 @@ class StockWarehouse(models.Model):
         return (
             warehouses
             and not self.env.su
-            and warehouses.check_access("read", raise_exception=False)
+            and warehouses.has_access("read")
             and failed_rules
             and not failed_rules - allowed_rules
         )


### PR DESCRIPTION
On [1], check_access_rights was migrated to check_access, preserving the argument raise_exception. OCA [2] mentions this is the method to use on 18.0, but it does not have the argument raise_exception. The method has_access should be used to preserve the functionality of raise_exception=False [3].

[1]: https://github.com/Vauxoo/addons-vauxoo/commit/09c556a0
[2]: https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-18.0
[3]: https://github.com/odoo/odoo/blob/76d429ce/odoo/models.py#L4452

Related to [I#29085](https://www.vauxoo.com/web#id=29085&cids=1&model=helpdesk.ticket&view_type=form)