### PR TITLE
[FIX] base_sync_login_email: constraint raised unexpectedly I#29788

### DIFF
--- a/base_sync_login_email/models/res_partner.py
+++ b/base_sync_login_email/models/res_partner.py
@@ -6,7 +6,7 @@ from odoo.tools import single_email_re
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    @api.constrains("email", "partner_share", "active")
+    @api.constrains("email", "active")
     def _check_email_internal_user(self):
         """If the partner belongs to an internal user, validate the email matches the user login"""
         for partner in self:


### PR DESCRIPTION
Currently, if the module is installed and there are already partners whose
email doesn't match the user's one, the constraint is triggered under
unexpected circumstances. For instance, when enabling/disabling technical
groups, which are the ones used by config settings not to grant access but
to enable features globally (e.g. product variants, multi warehouses, etc).

This is because, when those groups are enabled or disabled, they are added
or removed from all internal users, even archived ones. This makes the
`partner_share` field to be recomputed on the related partners, which in
turn triggers the constraint.

To solve this, the `partner_share` field is removed from the constraint's
dependencies. It was initially added so that the constraint was triggered
when a non-internal user became an internal one, but that situation
shouldn't be as common, and such a change may only be made by an
administrator anyway.