### PR TITLE
[IMP] stock_by_warehouse, stock_by_warehouse_sale: Backport of warehouse widget modal.

### DIFF
--- a/stock_by_warehouse/static/src/components/warehouse/warehouse_field.scss
+++ b/stock_by_warehouse/static/src/components/warehouse/warehouse_field.scss
@@ -1,3 +1,4 @@
+
 .js_product_warehouse, .js_available_info{
     cursor: pointer;
 }

--- a/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml
+++ b/stock_by_warehouse/static/src/components/warehouse/warehouse_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="stock_by_warehouse.ShowWarehouseInfo" owl="1">
-        <div>
+        <div class="mr8">
             <p t-if="this.props.byLocation" class="availability_product my-0 mr-2">
                 The product is available in: <t t-out="show" /> locations.
                 <a
@@ -24,66 +24,91 @@
         </div>
     </t>
 
+
     <t t-name="stock_by_warehouse.ProductWarehousePopOver" owl="1">
-        <h3 t-if="this.props.title" class="o_popover_header" t-out="this.props.title" />
+        <h3 t-if="this.props.title" class="popover-header d-flex justify-content-center" t-out="this.props.title" />
         <div class="popover-body stock-by-warehouse-widget">
-            <div class="panel clearfix container">
-                <div class="list-group">
+            <table class="table" style="border-collapse: collapse;">
+                <thead style="position: sticky; top: 0; background-color: #017E84; z-index: 1;">
+                    <tr style="text-align: center; background-color: #017E84; color: white;">
+                        <th id="th_warehouse">Warehouse</th>
+                        <th id="th_onhand">On Hand</th>
+                        <th id="th_outgoing">Outgoing</th>
+                        <th id="th_available">Available</th>
+                        <th id="th_incoming">Incoming</th>
+                    </tr>
+                </thead>
+                <tbody>
                     <t t-foreach="this.props.lines" t-as="line" t-key="line_index">
-                        <div
+                        <t
                             t-if="
-                                line.available_not_res &gt; 0
-                                or line.available &gt; 0
-                                or line.outgoing &gt; 0
-                                or line.saleable &gt; 0
-                                or line.incoming &gt; 0
-                                or line.virtual &gt; 0
+                                line.available gt 0
+                                or line.outgoing gt 0
+                                or line.saleable gt 0
+                                or line.incoming gt 0
+                                or line.virtual gt 0
                             "
-                            class="list-group-item row"
                         >
-                            <div name="warehouse_widget" class="d-flex justify-content-between">
-                                <b class="text-left" t-att-title="'Warehouse Name: ' + line.warehouse">
-                                    <t t-out="line.warehouse_short"> | </t>
-                                </b>
-                                <div class="text-right">
-                                    <span
-                                        title="This is real(on hand) quantity  minus reserved quantity"
-                                        class="text-muted"
-                                        t-out="line.available_not_res_formatted"
+                            <tr>
+                                <td style="text-align: center;">
+                                    <b
+                                        class="text-left"
+                                        t-att-title="'Warehouse Name: ' + line.warehouse"
+                                        t-out="line.warehouse_short"
                                     />
-                                    <br />
+                                </td>
+                                <td style="text-align: center;">
                                     <span
-                                        title="Available now but not necessarily what I can sale"
+                                        class="text-muted"
+                                        title="Available now, but not necessarily for sale"
                                         t-out="line.available_formatted"
                                     />
-                                    <br />
-                                    - <span title="Outgoing" class="text-danger" t-out="line.outgoing_formatted" />
-                                    <br />
-                                    = <span
-                                        title="I can sale this quantity now and deliver it immediately"
-                                        class="text-muted"
+                                </td>
+                                <td style="text-align: center;">
+                                    <span class="text-muted" title="Outgoing" t-out="line.outgoing_formatted" />
+                                </td>
+                                <td style="text-align: center;">
+                                    <t t-if="line.virtual gt 0" t-set="saleable_qty_title_message">
+                                        <t>This quantity is available for immediate sale and delivery.</t>
+                                        <t t-out="'\n'" />
+                                        <t>This represents on hand quantity minus the picked (outgoing) quantity.</t>
+                                    </t>
+                                    <t t-else="" t-set="saleable_qty_title_message">
+                                        There is a deficit. The reserved quantity is greater than the available stock.
+                                    </t>
+                                    <span
+                                        t-att-title="saleable_qty_title_message"
+                                        t-att-class="line.saleable gt 0 ? 'text-success' : 'text-danger'"
                                         t-out="line.saleable_formatted"
                                     />
-                                    <br />
-                                    + <span
-                                        title="Is coming in"
-                                        class="text-success"
+                                </td>
+                                <td style="text-align: center;">
+                                    <t
+                                        t-if="line.virtual lt 1 and line.incoming gt 0"
+                                        t-set="incoming_qty_title_message"
+                                    >
+                                        Incoming stock may not cover or will barely meet demand.
+                                    </t>
+                                    <t t-elif="line.incoming lt 1" t-set="incoming_qty_title_message">
+                                        No quantities are coming in.
+                                    </t>
+                                    <t t-else="" t-set="incoming_qty_title_message">
+                                        It is coming in. It will be available soon.
+                                    </t>
+                                    <span
+                                        t-att-title="incoming_qty_title_message"
+                                        t-att-class="line.virtual gt 0 ? '' : 'text-danger'"
                                         t-out="line.incoming_formatted"
                                     />
-                                    <br />
-                                    = <span
-                                        title="This will be available next"
-                                        class="text-muted"
-                                        t-out="line.virtual_formatted"
-                                    />
-                                </div>
-                            </div>
-                        </div>
+                                </td>
+                            </tr>
+                        </t>
                     </t>
-                </div>
-            </div>
+                </tbody>
+            </table>
         </div>
     </t>
+
 
     <t t-name="stock_by_warehouse.StockAvailabilityPopOver" owl="1">
         <h3 t-if="this.props.title" class="o_popover_header" t-out="this.props.title" />

--- a/stock_by_warehouse_sale/views/sale_order_views.xml
+++ b/stock_by_warehouse_sale/views/sale_order_views.xml
@@ -7,8 +7,14 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='order_line']/form//field[@name='sequence']" position="after">
-                <div class="text-center alert alertdialog" attrs="{'invisible': [('product_type', '!=', 'product')]}">
-                    <p>The saleable stock in: <field name="warehouse_id" /> that can be delivered immediately is:
+                <div
+                    role="alert"
+                    class="alert alert-info alertdialog text-center text-info"
+                    attrs="{'invisible': [('product_type', '!=', 'product')]}"
+                >
+                    <p class="m-0">The saleable stock in: <field
+                            name="warehouse_id"
+                        /> that can be delivered immediately is:
                         <field name="warehouses_stock" widget="warehouse" options="{'placement': 'bottom'}" />
                         &amp;nbsp;&amp;nbsp;
                         <field name="warehouses_stock_recompute" widget="boolean_toggle" />


### PR DESCRIPTION
- The modal `stock_by_warehouse.ProductWarehousePopOver` used in the `widget="warehouse"` defined by `stock_by_warehouse`  was improved to use the version for 17.0.
- The view stock_by_warehouse_purchase.view_order_form` was improved to correctly use bootstrap alerts.

This is a backport of these commits

https://github.com/Vauxoo/addons-vauxoo/commit/23c94e67f2bbbcbc064e876ead094bdb80e413d6
https://github.com/Vauxoo/addons-vauxoo/commit/02b2b10923d4718432614fb768a05d2b2cc55569

Before:

<img width="307" height="341" alt="image_2025-08-11_14-33-30 (2)" src="https://github.com/user-attachments/assets/3b390804-e6bf-4065-96db-b7003bc59356" />

After

<img width="307" height="341" alt="image_2025-08-11_14-33-30 (2)" src="https://github.com/user-attachments/assets/55712f83-6307-4f6c-be7c-e771c671f6a1" />



Task: Inventario (#29941).