### PR TITLE
[IMP] default_warehouse_from_sale_team: clarify AccessError for journal restrictions

### DIFF
--- a/default_warehouse_from_sale_team/i18n/es.po
+++ b/default_warehouse_from_sale_team/i18n/es.po
@@ -255,3 +255,18 @@ msgstr "Almacén"
 #: model_terms:ir.ui.view,arch_db:default_warehouse_from_sale_team.crm_team_view_form
 msgid "Warehouse settings for the sales team"
 msgstr "Configuración de almacén para el equipo de ventas"
+
+#. module: default_warehouse_from_sale_team
+#. odoo-python
+#: code:addons/default_warehouse_from_sale_team/models/ir_rule.py:0
+#, python-format
+msgid ""
+"You do not have access to the selected journal(s) for this operation.\n"
+"Journal(s): %s \n"
+"\n"
+"Please select a journal that corresponds to your branch."
+msgstr ""
+"No tiene acceso a los diarios seleccionados para esta operación.\n"
+"Diarios: %s\n"
+"\n"
+"Por favor seleccione un diario que corresponda a su sucursal."

--- a/default_warehouse_from_sale_team/models/__init__.py
+++ b/default_warehouse_from_sale_team/models/__init__.py
@@ -3,6 +3,7 @@ from . import account_move
 from . import crm_team
 from . import default_warehouse_mixin
 from . import default_picking_type_mixin
+from . import ir_rule
 from . import ir_sequence
 from . import procurement_group
 from . import purchase_order

--- a/default_warehouse_from_sale_team/models/ir_rule.py
+++ b/default_warehouse_from_sale_team/models/ir_rule.py
@@ -1,0 +1,25 @@
+from odoo import _, models
+from odoo.exceptions import AccessError
+
+
+class IrRule(models.Model):
+    _inherit = "ir.rule"
+
+    def _make_access_error(self, operation, records):
+        """Ensure that the selected journal is accessible for the user's team/branch.
+        If no team are defined for the journal, access is open to all users.
+        """
+        if records and records._name == "account.move":
+            journals = records.mapped("journal_id").sudo()
+            if journals:
+                journal_names = ", ".join(journals.mapped("display_name"))
+                records.invalidate_recordset()
+                return AccessError(
+                    _(
+                        "You do not have access to the selected journal(s) for this operation.\n"
+                        "Journal(s): %s \n\n"
+                        "Please select a journal that corresponds to your branch.",
+                        journal_names,
+                    )
+                )
+        return super()._make_access_error(operation, records)

--- a/default_warehouse_from_sale_team/tests/test_default_warehouse.py
+++ b/default_warehouse_from_sale_team/tests/test_default_warehouse.py
@@ -1,4 +1,7 @@
-from odoo import Command
+import re
+
+from odoo import Command, fields
+from odoo.exceptions import AccessError
 from odoo.tests import Form, TransactionCase, tagged
 
 
@@ -123,3 +126,57 @@ class TestSalesTeamDefaultWarehouse(TransactionCase):
         pick.action_assign()
         pick.move_ids.write({"quantity": 1, "picked": True})
         pick.button_validate()
+
+    def test_05_validate_saleteam_journal_access(self):
+        """Enforces record rule: move must use a public journal or one from the user's sales team;
+        otherwise AccessError with custom message.
+        """
+        today = fields.Date.context_today(self.env.user)
+        public_journal = self.env["account.journal"].create(
+            {
+                "name": "Public Sales",
+                "type": "sale",
+                "code": "PUB",
+            }
+        )
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.env.ref("base.res_partner_2").id,
+                "company_id": self.company.id,
+                "date": today,
+                "invoice_date": today,
+                "invoice_date_due": today,
+                "is_payment_only": True,
+                "journal_id": public_journal.id,
+            }
+        )
+        # Case 1: Journal assigned to demo user's team → should succeed
+        my_team_journal = self.env["account.journal"].create(
+            {
+                "name": "My team Journal",
+                "type": "sale",
+                "code": "My-J",
+                "section_id": self.sales_team.id,
+            }
+        )
+        invoice.with_user(self.demo_user).write({"journal_id": my_team_journal.id})
+        self.assertEqual(invoice.journal_id, my_team_journal)
+
+        # Case 2: Public Journal assigned to another team → should raise UserError
+        other_team = self.env["crm.team"].create({"name": "Other Team"})
+        other_team_journal = self.env["account.journal"].create(
+            {
+                "name": "Other team Journal",
+                "type": "sale",
+                "code": "OTH-J",
+                "section_id": other_team.id,
+            }
+        )
+        error_msg = (
+            "You do not have access to the selected journal(s) for this operation.\n"
+            f"Journal(s): {other_team_journal.display_name} \n\n"
+            "Please select a journal that corresponds to your branch."
+        )
+        with self.assertRaisesRegex(AccessError, re.escape(error_msg)):
+            invoice.with_user(self.demo_user).write({"journal_id": other_team_journal.id})


### PR DESCRIPTION
Improve UX by returning a specific AccessError when access is denied due to journal restrictions tied to sales teams (on account.move). The message now lists the affected journal(s) and suggests selecting one that matches the user’s branch/team. Security behavior is unchanged; this only refines the error copy.

Previously, users only saw a generic access denied error and assumed they lacked general billing permissions; this makes the cause explicit.

Added the necessary translations for the new error message and tests for the new flow.

Related to: typ!1371