### PR TITLE
[IMP] .github: drop workaround for OrchestSH install prefix T#97360

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,8 +82,8 @@ jobs:
         env:
           ORCHESTSH_PREFIX: /home/runner/.local/bin
         run: |
-          command -v orchestsh || wget -qO- https://raw.githubusercontent.com/Orchestsh/orchestsh/master/installer.sh | sed "s:/usr/bin:$ORCHESTSH_PREFIX:g" | sh
-          command -v staticv || wget -qO- https://raw.githubusercontent.com/OrchestSh/staticv/master/installer.sh | sed "s:/usr/bin:$ORCHESTSH_PREFIX:g" | sh
+          command -v orchestsh || wget -qO- https://raw.githubusercontent.com/Orchestsh/orchestsh/master/installer.sh | sh
+          command -v staticv || wget -qO- https://raw.githubusercontent.com/OrchestSh/staticv/master/installer.sh | sh
       - name: Build image
         env:
           PRIVATE_DEPLOY_KEY: ${{ secrets.PRIVATE_DEPLOY_KEY }}


### PR DESCRIPTION
Now that the installation scripts support specifying a custom install prefix for OrchestSH [1] and StaticV [2], it is no longer necessary to patch the installers to modify the destination path during CI.

[1]: https://github.com/OrchestSh/orchestsh/commit/754bcb54
[2]: https://github.com/OrchestSh/staticv/commit/a80094fb