### PR TITLE
[IMP] stock_by_warehouse: use Command API and clean up manifest

### DIFF
--- a/stock_by_warehouse/__manifest__.py
+++ b/stock_by_warehouse/__manifest__.py
@@ -16,7 +16,6 @@
         "views/product_product_views.xml",
         "views/product_template_views.xml",
     ],
-    "demo": [],
     "assets": {
         "web.assets_backend": [
             "stock_by_warehouse/static/src/components/warehouse/warehouse_field.scss",
@@ -24,6 +23,4 @@
             "stock_by_warehouse/static/src/components/warehouse/warehouse_field.esm.js",
         ],
     },
-    "installable": True,
-    "auto_install": False,
 }

--- a/stock_by_warehouse/tests/test_stock_available_unreserved.py
+++ b/stock_by_warehouse/tests/test_stock_available_unreserved.py
@@ -1,3 +1,4 @@
+from odoo.fields import Command
 from odoo.tests import Form, TransactionCase
 from odoo.tools.safe_eval import safe_eval
 
@@ -39,13 +40,11 @@ class TestStockLogisticsWarehouse(TransactionCase):
                 "type": "product",
                 "uom_id": cls.uom_unit.id,
                 "attribute_line_ids": [
-                    (
-                        0,
-                        0,
+                    Command.create(
                         {
                             "attribute_id": cls.attribute.id,
-                            "value_ids": [(6, 0, (cls.attribute_a + cls.attribute_b).ids)],
-                        },
+                            "value_ids": [Command.set((cls.attribute_a + cls.attribute_b).ids)],
+                        }
                     )
                 ],
             }


### PR DESCRIPTION
The test was using legacy ORM tuple syntax (0, 0, {...}) and (6, 0, ...) to create and set relational field values. This syntax is error-prone and harder to read compared to the modern Command API introduced in Odoo 15.

The Command.create() and Command.set() methods have been adopted to improve readability and align with current Odoo development standards. The Command import has been added accordingly.

Additionally, redundant manifest keys (demo, installable, auto_install) that simply replicate Odoo default values have been removed to keep the manifest clean and minimal.

task: [task](https://www.vauxoo.com/web#id=97360&cids=1&menu_id=1490&action=464&active_id=188&model=project.task&view_type=form)