### PR TITLE
[IMP] stock_by_warehouse_mrp_bom: remove redundant manifest keys and …

### DIFF
--- a/stock_by_warehouse_mrp_bom/__manifest__.py
+++ b/stock_by_warehouse_mrp_bom/__manifest__.py
@@ -14,7 +14,4 @@
         "stock_by_warehouse",
     ],
     "data": ["views/mrp_bom_line_views.xml", "views/mrp_bom_views.xml"],
-    "demo": [],
-    "installable": True,
-    "auto_install": False,
 }

--- a/stock_by_warehouse_mrp_bom/views/mrp_bom_views.xml
+++ b/stock_by_warehouse_mrp_bom/views/mrp_bom_views.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <record id="mrp_bom_view_form" model="ir.ui.view">
         <field name="name">mrp.bom.stock.warehouse</field>


### PR DESCRIPTION
…add XML declaration

Default manifest keys demo, installable and auto_install are implicit in Odoo and their presence adds unnecessary noise to the manifest file. Removing them keeps the manifest minimal and consistent with the coding conventions followed across the codebase.

The XML declaration header was missing from mrp_bom_views.xml. Adding it ensures compliance with OCA pre-commit formatting checks that require all XML files to begin with a proper declaration.
[task(https://www.vauxoo.com/web#id=97360&cids=1&menu_id=1490&action=464&active_id=188&model=project.task&view_type=form)