### PR TITLE
[IMP] product_cost_usd: remove superfluous manifest key

### DIFF
--- a/product_cost_usd/__manifest__.py
+++ b/product_cost_usd/__manifest__.py
@@ -20,5 +20,4 @@ This module adds the field Cost in USD to the Product form.
         "views/product_template_views.xml",
     ],
     "installable": True,
-    "auto_install": False,
 }


### PR DESCRIPTION
Following the same approach as Odoo [1], the `auto_install` key is removed because its value is the same as the default.

[1]: https://github.com/odoo/odoo/pull/90209