### PR TITLE
[FIX] stock_by_warehouse_sale: prevent singleton error in warehouse stock compute T#98915

### DIFF
--- a/stock_by_warehouse_sale/__manifest__.py
+++ b/stock_by_warehouse_sale/__manifest__.py
@@ -16,8 +16,4 @@
     "data": [
         "views/sale_order_views.xml",
     ],
-    "demo": [],
-    "test": [],
-    "installable": True,
-    "auto_install": False,
 }

--- a/stock_by_warehouse_sale/models/sale_order_line.py
+++ b/stock_by_warehouse_sale/models/sale_order_line.py
@@ -18,5 +18,5 @@ class SaleOrderLine(models.Model):
     @api.depends("warehouses_stock_recompute", "product_id")
     def _compute_warehouse_stock(self):
         for record in self:
-            record.warehouse_id = self.order_id.warehouse_id
+            record.warehouse_id = record.order_id.warehouse_id
             record._compute_get_warehouses_stock()


### PR DESCRIPTION
## Problem
When processing multiple sale order lines at once (e.g., during bulk creation, updates, or imports), a singleton error is raised, preventing the user from completing the action.
## Root Cause
In `_compute_warehouse_stock` of the `sale.order.line` model, the `warehouse_id` assignment incorrectly referenced the active recordset `self` (e.g., `self.order_id.warehouse_id`) inside the `for record in self:` loop instead of using the single loop variable `record`.
## Fix
- Corrected the reference to use the loop variable `record` (i.e., `record.warehouse_id = record.order_id.warehouse_id`).
- Cleaned up redundant and deprecated keys (`demo`, `test`, `installable`, `auto_install`) from the module manifest.
- Related Task: T#98915