### PR TITLE
[IMP] product_cost_usd: allow different USD costs in multicompany t#97815

### DIFF
--- a/product_cost_usd/migrations/19.0.1.0.0/pre-migration.py
+++ b/product_cost_usd/migrations/19.0.1.0.0/pre-migration.py
@@ -1,0 +1,21 @@
+import logging
+
+from odoo.upgrade import util
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _convert_standard_price_usd_to_company_dependent(cr)
+
+
+def _convert_standard_price_usd_to_company_dependent(cr):
+    """Convert standard_price_usd to company-dependent."""
+    util.make_field_company_dependent(
+        cr,
+        model="product.template",
+        field="standard_price_usd",
+        type="float",
+        company_field="company_id",
+    )
+    _logger.info("standard_price_usd field has been converted to be company dependent")

--- a/product_cost_usd/models/product_template.py
+++ b/product_cost_usd/models/product_template.py
@@ -15,6 +15,7 @@ class ProductTemplate(models.Model):
     standard_price_usd = fields.Float(
         string="Cost in USD",
         digits="Product Price",
+        company_dependent=True,
         help="Price cost of the product in USD currency",
     )
 


### PR DESCRIPTION
Align standard_price_usd with the native standard_price field, which
is already company-dependent, so each company can have its own USD
cost value for the same product.

Before this change, all companies shared the same USD cost. This was
limiting in multicompany scenarios where each company negotiates
different supplier prices in USD.

A pre-migration script is included to convert existing values.