### PR TITLE
[MIG] base_sync_login_email: Migrate to 19.0

### DIFF
--- a/base_sync_login_email/README.rst
+++ b/base_sync_login_email/README.rst
@@ -39,7 +39,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 `feedback
 <https://github.com/vauxoo/addons-vauxoo/issues/new?body=
 module:%20base_sync_login_email%0A
-version:%2016.0%0A%0A
+version:%2019.0%0A%0A
 **Steps%20to%20reproduce**%0A
 -%20...%0A%0A
 **Current%20behavior**%0A%0A

--- a/base_sync_login_email/README.rst
+++ b/base_sync_login_email/README.rst
@@ -1,0 +1,72 @@
+.. image:: https://img.shields.io/badge/license-LGPL--3-blue.png
+    :alt: License: LGPL-3
+    :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+
+===========================
+Sync User Login With E-Mail
+===========================
+
+This module ensures the e-mail address of a contact associated with an internal
+user remains synchronized with the user's login.
+
+**Why?**
+
+It is natively possible for an internal user to edit the e-mail of the contact
+associated to their user. This could be a security risk, because someone could
+(accidentally?) change their own e-mail to an address different from the one
+used to sign up (e.g. an e-mail outside the organization), which could lead to
+an external person to receive sensitive information or intended to be sent only
+to internal users.
+
+To prevent the above, this module disables editing e-mails of contacts
+associated with internal users if their e-mail matches their user login. Now, to
+edit an e-mail, you will need to edit the user login, which will update contact
+e-mails automatically, ensuring both login and e-mail are synced.
+
+This adds two security layers:
+
+- It prevents accidental or unauthorized changes to contact e-mails.
+- It restricts e-mail modifications to administrators, as only they have
+  permission to edit user records.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/Vauxoo/addons-vauxoo/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us to smash it by providing a detailed and welcomed
+`feedback
+<https://github.com/vauxoo/addons-vauxoo/issues/new?body=
+module:%20base_sync_login_email%0A
+version:%2016.0%0A%0A
+**Steps%20to%20reproduce**%0A
+-%20...%0A%0A
+**Current%20behavior**%0A%0A
+**Expected%20behavior**>`_.
+
+Do not contact contributors directly about support or help with technical issues.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Luis González <lgonzalez@vauxoo.com>
+
+Maintainers
+-----------
+
+This module is maintained by Vauxoo.
+
+.. image:: https://www.vauxoo.com/logo.png
+   :alt: Vauxoo
+   :target: https://vauxoo.com
+
+A latinamerican company that provides training, coaching,
+development and implementation of enterprise management
+systems and bases its entire operation strategy in the use
+of Open Source Software and its main product is odoo.
+
+To contribute to this module, please visit https://www.vauxoo.com.

--- a/base_sync_login_email/__init__.py
+++ b/base_sync_login_email/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/base_sync_login_email/__manifest__.py
+++ b/base_sync_login_email/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "Sync User Login With E-Mail",
+    "summary": """
+    Restrict editing e-mails of internal users and update e-mails according
+    to their logins.
+    """,
+    "author": "Vauxoo",
+    "website": "https://www.vauxoo.com",
+    "license": "LGPL-3",
+    "category": "Tools",
+    "version": "16.0.1.0.0",
+    "depends": [
+        "base",
+    ],
+}

--- a/base_sync_login_email/__manifest__.py
+++ b/base_sync_login_email/__manifest__.py
@@ -8,7 +8,7 @@
     "website": "https://www.vauxoo.com",
     "license": "LGPL-3",
     "category": "Tools",
-    "version": "16.0.1.0.0",
+    "version": "19.0.1.0.0",
     "depends": [
         "base",
     ],

--- a/base_sync_login_email/i18n/es.po
+++ b/base_sync_login_email/i18n/es.po
@@ -4,11 +4,11 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0+e\n"
+"Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-09 04:26+0000\n"
-"PO-Revision-Date: 2025-04-09 04:26+0000\n"
-"Last-Translator: Luis González <lgonzalez@vauxoo.com>\n"
+"POT-Creation-Date: 2026-09-11 17:34+0000\n"
+"PO-Revision-Date: 2026-09-11 17:34+0000\n"
+"Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,15 +21,26 @@ msgid "Contact"
 msgstr "Contacto"
 
 #. module: base_sync_login_email
+#: model:ir.model.fields,field_description:base_sync_login_email.field_res_partner__display_name
+#: model:ir.model.fields,field_description:base_sync_login_email.field_res_users__display_name
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: base_sync_login_email
+#: model:ir.model.fields,field_description:base_sync_login_email.field_res_partner__id
+#: model:ir.model.fields,field_description:base_sync_login_email.field_res_users__id
+msgid "ID"
+msgstr ""
+
+#. module: base_sync_login_email
 #. odoo-python
 #: code:addons/base_sync_login_email/models/res_partner.py:0
-#, python-format
 msgid ""
 "It's not possible to change this contact's email because it's associated to an internal user and the new email doesn't match the user login.\n"
 "- Contact's email: '%s'\n"
 "- User login: '%s'"
 msgstr ""
-"No es posible modifica el correo electrónico de este contacto porque está asociado con un usuario interno y el nuevo correo electrónico no coincide con el inicio de sesión (login) del usuario.\n"
+"No es posible modificar el correo electrónico de este contacto porque está asociado con un usuario interno y el nuevo correo electrónico no coincide con el inicio de sesión (login) del usuario.\n"
 "- Correo electrónico del contacto: '%s'\n"
 "- Inicio de sesión del usuario: '%s'"
 

--- a/base_sync_login_email/i18n/es.po
+++ b/base_sync_login_email/i18n/es.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* base_sync_login_email
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-09 04:26+0000\n"
+"PO-Revision-Date: 2025-04-09 04:26+0000\n"
+"Last-Translator: Luis González <lgonzalez@vauxoo.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: base_sync_login_email
+#: model:ir.model,name:base_sync_login_email.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: base_sync_login_email
+#. odoo-python
+#: code:addons/base_sync_login_email/models/res_partner.py:0
+#, python-format
+msgid ""
+"It's not possible to change this contact's email because it's associated to an internal user and the new email doesn't match the user login.\n"
+"- Contact's email: '%s'\n"
+"- User login: '%s'"
+msgstr ""
+"No es posible modifica el correo electrónico de este contacto porque está asociado con un usuario interno y el nuevo correo electrónico no coincide con el inicio de sesión (login) del usuario.\n"
+"- Correo electrónico del contacto: '%s'\n"
+"- Inicio de sesión del usuario: '%s'"
+
+#. module: base_sync_login_email
+#: model:ir.model,name:base_sync_login_email.model_res_users
+msgid "User"
+msgstr "Usuario"

--- a/base_sync_login_email/models/__init__.py
+++ b/base_sync_login_email/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_partner
+from . import res_users

--- a/base_sync_login_email/models/res_partner.py
+++ b/base_sync_login_email/models/res_partner.py
@@ -1,4 +1,4 @@
-from odoo import _, api, models
+from odoo import api, models
 from odoo.exceptions import ValidationError
 from odoo.tools import single_email_re
 
@@ -17,7 +17,7 @@ class ResPartner(models.Model):
             }
             if internal_emails - {new_email}:
                 raise ValidationError(
-                    _(
+                    self.env._(
                         "It's not possible to change this contact's email because it's associated to an internal user "
                         "and the new email doesn't match the user login.\n"
                         "- Contact's email: '%s'\n"

--- a/base_sync_login_email/models/res_partner.py
+++ b/base_sync_login_email/models/res_partner.py
@@ -1,0 +1,28 @@
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+from odoo.tools import single_email_re
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.constrains("email", "partner_share", "active")
+    def _check_email_internal_user(self):
+        """If the partner belongs to an internal user, validate the email matches the user login"""
+        for partner in self:
+            new_email = (partner.email or "").strip().lower()
+            internal_users = partner.with_context(active_test=False).user_ids.filtered(lambda u: not u.share)
+            internal_emails = {
+                login.lower() for login in internal_users.mapped("login") if single_email_re.match(login)
+            }
+            if internal_emails - {new_email}:
+                raise ValidationError(
+                    _(
+                        "It's not possible to change this contact's email because it's associated to an internal user "
+                        "and the new email doesn't match the user login.\n"
+                        "- Contact's email: '%s'\n"
+                        "- User login: '%s'",
+                        new_email,
+                        next(iter(internal_emails)),
+                    )
+                )

--- a/base_sync_login_email/models/res_partner.py
+++ b/base_sync_login_email/models/res_partner.py
@@ -6,7 +6,7 @@ from odoo.tools import single_email_re
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    @api.constrains("email", "partner_share", "active")
+    @api.constrains("email", "active")
     def _check_email_internal_user(self):
         """If the partner belongs to an internal user, validate the email matches the user login"""
         for partner in self:

--- a/base_sync_login_email/models/res_users.py
+++ b/base_sync_login_email/models/res_users.py
@@ -1,0 +1,20 @@
+from odoo import models
+from odoo.tools import single_email_re
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def write(self, vals):
+        """If login and email matches and login is changed, change email accordingly"""
+        new_login = vals.get("login")
+        if (
+            new_login
+            and "email" not in vals
+            and len(self) == 1
+            and self.login.lower() == (self.email or "").lower()
+            and self.login != new_login
+            and single_email_re.match(new_login)
+        ):
+            vals["email"] = new_login
+        return super().write(vals)

--- a/base_sync_login_email/tests/__init__.py
+++ b/base_sync_login_email/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_login

--- a/base_sync_login_email/tests/test_login.py
+++ b/base_sync_login_email/tests/test_login.py
@@ -1,0 +1,42 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase, new_test_user, tagged
+
+
+@tagged("login")
+class TestLogin(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.original_email = "original.email@example.com"
+        cls.new_email = "new.email@example.com"
+        cls.user = new_test_user(cls.env, login=cls.original_email, context={"no_reset_password": True})
+        cls.partner = cls.user.partner_id
+
+    def test_01_restrict_email_edition_internal_user(self):
+        """Ensure a partner email cannot be changed if such partner is linked to an internal user"""
+        error_msg = "It's not possible to change this contact's email"
+        with self.assertRaisesRegex(ValidationError, error_msg):
+            self.partner.email = self.new_email
+
+    def test_02_sync_login_and_email(self):
+        """If a user login is updated, the partner's email should be updated accordingly"""
+        self.assertEqual(self.partner.email, self.original_email)
+        self.user.login = self.new_email
+        self.assertEqual(self.partner.email, self.new_email)
+
+    def test_03_edit_nonemail_login(self):
+        """If the user login is not an email, partner's email shouldn't be updated and should be editable"""
+        self.user.login = "nonemail.login"
+        self.assertEqual(self.partner.email, self.original_email)
+        self.partner.email = self.new_email
+        self.assertEqual(self.partner.email, self.new_email)
+
+    def test_04_edit_email_case_insensitive(self):
+        """Editing a partner's email should be allowed if only the letter casing is being changed"""
+        self.user.login = self.new_email.upper()
+        self.assertEqual(self.partner.email, self.new_email.upper())
+        self.partner.email = self.new_email
+        self.partner.email = self.new_email.title()
+        error_msg = "It's not possible to change this contact's email"
+        with self.assertRaisesRegex(ValidationError, error_msg):
+            self.partner.email = self.original_email


### PR DESCRIPTION
## What

Brings `base_sync_login_email` to 19.0. The module is not present on this branch.

## What the module does

It keeps the email of a contact linked to an internal user in sync with that user's login:

- `res.partner` gains an `@api.constrains` on `email`/`active` that rejects an address not matching the login of any internal user attached to the partner.
- `res.users.write` propagates a login change to the partner's email, but only when login and email were already in sync and the new login is a valid address.

Net effect: a contact that backs an internal user cannot silently drift away from that user's login, whichever code path attempts the write.

## Changes

| File | Change |
|---|---|
| `__manifest__.py` | version `16.0.1.0.0` → `19.0.1.0.0` |
| `models/res_partner.py` | `self.env._` replaces the module-level `_` import |
| `i18n/es.po` | regenerated on 19.0: drops `#, python-format`, header now `Odoo Server 19.0`; fixes `modifica` → `modificar` |
| `README.rst` | bug-tracker template `version:%2016.0` → `%2019.0` |

No logic change was required: `single_email_re` is still exposed by `odoo.tools`, and the test helpers `TransactionCase`, `new_test_user` and `tagged` are unchanged.

## Validation

Installed on a fresh 19.0 database, tests run with `--test-tags=base_sync_login_email`:

```
0 failed, 0 error(s) of 4 tests
```

The four cases cover: the constraint rejecting a mismatched email, login→email propagation, a non-email login leaving the partner editable, and case-insensitive comparison.

`pre-commit-vauxoo` reports no finding for this module.