### PR TITLE
[FIX] .github: run secret-free jobs in the pull_request context

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: tests
 
 on:
+  # Jobs that check out and execute the contributor's code belong here: a fork
+  # gets a read-only token and no secrets, so running its code is safe.
+  pull_request:
+    branches:
+      - "*.0"
+  # Reserved for jobs that need repository secrets. This context runs with the
+  # base repository's token, so any job kept here must NOT execute fork code.
   pull_request_target:
     branches:
       - "*.0"
@@ -17,6 +24,9 @@ jobs:
   pre-commit-vauxoo:
     runs-on: ubuntu-latest
     name: pre-commit-vauxoo
+    # Needs no secret, so it runs in the untrusted context. The guard keeps it
+    # from running twice when both PR events fire for the same pull request.
+    if: github.event_name != 'pull_request_target'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -36,6 +46,7 @@ jobs:
   no-dependency-files:
     runs-on: ubuntu-latest
     name: No dependency files
+    if: github.event_name != 'pull_request_target'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -52,6 +63,12 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     name: Build Docker and test Odoo
+    # Kept on pull_request_target because it needs PRIVATE_DEPLOY_KEY to reach
+    # private repositories and the registry credentials to push the image.
+    # That combination -- secrets plus fork code -- is what actions/checkout
+    # refuses for forks; see the note in the pull request that introduced this
+    # guard. Skipped on pull_request so it does not run twice on internal PRs.
+    if: github.event_name != 'pull_request'
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
     steps:


### PR DESCRIPTION
## The problem

Every pull request coming from a fork fails all three checks within 2-4 seconds, before any code is fetched:

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch
cache scope, and runner access. Fetching and executing a fork's code in that trusted
context commonly leads to "pwn request" vulnerabilities.
```

`test.yml` triggers on `pull_request_target` and then checks out the PR head (`ref: ${{ env.CI_COMMIT_SHA }}`). A recent `actions/checkout@v6` release refuses that combination by default. Because the workflow pins the floating `@v6` tag, the change arrived on its own — nothing in this repository was touched.

The timeline matches: fork PRs #1734 to #1737 were green in June and July, #1738 is already mixed, and everything from a fork fails now.

## What this changes

The three jobs do not have the same needs:

| Job | Needs secrets | Executes PR code |
|---|---|---|
| `pre-commit-vauxoo` | no | yes |
| `No dependency files` | no | yes |
| `Build Docker and test Odoo` | **yes** (`PRIVATE_DEPLOY_KEY`, `DOCKER_USER`, `DOCKER_PASSWORD`, `ORCHEST_REGISTRY`, `ORCHEST_TOKEN`) | yes |

The first two move to `pull_request`, where a fork gets a read-only token and no secrets — running its code there is safe, and the checkout restriction does not apply. They go green again for fork PRs with this change.

Each job gets an event guard, because both PR events fire for the same pull request and without it every job would run twice:

| Event | pre-commit | No dependency files | Build Docker and test Odoo |
|---|---|---|---|
| `pull_request` | runs | runs | skipped |
| `pull_request_target` | skipped | skipped | runs |
| `push` | runs | runs | runs |

Behaviour on `push` to a `*.0` branch, and on internal (non-fork) PRs, is unchanged: every job still runs exactly once.

## What this does NOT fix, and why

`build_and_test` still fails for fork PRs. It needs `PRIVATE_DEPLOY_KEY` to reach the private repositories and the registry credentials to push the image, and it also builds and runs the contributor's code. Secrets plus fork code is exactly the combination that must not happen, so there is no purely technical fix here — it is a policy decision for the maintainers. Two options:

1. **Manual approval gate.** Keep it on `pull_request_target` and attach an `environment:` with required reviewers, so the job pauses until a maintainer approves running that fork's code. This is GitHub's recommended pattern, but the environment has to be created in the repository settings, which a PR cannot do.
2. **Restrict it to trusted refs.** Run it only on `push` to `*.0` and on internal PRs, accepting that fork contributions get lint and the dependency check but not the image build until a maintainer pushes the branch into this repository.

I did not pick one — that is yours to decide. What I deliberately did not do is set `allow-unsafe-pr-checkout: true`: it would make all three checks green immediately while re-opening the exact exposure the action is flagging, on a public repository with 281 forks.

## Validation

The `pull_request` jobs in this PR run from this branch's own workflow file, so the checks on this PR exercise the change directly.