### PR TITLE
[FIX] base_sync_login_email: skip the login check while loading data files

### DIFF
--- a/base_sync_login_email/models/res_partner.py
+++ b/base_sync_login_email/models/res_partner.py
@@ -9,6 +9,15 @@ class ResPartner(models.Model):
     @api.constrains("email", "active")
     def _check_email_internal_user(self):
         """If the partner belongs to an internal user, validate the email matches the user login"""
+        # Records loaded from a module's data or demo files are not user input, so the safeguard has nothing to
+        # protect there and enforcing it only blocks module installation. Odoo's own demo data is the proven case:
+        # l10n_mx_hr_payroll and l10n_us_hr_payroll give internal users a login that differs from the partner
+        # email on purpose, the failed demo load is rolled back inside a savepoint without a previous flush, and
+        # the pending writes of the module's regular data are lost with it, breaking every module installed later.
+        # install_mode is the flag Odoo sets while importing XML/CSV records and the one the core itself uses to
+        # relax validations in that phase (res.currency, res.company, auth_signup).
+        if self.env.context.get("install_mode"):
+            return
         for partner in self:
             new_email = (partner.email or "").strip().lower()
             internal_users = partner.with_context(active_test=False).user_ids.filtered(lambda u: not u.share)

--- a/base_sync_login_email/tests/test_login.py
+++ b/base_sync_login_email/tests/test_login.py
@@ -1,3 +1,4 @@
+from odoo import Command
 from odoo.exceptions import ValidationError
 from odoo.tests import TransactionCase, new_test_user, tagged
 
@@ -40,3 +41,30 @@ class TestLogin(TransactionCase):
         error_msg = "It's not possible to change this contact's email"
         with self.assertRaisesRegex(ValidationError, error_msg):
             self.partner.email = self.original_email
+
+    def test_05_data_files_bypass_constraint(self):
+        """Records loaded from data/demo files must be free to desync email and login, otherwise installing a
+        module that ships such users fails (Odoo's own payroll demo does exactly that)"""
+        self.partner.with_context(install_mode=True).email = self.new_email
+        self.assertEqual(self.partner.email, self.new_email)
+        # Creating a user on a partner whose email does not match the login is the exact pattern used by
+        # Odoo's payroll demo files, so it must succeed as well
+        demo_partner = self.env["res.partner"].create({"name": "Demo Partner", "email": "demo.partner@example.com"})
+        demo_user = (
+            self.env["res.users"]
+            .with_context(no_reset_password=True, install_mode=True)
+            .create(
+                {
+                    "name": "Demo User",
+                    "login": "demo.user@example.com",
+                    "partner_id": demo_partner.id,
+                    "group_ids": [Command.set([self.env.ref("base.group_user").id])],
+                }
+            )
+        )
+        self.assertEqual(demo_user.partner_id, demo_partner)
+        self.assertEqual(demo_partner.email, "demo.partner@example.com")
+        # Outside data loading the safeguard keeps working on that same partner
+        error_msg = "It's not possible to change this contact's email"
+        with self.assertRaisesRegex(ValidationError, error_msg):
+            demo_partner.email = "another.email@example.com"


### PR DESCRIPTION
## What
`_check_email_internal_user` returns early when the context carries `install_mode`, the flag Odoo sets while importing XML/CSV records (data and demo phases alike) and the one the core itself uses to relax validations in that phase (`res.currency`, `res.company`, `auth_signup`). Same approach as OCA/server-auth#986 for `password_security`. Behaviour outside data loading is unchanged. A new test covers both sides.

## Why
Records loaded from a module's files are not user input, so the safeguard has nothing to protect there and enforcing it only blocks module installation. Odoo's own demo data is the proven case: `l10n_mx_hr_payroll` (demo line 138) and `l10n_us_hr_payroll` (demo line 71) deliberately create internal users whose login differs from the partner email, and with this module installed both demo sets fail with the constraint message.

Worse, `load_demo()` rolls the failed demo back inside a `savepoint(flush=False)` and there is no flush between the module's data and demo phases, so pending writes of the regular data files are lost with the rollback while the ORM believes they are persisted. `l10n_mx_edi_payslip` then aborts the registry with `No rule parameter with code "l10n_mx_daily_min_wage"`. This is what broke the CI of https://git.vauxoo.com/vauxoo/instance/-/merge_requests/1953.

## How to Test
Install with demo, before and after the patch:

```
odoo-bin -d test --with-demo --test-enable --test-tags /base_sync_login_email --stop-after-init \
  -i base_sync_login_email,l10n_mx_hr_payroll,l10n_us_hr_payroll
```

Before: two `demo data failed to install` warnings, 4 tests. After: no warnings, 5 tests, both payroll demos loaded.

Task: t#33602

## Checklist
- [ ] CI passes (GitHub checks refuse fork PRs under `pull_request_target`, see #1740; validated through vauxoo/instance!1957 instead)
- [x] Tests cover the change
- [ ] Docs updated if behaviour changed (not needed)
